### PR TITLE
Reduce lookups: skip blocks already served by vLLM's local prefix cache

### DIFF
--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -84,9 +84,12 @@ Edit `scripts/mooncake/mooncake_config.json`:
 ```
 
 - `protocol`: Use `"rdma"` for best performance. `"tcp"` works as a fallback but performs poorly.
-- `global_segment_size`: CPU memory contributed to the distributed pool. Automatically updated by `setup_vllm_env.sh` to match `--cpu-mem-size`.
-- `local_buffer_size`: Private staging buffer for this node's transfer engine. I am not sure about this param, and maybe we don't need to manually set it at all.
-- `device_name`: Leave empty; Mooncake auto-picks RDMA devices when needed.
+- Adjust `global_segment_size` and `local_buffer_size` based on available memory.
+    - global_segment_size: Memory contributed to the distributed pool
+    - local_buffer_size: Private buffer for this node's own operations
+    - For now we use a single node so they don't differ much
+    - **These sizes are per GPU (per rank), not for the entire node.** For example, with 4 GPUs and `global_segment_size` set to `80GB`, each rank allocates 80 GB of CPU memory, totaling 320 GB across the node.
+- Note: the benchmark script automatically updates `global_segment_size` and `local_buffer_size` to match `CPU_OFFLOAD_GIB`. The `CPU_OFFLOAD_GIB` and `DISK_OFFLOAD_GIB` env vars in the benchmark scripts are also per GPU (per rank).
 
 ### 3. Environment Setup (setup_vllm_env.sh)
 
@@ -187,3 +190,23 @@ python scripts/mooncake/compare_results.py ./bench_results --prefix mt_
 ```bash
 bash scripts/mooncake/start_mooncake_master.sh --stop
 ```
+
+## Notes
+
+### Cross-DP External Prefix Cache Hits
+
+When running `MooncakeStoreConnector` with DP, set a fixed
+`PYTHONHASHSEED` before launching vLLM if you want cross-DP external
+prefix cache lookup to work reliably, for example:
+
+```bash
+PYTHONHASHSEED=0 BACKENDS=mooncake-mem \
+bash scripts/mooncake/benchmark_multi_turn.sh
+```
+
+If `PYTHONHASHSEED` is unset, each engine process initializes the root
+prefix-cache hash seed randomly. Identical prompts can then produce
+different block-hash chains on different DP ranks, which means a rank
+may query Mooncake external cache but still report
+`external_prefix_cache_hits=0` even when another DP rank already stored
+the same prefix.

--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -4,15 +4,18 @@
 
 ### 1. Install Mooncake
 
-```bash
-# CUDA <13.0
-uv pip install mooncake-transfer-engine
+We need to use our own version of Mooncake for GB200:
 
-# CUDA >= 13.0
-uv pip install mooncake-transfer-engine-cuda13
+```shell
+git clone https://github.com/ivanium/Mooncake
+cd Mooncake
+git checkout yifan/dev
+# NOTE: Install necessary dependencies
+./scripts/dev_compile.sh
+# NOTE: Please check to ensure compile succeeded before installing
+# NOTE: Please ensure to activate vllm venv before installing
+./scripts/dev_install.sh
 ```
-
-Follow Mooncake README is good in general.
 
 ### 2. Verify Installation
 

--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -33,67 +33,145 @@ python scripts/mooncake/mooncake_example.py
 
 You should see `Hello, Mooncake Store!` printed. Stop the master with Ctrl-C.
 
-## Benchmarking CPU KV Cache Offloading
+## Running Benchmarks
 
 ### 1. Start the Master Server
 
 ```bash
+bash scripts/mooncake/start_mooncake_master.sh
+# With disk offloading support:
+bash scripts/mooncake/start_mooncake_master.sh --enable-offload
+# Start master and run it in background
 bash scripts/mooncake/start_mooncake_master.sh --bg
+# With disk offloading support and running in background:
+bash scripts/mooncake/start_mooncake_master.sh --enable-offload --bg
 ```
 
-This starts the master in the background with default ports (RPC: 50051, HTTP metadata: 8080). Logs are written to `scripts/mooncake/mooncake_master.log`. See the script header for environment variables to customize ports and eviction settings.
+This starts the master in the background. Logs go to `scripts/mooncake/mooncake_master.log`.
+
+Default ports:
+
+- RPC: 50051
+- HTTP metadata: 8080
+- Prometheus metrics: 9003
+
+See the script header for environment variables (`MC_RPC_PORT`, `MC_HTTP_PORT`, etc.) to customize ports and eviction settings. Mooncake master is launched cluster-wise, so we may get port conflict if someone else has already launched it. Typically we don't need to change this, and multiple users should be able to share the same master. One can freely change ports here, but also remember to update the `mooncake_config.json` for the client (vLLM) below.
 
 ### 2. Configure Mooncake
 
-Edit `scripts/mooncake/mooncake_config.json` to match your setup:
+Edit `scripts/mooncake/mooncake_config.json`:
 
 ```json
 {
   "metadata_server": "http://127.0.0.1:8080/metadata",
   "master_server_address": "127.0.0.1:50051",
-  "global_segment_size": "80GB",
-  "local_buffer_size": "80GB",
-  "protocol": "tcp",
+  "global_segment_size": "600GB",
+  "local_buffer_size": "4GB",
+  "protocol": "rdma",
   "device_name": ""
 }
 ```
 
-- I haven't tried `protocol` and `device_name` yet, but "rdma" is worth a try, although not sure its benefits on a single node, we will need it anyway.
-- Adjust `global_segment_size` and `local_buffer_size` based on available memory.
-    - global_segment_size: Memory contributed to the distributed pool
-    - local_buffer_size: Private buffer for this node's own operations
-    - For now we use a single node so they don't differ much
-- Note: the benchmark script automatically updates `global_segment_size` and `local_buffer_size` to match `KV_OFFLOAD_GIB`.
+- `protocol`: Use `"rdma"` for best performance. `"tcp"` works as a fallback but performs poorly.
+- `global_segment_size`: CPU memory contributed to the distributed pool. Automatically updated by `setup_vllm_env.sh` to match `--cpu-mem-size`.
+- `local_buffer_size`: Private staging buffer for this node's transfer engine. I am not sure about this param, and maybe we don't need to manually set it at all.
+- `device_name`: Leave empty; Mooncake auto-picks RDMA devices when needed.
 
-### 3. Run the Benchmark
+### 3. Environment Setup (setup_vllm_env.sh)
 
-By default, the script runs two settings (`baseline,mooncake`) and builds a comparison table at the end. Backends with missing prerequisites are auto-skipped.
-`baseline` is no offloading.
+Before running benchmarks with the mooncake backend, source `setup_vllm_env.sh` to configure all necessary environment variables. The benchmark scripts do this automatically, but you can also use it directly:
+
+```bash
+# CPU offloading only (80 GB)
+source scripts/mooncake/setup_vllm_env.sh --cpu-mem-size 80
+
+# CPU + disk offloading (80 GB CPU, 400 GB disk)
+source scripts/mooncake/setup_vllm_env.sh --cpu-mem-size 80 --disk-size 400
+
+# Custom disk path
+source scripts/mooncake/setup_vllm_env.sh --cpu-mem-size 80 --disk-size 400 --disk-path /mnt/data/mooncake_offload
+```
+
+This script:
+
+- Sets `MOONCAKE_CONFIG_PATH` and updates `global_segment_size` in the config JSON
+- Enables `MC_TCP_ENABLE_CONNECTION_POOL`
+- When `--disk-size` is given, sets all disk offloading env vars (`MOONCAKE_ENABLE_OFFLOAD`, `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`, eviction policy, io_uring, etc.)
+
+### 4a. Single-Turn Benchmark (benchmark_cpu_offloading.sh)
+
+Measures raw KV offloading overhead using random (unique) prompts so no prefix cache is ever hit.
 
 ```bash
 MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
 bash scripts/mooncake/benchmark_cpu_offloading.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
 ```
 
-Defaults: `meta-llama/Llama-3.1-8B`, input 8192 tokens, output 1024 tokens, 200 prompts.
+Defaults: `meta-llama/Llama-3.1-8B-Instruct`, input 8192, output 1024, 200 prompts.
 
-To run only specific backends, set `BACKENDS` (comma-separated):
+Supported backends (comma-separated via `BACKENDS`):
+
+- `baseline` - No offloading
+- `native` - Built-in vLLM KV offloading (`--kv-offloading-backend native`)
+- `simple` - Simple native offload (`VLLM_USE_SIMPLE_KV_OFFLOAD=1` + native backend)
+- `mooncake` - MooncakeStoreConnector via `--kv-transfer-config`
+
+Environment variables:
+
+- `CPU_OFFLOAD_GIB` - CPU offload buffer in GiB (default: 80)
+- `DISK_OFFLOAD_GIB` - Disk offload quota in GiB (default: 400)
+- `REQUEST_RATE` - Requests/s (default: 1)
+- `PORT` - Server port (default: 8192)
+- `RESULT_DIR` - Output directory (default: `./bench_results`)
+- `BACKENDS` - Comma-separated backends (default: `baseline,mooncake`)
+
+Example:
 
 ```bash
-# Only mooncake (no baseline)
+# Only mooncake with disk offloading
 BACKENDS=mooncake \
-MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
-bash scripts/mooncake/benchmark_cpu_offloading.sh
-
-# mooncake vs simple vs baseline
-BACKENDS=baseline,mooncake,simple \
+CPU_OFFLOAD_GIB=80 \
+DISK_OFFLOAD_GIB=400 \
 MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
 bash scripts/mooncake/benchmark_cpu_offloading.sh
 ```
 
-Results are saved to `./bench_results/` and a comparison table is printed at the end.
+### 4b. Multi-Turn Benchmark (benchmark_multi_turn.sh)
 
-### 4. Stop the Master
+Measures multi-turn chat performance with prefix sharing (global + conversation prefixes).
+
+```bash
+MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
+bash scripts/mooncake/benchmark_multi_turn.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+```
+
+Defaults: `meta-llama/Llama-3.1-8B-Instruct`, input 70000, output 200, 200 prompts.
+
+Additional backends:
+
+- `mooncake-mem` - MooncakeStoreConnector with CPU memory only (no disk)
+
+Additional environment variables:
+
+- `MULTI_TURN_NUM_TURNS` - Turns per conversation (default: 3)
+- `MULTI_TURN_CONCURRENCY` - Concurrent conversations (default: 16)
+- `MULTI_TURN_DELAY_MS` - Delay between turns in ms (default: 500)
+- `GLOBAL_PREFIX_RATIO` - Fraction of input as global prefix (default: 0.1)
+- `CONV_PREFIX_RATIO` - Fraction of input as conversation prefix (default: 0.8)
+
+### 5. Compare Results (compare_results.py)
+
+Both benchmark scripts automatically run the comparison at the end. To re-run manually:
+
+```bash
+# Single-turn results
+python scripts/mooncake/compare_results.py ./bench_results
+
+# Multi-turn results
+python scripts/mooncake/compare_results.py ./bench_results --prefix mt_
+```
+
+### 6. Stop the Master
 
 ```bash
 bash scripts/mooncake/start_mooncake_master.sh --stop

--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -4,7 +4,18 @@
 
 ### 1. Install Mooncake
 
-We need to use our own version of Mooncake for GB200:
+We need to use our own version of Mooncake for GB200.
+
+#### Option A: Install from pre-built wheel (recommended)
+
+NOTE: this wheel is pre-compiled only for Grace-Blackwell and Grace-Hopper (ARM64) platforms. For AMD64 (including Intel platforms), users still need to go with Option B and manual compile for now. We will add a pre-compiled wheel later.
+
+```bash
+# Make sure your vllm venv is activated
+uv pip install scripts/mooncake/mooncake_transfer_engine-0.3.10.post1-cp312-cp312-manylinux_2_39_aarch64.whl
+```
+
+#### Option B: Build from source
 
 ```shell
 git clone https://github.com/ivanium/Mooncake

--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -1,0 +1,97 @@
+# Mooncake KV Store for vLLM
+
+## Setup
+
+### 1. Install Mooncake
+
+```bash
+# CUDA <13.0
+uv pip install mooncake-transfer-engine
+
+# CUDA >= 13.0
+uv pip install mooncake-transfer-engine-cuda13
+```
+
+Follow Mooncake README is good in general.
+
+### 2. Verify Installation
+
+Start the Mooncake master server:
+
+```bash
+bash scripts/mooncake/start_mooncake_master.sh
+```
+
+In a separate terminal, run the example script to confirm everything works:
+
+```bash
+python scripts/mooncake/mooncake_example.py
+```
+
+You should see `Hello, Mooncake Store!` printed. Stop the master with Ctrl-C.
+
+## Benchmarking CPU KV Cache Offloading
+
+### 1. Start the Master Server
+
+```bash
+bash scripts/mooncake/start_mooncake_master.sh --bg
+```
+
+This starts the master in the background with default ports (RPC: 50051, HTTP metadata: 8080). Logs are written to `scripts/mooncake/mooncake_master.log`. See the script header for environment variables to customize ports and eviction settings.
+
+### 2. Configure Mooncake
+
+Edit `scripts/mooncake/mooncake_config.json` to match your setup:
+
+```json
+{
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "master_server_address": "127.0.0.1:50051",
+  "global_segment_size": "80GB",
+  "local_buffer_size": "80GB",
+  "protocol": "tcp",
+  "device_name": ""
+}
+```
+
+- I haven't tried `protocol` and `device_name` yet, but "rdma" is worth a try, although not sure its benefits on a single node, we will need it anyway.
+- Adjust `global_segment_size` and `local_buffer_size` based on available memory.
+    - global_segment_size: Memory contributed to the distributed pool
+    - local_buffer_size: Private buffer for this node's own operations
+    - For now we use a single node so they don't differ much
+- Note: the benchmark script automatically updates `global_segment_size` and `local_buffer_size` to match `KV_OFFLOAD_GIB`.
+
+### 3. Run the Benchmark
+
+By default, the script runs two settings (`baseline,mooncake`) and builds a comparison table at the end. Backends with missing prerequisites are auto-skipped.
+`baseline` is no offloading.
+
+```bash
+MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
+bash scripts/mooncake/benchmark_cpu_offloading.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+```
+
+Defaults: `meta-llama/Llama-3.1-8B`, input 8192 tokens, output 1024 tokens, 200 prompts.
+
+To run only specific backends, set `BACKENDS` (comma-separated):
+
+```bash
+# Only mooncake (no baseline)
+BACKENDS=mooncake \
+MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
+bash scripts/mooncake/benchmark_cpu_offloading.sh
+
+# mooncake vs simple vs baseline
+BACKENDS=baseline,mooncake,simple \
+MOONCAKE_CONFIG_PATH=scripts/mooncake/mooncake_config.json \
+bash scripts/mooncake/benchmark_cpu_offloading.sh
+```
+
+Results are saved to `./bench_results/` and a comparison table is printed at the end.
+
+### 4. Stop the Master
+
+```bash
+bash scripts/mooncake/start_mooncake_master.sh --stop
+```

--- a/scripts/mooncake/benchmark_cpu_offloading.sh
+++ b/scripts/mooncake/benchmark_cpu_offloading.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Benchmark CPU KV cache offloading overhead.
+# Launches a vllm server, runs `vllm bench serve` against it, then
+# repeats with offloading enabled. Uses random (unique) prompts so
+# no offloaded prefix is ever hit — isolating the pure store overhead.
+#
+# Usage:
+#   bash benchmark_cpu_offloading.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+#
+# Supported backends (comma-separated in BACKENDS):
+#   baseline        - No offloading
+#   native          - Built-in vLLM KV offloading (--kv-offloading-backend native)
+#   simple          - Simple native offload (VLLM_USE_SIMPLE_KV_OFFLOAD=1 + native backend)
+#   mooncake        - MooncakeStoreConnector via --kv-transfer-config
+#
+# Environment variables:
+#   KV_OFFLOAD_GIB        - CPU offload buffer in GiB   (default: 80)
+#   REQUEST_RATE          - Requests/s to the server     (default: 1)
+#   PORT                  - Server port                  (default: 8192)
+#   RESULT_DIR            - Output directory             (default: ./bench_results)
+#   BACKENDS              - Comma-separated backends     (default: baseline,native,simple,mooncake)
+#   MOONCAKE_CONFIG_PATH  - Path to mooncake config JSON (required for mooncake, auto-skipped if unset)
+
+set -euo pipefail
+
+MODEL="${1:-meta-llama/Llama-3.1-8B}"
+# MODEL="${1:-nvidia/Qwen3.5-397B-A17B-NVFP4}"
+INPUT_LEN="${2:-8192}"
+OUTPUT_LEN="${3:-1024}"
+NUM_PROMPTS="${4:-200}"
+KV_OFFLOAD_GIB="${KV_OFFLOAD_GIB:-80}"
+REQUEST_RATE="${REQUEST_RATE:-1}"
+PORT="${PORT:-8192}"
+RESULT_DIR="${RESULT_DIR:-./bench_results}"
+BACKENDS="${BACKENDS:-baseline,mooncake}"
+
+mkdir -p "$RESULT_DIR"
+
+SERVER_COMMON=(
+    --model "$MODEL"
+    --disable-hybrid-kv-cache-manager
+    --port "$PORT"
+    --no-enable-log-requests
+)
+if [[ "$MODEL" == *"Qwen3.5"* ]]; then
+    SERVER_COMMON+=(
+        --mamba-cache-mode align
+        --enable-prefix-caching
+    )
+fi
+
+if [[ "$MODEL" == "nvidia/Qwen3.5-397B-A17B-NVFP4" ]]; then
+    SERVER_COMMON+=(
+        -dp 4
+        --enable-expert-parallel
+        --language-model-only
+        --reasoning-parser qwen3
+    )
+fi
+
+BENCH_COMMON=(
+    --model "$MODEL"
+    --base-url "http://127.0.0.1:${PORT}"
+    --dataset-name random
+    --random-input-len "$INPUT_LEN"
+    --random-output-len "$OUTPUT_LEN"
+    --num-prompts "$NUM_PROMPTS"
+    --request-rate "$REQUEST_RATE"
+    --seed 42
+    --save-result
+    --result-dir "$RESULT_DIR"
+)
+
+wait_for_server() {
+    echo "  Waiting for server on port $PORT..."
+    for _ in $(seq 1 180); do
+        if curl -sf "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+            echo "  Server ready."
+            return 0
+        fi
+        sleep 1
+    done
+    echo "  ERROR: server did not start within 180s" >&2
+    return 1
+}
+
+kill_server() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        unset SERVER_PID
+    fi
+}
+trap kill_server EXIT
+
+run_one() {
+    local label="$1"
+    local result_file="$2"
+    shift 2
+    local server_extra=("$@")
+
+    echo ""
+    echo ">>> Starting server: $label"
+    echo "Command: vllm serve ${SERVER_COMMON[@]} ${server_extra[@]}"
+    vllm serve \
+        "${SERVER_COMMON[@]}" "${server_extra[@]}" &
+    SERVER_PID=$!
+
+    wait_for_server
+
+    echo ">>> Running benchmark: $label"
+    vllm bench serve \
+        "${BENCH_COMMON[@]}" \
+        --result-filename "$result_file"
+
+    echo ">>> Stopping server"
+    kill_server
+}
+
+echo "============================================"
+echo "  CPU Offloading Overhead Benchmark"
+echo "============================================"
+echo "  Model:         $MODEL"
+echo "  Input len:     $INPUT_LEN"
+echo "  Output len:    $OUTPUT_LEN"
+echo "  Num prompts:   $NUM_PROMPTS"
+echo "  Request rate:  $REQUEST_RATE req/s"
+echo "  Backends:      $BACKENDS"
+echo "  Offload size:  ${KV_OFFLOAD_GIB} GiB"
+echo "============================================"
+
+# ── Run each requested backend ──────────────────────────────────
+IFS=',' read -ra BACKEND_LIST <<< "$BACKENDS"
+
+for backend in "${BACKEND_LIST[@]}"; do
+    case "$backend" in
+        baseline)
+            run_one "Baseline (no offloading)" "baseline.json"
+            ;;
+        native)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            run_one "With CPU offloading (native)" "native.json" \
+                --kv-offloading-size "$KV_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        simple)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=1
+            run_one "With CPU offloading (simple)" "simple.json" \
+                --kv-offloading-size "$KV_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        mooncake)
+            if [[ -z "${MOONCAKE_CONFIG_PATH:-}" || ! -f "${MOONCAKE_CONFIG_PATH:-}" ]]; then
+                echo ""
+                echo ">>> Skipping mooncake: MOONCAKE_CONFIG_PATH not set or file missing"
+                continue
+            fi
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            export MC_TCP_ENABLE_CONNECTION_POOL=1
+            # Update mooncake config with the requested offload size
+            python3 -c "
+import json, sys
+
+cfg_path = sys.argv[1]
+size = sys.argv[2] + 'GB'
+with open(cfg_path) as f:
+    cfg = json.load(f)
+cfg['global_segment_size'] = size
+cfg['local_buffer_size'] = size
+
+with open(cfg_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+" "$MOONCAKE_CONFIG_PATH" "$KV_OFFLOAD_GIB"
+            echo "  Updated $MOONCAKE_CONFIG_PATH: segment/buffer size = ${KV_OFFLOAD_GIB}GB"
+            run_one "With CPU offloading (mooncake)" "mooncake.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;
+        *)
+            echo ""
+            echo ">>> Skipping unknown backend: $backend"
+            ;;
+    esac
+done
+
+# ── Compare all available results ───────────────────────────────
+python3 - "$RESULT_DIR" <<'PYEOF'
+import json, sys, os
+
+d = sys.argv[1]
+
+# Backend label -> result filename
+ALL_BACKENDS = [
+    ("baseline", "baseline.json"),
+    ("native",   "native.json"),
+    ("simple",   "simple.json"),
+    ("mooncake", "mooncake.json"),
+]
+
+results = {}
+for label, fname in ALL_BACKENDS:
+    path = os.path.join(d, fname)
+    if os.path.isfile(path):
+        with open(path) as f:
+            results[label] = json.load(f)
+
+if not results:
+    print("\nNo result files found — nothing to compare.\n")
+    sys.exit(0)
+
+metrics = [
+    ("Output throughput (tok/s)", "output_throughput",  ".1f"),
+    ("Request throughput (req/s)", "request_throughput", ".3f"),
+    ("Mean TTFT (ms)",            "mean_ttft_ms",       ".2f"),
+    ("Mean TPOT (ms)",            "mean_tpot_ms",       ".2f"),
+]
+
+labels = list(results.keys())
+col_w = 14
+
+def pct(old, new):
+    return (new - old) / old * 100 if old else 0.0
+
+print()
+print("=" * (32 + col_w * len(labels)))
+print("  COMPARISON  (delta vs baseline: + = regression, - = improvement)")
+print("=" * (32 + col_w * len(labels)))
+
+# Header
+header = f"  {'Metric':<30}"
+for lb in labels:
+    header += f"  {lb:>{col_w - 2}}"
+print(header)
+sep = f"  {'-' * 30}"
+for _ in labels:
+    sep += f"  {'-' * (col_w - 2)}"
+print(sep)
+
+baseline = results.get("baseline")
+
+for metric_label, key, fmt in metrics:
+    row = f"  {metric_label:<30}"
+    for lb in labels:
+        val = results[lb][key]
+        cell = f"{val:{fmt}}"
+        if baseline and lb != "baseline":
+            delta = pct(baseline[key], val)
+            cell += f" ({delta:+.1f}%)"
+        row += f"  {cell:>{col_w - 2}}"
+    print(row)
+
+print("=" * (32 + col_w * len(labels)))
+print()
+PYEOF

--- a/scripts/mooncake/benchmark_cpu_offloading.sh
+++ b/scripts/mooncake/benchmark_cpu_offloading.sh
@@ -11,6 +11,7 @@
 #   baseline        - No offloading
 #   native          - Built-in vLLM KV offloading (--kv-offloading-backend native)
 #   simple          - Simple native offload (VLLM_USE_SIMPLE_KV_OFFLOAD=1 + native backend)
+#   mooncake-mem    - MooncakeStoreConnector with CPU memory only (no disk)
 #   mooncake        - MooncakeStoreConnector via --kv-transfer-config
 #
 # Environment variables:
@@ -166,6 +167,13 @@ for backend in "${BACKEND_LIST[@]}"; do
             fi
             source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
             run_one "With CPU offloading (mooncake)" "mooncake.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;  
+        mooncake-mem)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            SETUP_ARGS=(--cpu-mem-size "$CPU_OFFLOAD_GIB")
+            source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
+            run_one "With CPU offloading (mooncake-mem)" "mt_mooncake_mem.json" \
                 --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
             ;;
         *)

--- a/scripts/mooncake/benchmark_multi_turn.sh
+++ b/scripts/mooncake/benchmark_multi_turn.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Benchmark CPU KV cache offloading overhead.
-# Launches a vllm server, runs `vllm-bench` against it, then
-# repeats with offloading enabled. Uses random (unique) prompts so
-# no offloaded prefix is ever hit — isolating the pure store overhead.
+# Benchmark multi-turn chat with/without CPU KV cache offloading.
+# Launches a vllm server, runs `vllm-bench` with multi-turn options,
+# then repeats with offloading enabled.
 #
 # Usage:
-#   bash benchmark_cpu_offloading.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+#   bash benchmark_multi_turn.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
 #
 # Supported backends (comma-separated in BACKENDS):
 #   baseline        - No offloading
@@ -15,28 +14,36 @@
 #
 # Environment variables:
 #   CPU_OFFLOAD_GIB       - CPU offload buffer in GiB   (default: 80)
-#   DISK_OFFLOAD_GIB      - Disk offload quota in GiB   (default: unset = disabled)
-#   REQUEST_RATE          - Requests/s to the server     (default: 1)
+#   DISK_OFFLOAD_GIB      - Disk offload quota in GiB   (default: 400)
 #   PORT                  - Server port                  (default: 8192)
 #   RESULT_DIR            - Output directory             (default: ./bench_results)
-#   BACKENDS              - Comma-separated backends     (default: baseline,native,simple,mooncake)
+#   BACKENDS              - Comma-separated backends     (default: baseline,mooncake)
 #   MOONCAKE_CONFIG_PATH  - Path to mooncake config JSON (required for mooncake, auto-skipped if unset)
+#   MULTI_TURN_NUM_TURNS  - Number of turns per conversation  (default: 4)
+#   MULTI_TURN_CONCURRENCY - Concurrent conversations         (default: 8)
+#   MULTI_TURN_DELAY_MS   - Delay between turns in ms         (default: 500)
+#   GLOBAL_PREFIX_RATIO   - Fraction of input as global prefix  (default: 0.1)
+#   CONV_PREFIX_RATIO     - Fraction of input as conversation prefix (default: 0.8)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MODEL="${1:-meta-llama/Llama-3.1-8B-Instruct}"
-# MODEL="${1:-nvidia/Qwen3.5-397B-A17B-NVFP4}"
-INPUT_LEN="${2:-8192}"
-OUTPUT_LEN="${3:-1024}"
-NUM_PROMPTS="${4:-200}"
-CPU_OFFLOAD_GIB="${CPU_OFFLOAD_GIB:-80}"
-DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-400}"
-REQUEST_RATE="${REQUEST_RATE:-1}"
+INPUT_LEN="${2:-70000}"
+OUTPUT_LEN="${3:-200}"
+NUM_PROMPTS="${4:-50}"
+CPU_OFFLOAD_GIB="${CPU_OFFLOAD_GIB:-600}"
+DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-1000}"
 PORT="${PORT:-8192}"
 RESULT_DIR="${RESULT_DIR:-./bench_results}"
 BACKENDS="${BACKENDS:-baseline,mooncake}"
+
+MULTI_TURN_NUM_TURNS="${MULTI_TURN_NUM_TURNS:-3}"
+MULTI_TURN_CONCURRENCY="${MULTI_TURN_CONCURRENCY:-10}"
+MULTI_TURN_DELAY_MS="${MULTI_TURN_DELAY_MS:-500}"
+GLOBAL_PREFIX_RATIO="${GLOBAL_PREFIX_RATIO:-0.1}"
+CONV_PREFIX_RATIO="${CONV_PREFIX_RATIO:-0.8}"
 
 mkdir -p "$RESULT_DIR"
 
@@ -64,14 +71,20 @@ if [[ "$MODEL" == "nvidia/Qwen3.5-397B-A17B-NVFP4" ]]; then
 fi
 
 BENCH_COMMON=(
+    --backend openai-chat
     --model "$MODEL"
     --base-url "http://127.0.0.1:${PORT}"
     --dataset-name random
     --random-input-len "$INPUT_LEN"
     --random-output-len "$OUTPUT_LEN"
     --num-prompts "$NUM_PROMPTS"
-    --request-rate "$REQUEST_RATE"
-    --seed 42
+    --multi-turn
+    --multi-turn-num-turns "$MULTI_TURN_NUM_TURNS"
+    --multi-turn-concurrency "$MULTI_TURN_CONCURRENCY"
+    --multi-turn-delay-ms "$MULTI_TURN_DELAY_MS"
+    --multi-turn-prefix-global-ratio "$GLOBAL_PREFIX_RATIO"
+    --multi-turn-prefix-conversation-ratio "$CONV_PREFIX_RATIO"
+    --percentile-metrics "ttft,tpot,itl,e2el"
     --save-result
     --result-dir "$RESULT_DIR"
 )
@@ -124,13 +137,17 @@ run_one() {
 }
 
 echo "============================================"
-echo "  CPU Offloading Overhead Benchmark"
+echo "  Multi-Turn Offloading Benchmark"
 echo "============================================"
 echo "  Model:         $MODEL"
 echo "  Input len:     $INPUT_LEN"
 echo "  Output len:    $OUTPUT_LEN"
 echo "  Num prompts:   $NUM_PROMPTS"
-echo "  Request rate:  $REQUEST_RATE req/s"
+echo "  Turns:         $MULTI_TURN_NUM_TURNS"
+echo "  Concurrency:   $MULTI_TURN_CONCURRENCY"
+echo "  Turn delay:    ${MULTI_TURN_DELAY_MS} ms"
+echo "  Global prefix: $GLOBAL_PREFIX_RATIO"
+echo "  Conv prefix:   $CONV_PREFIX_RATIO"
 echo "  Backends:      $BACKENDS"
 echo "  CPU offload:   ${CPU_OFFLOAD_GIB} GiB"
 if [[ -n "$DISK_OFFLOAD_GIB" ]]; then
@@ -144,17 +161,17 @@ IFS=',' read -ra BACKEND_LIST <<< "$BACKENDS"
 for backend in "${BACKEND_LIST[@]}"; do
     case "$backend" in
         baseline)
-            run_one "Baseline (no offloading)" "baseline.json"
+            run_one "Baseline (no offloading)" "mt_baseline.json"
             ;;
         native)
             export VLLM_USE_SIMPLE_KV_OFFLOAD=0
-            run_one "With CPU offloading (native)" "native.json" \
+            run_one "With CPU offloading (native)" "mt_native.json" \
                 --kv-offloading-size "$CPU_OFFLOAD_GIB" \
                 --kv-offloading-backend "native"
             ;;
         simple)
             export VLLM_USE_SIMPLE_KV_OFFLOAD=1
-            run_one "With CPU offloading (simple)" "simple.json" \
+            run_one "With CPU offloading (simple)" "mt_simple.json" \
                 --kv-offloading-size "$CPU_OFFLOAD_GIB" \
                 --kv-offloading-backend "native"
             ;;
@@ -165,7 +182,7 @@ for backend in "${BACKEND_LIST[@]}"; do
                 SETUP_ARGS+=(--disk-size "$DISK_OFFLOAD_GIB")
             fi
             source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
-            run_one "With CPU offloading (mooncake)" "mooncake.json" \
+            run_one "With CPU offloading (mooncake)" "mt_mooncake.json" \
                 --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
             ;;
         *)
@@ -176,4 +193,4 @@ for backend in "${BACKEND_LIST[@]}"; do
 done
 
 # ── Compare all available results ───────────────────────────────
-python3 "${SCRIPT_DIR}/compare_results.py" "$RESULT_DIR"
+python3 "${SCRIPT_DIR}/compare_results.py" "$RESULT_DIR" --prefix mt_

--- a/scripts/mooncake/benchmark_multi_turn.sh
+++ b/scripts/mooncake/benchmark_multi_turn.sh
@@ -10,6 +10,7 @@
 #   baseline        - No offloading
 #   native          - Built-in vLLM KV offloading (--kv-offloading-backend native)
 #   simple          - Simple native offload (VLLM_USE_SIMPLE_KV_OFFLOAD=1 + native backend)
+#   mooncake-mem    - MooncakeStoreConnector with CPU memory only (no disk)
 #   mooncake        - MooncakeStoreConnector via --kv-transfer-config
 #
 # Environment variables:
@@ -32,15 +33,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODEL="${1:-meta-llama/Llama-3.1-8B-Instruct}"
 INPUT_LEN="${2:-70000}"
 OUTPUT_LEN="${3:-200}"
-NUM_PROMPTS="${4:-50}"
+NUM_PROMPTS="${4:-200}"
 CPU_OFFLOAD_GIB="${CPU_OFFLOAD_GIB:-600}"
-DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-1000}"
+DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-2000}"
 PORT="${PORT:-8192}"
 RESULT_DIR="${RESULT_DIR:-./bench_results}"
 BACKENDS="${BACKENDS:-baseline,mooncake}"
 
 MULTI_TURN_NUM_TURNS="${MULTI_TURN_NUM_TURNS:-3}"
-MULTI_TURN_CONCURRENCY="${MULTI_TURN_CONCURRENCY:-10}"
+MULTI_TURN_CONCURRENCY="${MULTI_TURN_CONCURRENCY:-16}"
 MULTI_TURN_DELAY_MS="${MULTI_TURN_DELAY_MS:-500}"
 GLOBAL_PREFIX_RATIO="${GLOBAL_PREFIX_RATIO:-0.1}"
 CONV_PREFIX_RATIO="${CONV_PREFIX_RATIO:-0.8}"
@@ -183,6 +184,13 @@ for backend in "${BACKEND_LIST[@]}"; do
             fi
             source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
             run_one "With CPU offloading (mooncake)" "mt_mooncake.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;
+        mooncake-mem)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            SETUP_ARGS=(--cpu-mem-size "$CPU_OFFLOAD_GIB")
+            source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
+            run_one "With CPU offloading (mooncake-mem)" "mt_mooncake_mem.json" \
                 --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
             ;;
         *)

--- a/scripts/mooncake/compare_results.py
+++ b/scripts/mooncake/compare_results.py
@@ -18,7 +18,7 @@ import argparse
 import json
 import os
 
-ALL_BACKENDS = ["baseline", "native", "simple", "mooncake"]
+ALL_BACKENDS = ["baseline", "native", "simple", "mooncake_mem", "mooncake"]
 
 METRICS = [
     ("Output throughput (tok/s)", "output_throughput", ".1f"),
@@ -31,7 +31,7 @@ METRICS = [
     ("Mean E2EL (ms)", "mean_e2el_ms", ".2f"),
 ]
 
-COL_W = 14
+COL_W = 20
 
 
 def pct(old, new):

--- a/scripts/mooncake/compare_results.py
+++ b/scripts/mooncake/compare_results.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare benchmark results across offloading backends.
+
+Usage:
+    python compare_results.py <result_dir> [--prefix PREFIX]
+
+Examples:
+    # Compare multi-turn results (mt_baseline.json, mt_mooncake.json, ...)
+    python compare_results.py ./bench_results --prefix mt_
+
+    # Compare single-turn results (baseline.json, mooncake.json, ...)
+    python compare_results.py ./bench_results
+"""
+
+import argparse
+import json
+import os
+
+ALL_BACKENDS = ["baseline", "native", "simple", "mooncake"]
+
+METRICS = [
+    ("Output throughput (tok/s)", "output_throughput", ".1f"),
+    ("Request throughput (req/s)", "request_throughput", ".3f"),
+    ("Mean TTFT (ms)", "mean_ttft_ms", ".2f"),
+    ("Median TTFT (ms)", "median_ttft_ms", ".2f"),
+    ("P99 TTFT (ms)", "p99_ttft_ms", ".2f"),
+    ("Mean TPOT (ms)", "mean_tpot_ms", ".2f"),
+    ("Mean ITL (ms)", "mean_itl_ms", ".2f"),
+    ("Mean E2EL (ms)", "mean_e2el_ms", ".2f"),
+]
+
+COL_W = 14
+
+
+def pct(old, new):
+    return (new - old) / old * 100 if old else 0.0
+
+
+def load_results(result_dir, prefix):
+    results = {}
+    for label in ALL_BACKENDS:
+        path = os.path.join(result_dir, f"{prefix}{label}.json")
+        if os.path.isfile(path):
+            with open(path) as f:
+                results[label] = json.load(f)
+    return results
+
+
+def print_comparison(results, title):
+    if not results:
+        print("\nNo result files found — nothing to compare.\n")
+        return
+
+    labels = list(results.keys())
+
+    print()
+    print("=" * (32 + COL_W * len(labels)))
+    print(f"  {title}  (delta vs baseline: + = regression, - = improvement)")
+    print("=" * (32 + COL_W * len(labels)))
+
+    header = f"  {'Metric':<30}"
+    for lb in labels:
+        header += f"  {lb:>{COL_W - 2}}"
+    print(header)
+
+    sep = f"  {'-' * 30}"
+    for _ in labels:
+        sep += f"  {'-' * (COL_W - 2)}"
+    print(sep)
+
+    baseline = results.get("baseline")
+
+    for metric_label, key, fmt in METRICS:
+        # Skip metrics not present in any result
+        if all(results[lb].get(key) is None for lb in labels):
+            continue
+        row = f"  {metric_label:<30}"
+        for lb in labels:
+            val = results[lb].get(key)
+            if val is None:
+                row += f"  {'N/A':>{COL_W - 2}}"
+                continue
+            cell = f"{val:{fmt}}"
+            if baseline and lb != "baseline":
+                bval = baseline.get(key, 0)
+                delta = pct(bval, val)
+                cell += f" ({delta:+.1f}%)"
+            row += f"  {cell:>{COL_W - 2}}"
+        print(row)
+
+    print("=" * (32 + COL_W * len(labels)))
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare benchmark results across offloading backends."
+    )
+    parser.add_argument("result_dir", help="Directory containing result JSONs")
+    parser.add_argument(
+        "--prefix",
+        default="",
+        help="Filename prefix (e.g. 'mt_' for multi-turn results)",
+    )
+    args = parser.parse_args()
+
+    results = load_results(args.result_dir, args.prefix)
+    title = "MULTI-TURN COMPARISON" if args.prefix == "mt_" else "COMPARISON"
+    print_comparison(results, title)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -3,6 +3,6 @@
   "master_server_address": "127.0.0.1:50051",
   "global_segment_size": "80GB",
   "local_buffer_size": "80GB",
-  "protocol": "tcp",
+  "protocol": "rdma",
   "device_name": ""
 }

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -2,7 +2,7 @@
   "metadata_server": "http://127.0.0.1:8080/metadata",
   "master_server_address": "127.0.0.1:50051",
   "global_segment_size": "600GB",
-  "local_buffer_size": "1GB",
+  "local_buffer_size": "4GB",
   "protocol": "rdma",
   "device_name": ""
 }

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -1,0 +1,8 @@
+{
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "master_server_address": "127.0.0.1:50051",
+  "global_segment_size": "80GB",
+  "local_buffer_size": "80GB",
+  "protocol": "tcp",
+  "device_name": ""
+}

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -1,8 +1,8 @@
 {
   "metadata_server": "http://127.0.0.1:8080/metadata",
   "master_server_address": "127.0.0.1:50051",
-  "global_segment_size": "80GB",
-  "local_buffer_size": "80GB",
+  "global_segment_size": "600GB",
+  "local_buffer_size": "1GB",
   "protocol": "rdma",
   "device_name": ""
 }

--- a/scripts/mooncake/mooncake_config_gb200_rack1_01.json
+++ b/scripts/mooncake/mooncake_config_gb200_rack1_01.json
@@ -1,0 +1,8 @@
+{
+  "metadata_server": "http://192.168.0.101:8080/metadata",
+  "master_server_address": "192.168.0.101:50051",
+  "global_segment_size": "100GB",
+  "local_buffer_size": "4GB",
+  "protocol": "rdma",
+  "device_name": ""
+}

--- a/scripts/mooncake/mooncake_example.py
+++ b/scripts/mooncake/mooncake_example.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from mooncake.store import MooncakeDistributedStore
+
+# 1. Create store instance
+store = MooncakeDistributedStore()
+
+# 2. Setup with all required parameters
+store.setup(
+    "localhost",  # Your node's address
+    "http://localhost:8080/metadata",  # HTTP metadata server
+    512 * 1024 * 1024,  # 512MB segment size
+    128 * 1024 * 1024,  # 128MB local buffer
+    "tcp",  # Use TCP (RDMA for high performance)
+    "",  # Leave empty; Mooncake auto-picks RDMA devices when needed
+    "localhost:50051",  # Master service
+)
+
+# 3. Store data
+store.put("hello_key", b"Hello, Mooncake Store!")
+
+# 4. Retrieve data
+data = store.get("hello_key")
+print(data.decode())  # Output: Hello, Mooncake Store!
+
+# 5. Clean up
+store.close()

--- a/scripts/mooncake/setup_vllm_env.sh
+++ b/scripts/mooncake/setup_vllm_env.sh
@@ -11,10 +11,6 @@
 #   --disk-size    <GB>  Enable disk offloading with the given quota in GB (optional)
 #   --disk-path    <dir> SSD directory for disk offloading (default: /mnt/data/mooncake_offload)
 #
-# Environment variables:
-#   MOONCAKE_LOCAL_BUFFER_GIB  Private Mooncake request buffer in GiB
-#                              (default: 1)
-
 set -euo pipefail
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,12 +42,6 @@ if [[ -z "$CPU_MEM_GB" ]]; then
     return 1 2>/dev/null || exit 1
 fi
 
-LOCAL_BUFFER_GIB="${MOONCAKE_LOCAL_BUFFER_GIB:-4}"
-if ! [[ "$LOCAL_BUFFER_GIB" =~ ^[0-9]+$ ]] || [[ "$LOCAL_BUFFER_GIB" -lt 1 ]]; then
-    echo "Error: MOONCAKE_LOCAL_BUFFER_GIB must be a positive integer" >&2
-    return 4 2>/dev/null || exit 1
-fi
-
 # --- Mooncake connection pool -----------------------------------------------
 export MC_TCP_ENABLE_CONNECTION_POOL=1
 
@@ -61,20 +51,18 @@ export MOONCAKE_CONFIG_PATH="${MOONCAKE_CONFIG_PATH:-${SCRIPTS_DIR}/mooncake_con
 python3 -c "
 import json, sys
 
-cfg_path, global_size_gb, local_buffer_gb = sys.argv[1], sys.argv[2], sys.argv[3]
+cfg_path, global_size_gb = sys.argv[1], sys.argv[2]
 with open(cfg_path) as f:
     cfg = json.load(f)
 cfg['global_segment_size'] = global_size_gb + 'GB'
-cfg['local_buffer_size'] = local_buffer_gb + 'GB'
 with open(cfg_path, 'w') as f:
     json.dump(cfg, f, indent=2)
     f.write('\n')
-" "$MOONCAKE_CONFIG_PATH" "$CPU_MEM_GB" "$LOCAL_BUFFER_GIB"
+" "$MOONCAKE_CONFIG_PATH" "$CPU_MEM_GB"
 
 echo "Mooncake env configured:"
 echo "  Config:   $MOONCAKE_CONFIG_PATH"
 echo "  CPU mem:  ${CPU_MEM_GB} GB (global segment)"
-echo "  Local buf: ${LOCAL_BUFFER_GIB} GB"
 
 # --- Disk offloading (client-side env vars) ---------------------------------
 if [[ -n "$DISK_GB" ]]; then
@@ -90,7 +78,7 @@ if [[ -n "$DISK_GB" ]]; then
     export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR="${MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR:-bucket_storage_backend}"
     export MOONCAKE_BUCKET_EVICTION_POLICY="${MOONCAKE_BUCKET_EVICTION_POLICY:-lru}"
     export MOONCAKE_USE_URING="${MOONCAKE_USE_URING:-true}"
-    export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES="${MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES:-4294967296}"  # 4 GB staging buffer
+    export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES="${MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES:-1073741824}"  # 1 GB staging buffer
 
     export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES="$DISK_BYTES"
     export MOONCAKE_BUCKET_MAX_TOTAL_SIZE=$(( DISK_BYTES - 42949672960 ))  # 40 GB headroom

--- a/scripts/mooncake/setup_vllm_env.sh
+++ b/scripts/mooncake/setup_vllm_env.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Set up environment variables for a vLLM worker with Mooncake KV offloading.
+#
+# Usage:
+#   source setup_vllm_env.sh --cpu-mem-size 80                       # 80 GB CPU offload, no disk
+#   source setup_vllm_env.sh --cpu-mem-size 80 --disk-size 400      # 80 GB CPU + 400 GB disk offload
+#   source setup_vllm_env.sh --cpu-mem-size 80 --disk-size 400 --disk-path /nvme/offload
+#
+# Options:
+#   --cpu-mem-size <GB>  CPU memory size in GB for Mooncake global segment (required)
+#   --disk-size    <GB>  Enable disk offloading with the given quota in GB (optional)
+#   --disk-path    <dir> SSD directory for disk offloading (default: /mnt/data/mooncake_offload)
+#
+# Environment variables:
+#   MOONCAKE_LOCAL_BUFFER_GIB  Private Mooncake request buffer in GiB
+#                              (default: 1)
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Parse arguments --------------------------------------------------------
+CPU_MEM_GB=""
+DISK_GB=""
+DISK_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cpu-mem-size)
+            CPU_MEM_GB="$2"; shift 2 ;;
+        --disk-size)
+            DISK_GB="$2"; shift 2 ;;
+        --disk-path)
+            DISK_PATH="$2"; shift 2 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: source $0 --cpu-mem-size <GB> [--disk-size <GB>] [--disk-path <dir>]" >&2
+            return 1 2>/dev/null || exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$CPU_MEM_GB" ]]; then
+    echo "Error: --cpu-mem-size is required" >&2
+    echo "Usage: source $0 --cpu-mem-size <GB> [--disk-size <GB>] [--disk-path <dir>]" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+LOCAL_BUFFER_GIB="${MOONCAKE_LOCAL_BUFFER_GIB:-4}"
+if ! [[ "$LOCAL_BUFFER_GIB" =~ ^[0-9]+$ ]] || [[ "$LOCAL_BUFFER_GIB" -lt 1 ]]; then
+    echo "Error: MOONCAKE_LOCAL_BUFFER_GIB must be a positive integer" >&2
+    return 4 2>/dev/null || exit 1
+fi
+
+# --- Mooncake connection pool -----------------------------------------------
+export MC_TCP_ENABLE_CONNECTION_POOL=1
+
+# --- Update mooncake config with CPU memory size ----------------------------
+export MOONCAKE_CONFIG_PATH="${MOONCAKE_CONFIG_PATH:-${SCRIPTS_DIR}/mooncake_config.json}"
+
+python3 -c "
+import json, sys
+
+cfg_path, global_size_gb, local_buffer_gb = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(cfg_path) as f:
+    cfg = json.load(f)
+cfg['global_segment_size'] = global_size_gb + 'GB'
+cfg['local_buffer_size'] = local_buffer_gb + 'GB'
+with open(cfg_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+" "$MOONCAKE_CONFIG_PATH" "$CPU_MEM_GB" "$LOCAL_BUFFER_GIB"
+
+echo "Mooncake env configured:"
+echo "  Config:   $MOONCAKE_CONFIG_PATH"
+echo "  CPU mem:  ${CPU_MEM_GB} GB (global segment)"
+echo "  Local buf: ${LOCAL_BUFFER_GIB} GB"
+
+# --- Disk offloading (client-side env vars) ---------------------------------
+if [[ -n "$DISK_GB" ]]; then
+    DISK_PATH="${DISK_PATH:-/mnt/data/mooncake_offload}"
+    DISK_BYTES=$(( DISK_GB * 1073741824 ))
+    if [[ "$DISK_GB" -lt 10 ]]; then
+        echo "Error: Disk size must be at least 10 GB" >&2
+        return 1 2>/dev/null || exit 1
+    fi
+
+    export MOONCAKE_ENABLE_OFFLOAD=1
+    export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$DISK_PATH"
+    export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR="${MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR:-bucket_storage_backend}"
+    export MOONCAKE_BUCKET_EVICTION_POLICY="${MOONCAKE_BUCKET_EVICTION_POLICY:-lru}"
+    export MOONCAKE_USE_URING="${MOONCAKE_USE_URING:-true}"
+    export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES="${MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES:-4294967296}"  # 4 GB staging buffer
+
+    export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES="$DISK_BYTES"
+    export MOONCAKE_BUCKET_MAX_TOTAL_SIZE=$(( DISK_BYTES - 42949672960 ))  # 40 GB headroom
+
+    export MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS="${MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS:-3}"
+
+    mkdir -p "$MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"
+
+    echo "  Disk:     ${DISK_GB} GB (path=${DISK_PATH}, eviction=${MOONCAKE_BUCKET_EVICTION_POLICY})"
+else
+    echo "  Disk:     OFF (pass --disk-size <GB> to enable)"
+fi

--- a/scripts/mooncake/start_mooncake_master.sh
+++ b/scripts/mooncake/start_mooncake_master.sh
@@ -6,18 +6,22 @@
 #   - HTTP metadata (port 8080): transfer engine peer discovery
 #
 # Usage:
-#   bash start_mooncake_master.sh          # foreground
-#   bash start_mooncake_master.sh --bg     # background (PID written to mooncake_master.pid)
-#   bash start_mooncake_master.sh --stop   # kill backgrounded master
+#   bash start_mooncake_master.sh                          # foreground
+#   bash start_mooncake_master.sh --bg                     # background (PID → mooncake_master.pid)
+#   bash start_mooncake_master.sh --enable-offload --bg    # background with disk offloading
+#   bash start_mooncake_master.sh --stop                   # kill backgrounded master
+#
+# Flags can appear in any order; --stop is processed first and ignores others.
 #
 # Environment variables (all optional):
-#   MC_RPC_PORT       - Master RPC port          (default: 50051)
-#   MC_HTTP_PORT      - HTTP metadata port        (default: 8080)
-#   MC_METRICS_PORT   - Prometheus metrics port   (default: 9003)
-#   MC_RPC_THREADS    - RPC worker threads        (default: 4)
-#   MC_LEASE_TTL      - KV lease TTL in ms        (default: 30000)
-#   MC_EVICT_HI       - Eviction high watermark   (default: 0.95)
+#   MC_RPC_PORT       - Master RPC port           (default: 50051)
+#   MC_HTTP_PORT      - HTTP metadata port         (default: 8080)
+#   MC_METRICS_PORT   - Prometheus metrics port    (default: 9003)
+#   MC_RPC_THREADS    - RPC worker threads         (default: 4)
+#   MC_LEASE_TTL      - KV lease TTL in ms         (default: 30000)
+#   MC_EVICT_HI       - Eviction high watermark    (default: 0.95)
 #   MC_EVICT_RATIO    - Fraction to evict per pass (default: 0.1)
+
 
 set -euo pipefail
 
@@ -25,6 +29,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PID_FILE="$SCRIPT_DIR/mooncake_master.pid"
 LOG_FILE="$SCRIPT_DIR/mooncake_master.log"
 
+# --- Parse flags -----------------------------------------------------------
+OPT_BG=false
+OPT_STOP=false
+OPT_OFFLOAD=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --bg)              OPT_BG=true ;;
+        --stop)            OPT_STOP=true ;;
+        --enable-offload)  OPT_OFFLOAD=true ;;
+        *)
+            echo "Unknown flag: $arg" >&2
+            echo "Usage: $0 [--bg] [--enable-offload] [--stop]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# --- Master settings -------------------------------------------------------
 MC_RPC_PORT="${MC_RPC_PORT:-50051}"
 MC_HTTP_PORT="${MC_HTTP_PORT:-8080}"
 MC_METRICS_PORT="${MC_METRICS_PORT:-9003}"
@@ -33,24 +56,32 @@ MC_LEASE_TTL="${MC_LEASE_TTL:-30000}"
 MC_EVICT_HI="${MC_EVICT_HI:-0.95}"
 MC_EVICT_RATIO="${MC_EVICT_RATIO:-0.1}"
 
-stop_master() {
-    if [[ -f "$PID_FILE" ]]; then
-        local pid
-        pid=$(<"$PID_FILE")
-        if kill -0 "$pid" 2>/dev/null; then
-            echo "Stopping mooncake_master (PID $pid)"
-            kill "$pid"
-            wait "$pid" 2>/dev/null || true
-        else
-            echo "mooncake_master (PID $pid) is not running"
-        fi
-        rm -f "$PID_FILE"
-    else
-        echo "No PID file found at $PID_FILE"
-    fi
+
+# --- Helper: stop a previously backgrounded master -------------------------
+is_our_master() {
+    local pid=$1
+    kill -0 "$pid" 2>/dev/null || return 1
+    [[ "$(ps -o comm= -p "$pid" 2>/dev/null)" == mooncake_maste* ]] || return 1
+    [[ "$(ps -o uid= -p "$pid" 2>/dev/null | tr -d ' ')" == "$(id -u)" ]]
 }
 
-if [[ "${1:-}" == "--stop" ]]; then
+stop_master() {
+    [[ -f "$PID_FILE" ]] || return 0
+    local pid=$(<"$PID_FILE")
+
+    if ! is_our_master "$pid"; then
+        rm -f "$PID_FILE"
+        return 0
+    fi
+
+    echo "Stopping mooncake_master (PID $pid) ..."
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 5); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    if kill -0 "$pid" 2>/dev/null; then kill -KILL "$pid" 2>/dev/null; sleep 1; fi
+    rm -f "$PID_FILE"
+}
+
+if $OPT_STOP; then
     stop_master
     exit 0
 fi
@@ -58,6 +89,7 @@ fi
 # Ensure no stale instance
 stop_master 2>/dev/null || true
 
+# --- Build command ----------------------------------------------------------
 CMD=(
     mooncake_master
     -rpc_port="$MC_RPC_PORT"
@@ -75,14 +107,36 @@ CMD=(
     -logtostderr
 )
 
+if $OPT_OFFLOAD; then
+    CMD+=( -enable_offload=true )
+    # Note: do NOT pass -root_fs_dir here. That enables direct disk writes
+    # during put, which segfaults on GPU-resident data. Disk offload for
+    # vLLM works via the client-side FileStorage heartbeat path instead:
+    # CPU memory -> SSD (background), not GPU -> SSD (inline).
+fi
+
+# --- Start ------------------------------------------------------------------
 echo "Starting mooncake_master"
 echo "  RPC:      0.0.0.0:${MC_RPC_PORT}"
 echo "  HTTP:     0.0.0.0:${MC_HTTP_PORT}/metadata"
 echo "  Metrics:  0.0.0.0:${MC_METRICS_PORT}"
+if $OPT_OFFLOAD; then
+    echo "  Offload:  ON"
+else
+    echo "  Offload:  OFF (pass --enable-offload to enable)"
+fi
 
-if [[ "${1:-}" == "--bg" ]]; then
-    "${CMD[@]}" > "$LOG_FILE" 2>&1 &
+if $OPT_BG; then
+    : > "$LOG_FILE"
+    nohup "${CMD[@]}" > "$LOG_FILE" 2>&1 < /dev/null &
     echo $! > "$PID_FILE"
+    sleep 1
+    if ! is_our_master "$(cat "$PID_FILE")"; then
+        echo "  ERROR: mooncake_master failed to stay running" >&2
+        tail -n 50 "$LOG_FILE" >&2 || true
+        rm -f "$PID_FILE"
+        exit 1
+    fi
     echo "  PID:      $(<"$PID_FILE") (written to $PID_FILE)"
     echo "  Log:      $LOG_FILE"
     echo ""

--- a/scripts/mooncake/start_mooncake_master.sh
+++ b/scripts/mooncake/start_mooncake_master.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Start a local Mooncake master server for benchmarking.
+#
+# The master provides two services:
+#   - RPC (port 50051): object metadata, allocation, eviction
+#   - HTTP metadata (port 8080): transfer engine peer discovery
+#
+# Usage:
+#   bash start_mooncake_master.sh          # foreground
+#   bash start_mooncake_master.sh --bg     # background (PID written to mooncake_master.pid)
+#   bash start_mooncake_master.sh --stop   # kill backgrounded master
+#
+# Environment variables (all optional):
+#   MC_RPC_PORT       - Master RPC port          (default: 50051)
+#   MC_HTTP_PORT      - HTTP metadata port        (default: 8080)
+#   MC_METRICS_PORT   - Prometheus metrics port   (default: 9003)
+#   MC_RPC_THREADS    - RPC worker threads        (default: 4)
+#   MC_LEASE_TTL      - KV lease TTL in ms        (default: 30000)
+#   MC_EVICT_HI       - Eviction high watermark   (default: 0.95)
+#   MC_EVICT_RATIO    - Fraction to evict per pass (default: 0.1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="$SCRIPT_DIR/mooncake_master.pid"
+LOG_FILE="$SCRIPT_DIR/mooncake_master.log"
+
+MC_RPC_PORT="${MC_RPC_PORT:-50051}"
+MC_HTTP_PORT="${MC_HTTP_PORT:-8080}"
+MC_METRICS_PORT="${MC_METRICS_PORT:-9003}"
+MC_RPC_THREADS="${MC_RPC_THREADS:-4}"
+MC_LEASE_TTL="${MC_LEASE_TTL:-30000}"
+MC_EVICT_HI="${MC_EVICT_HI:-0.95}"
+MC_EVICT_RATIO="${MC_EVICT_RATIO:-0.1}"
+
+stop_master() {
+    if [[ -f "$PID_FILE" ]]; then
+        local pid
+        pid=$(<"$PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Stopping mooncake_master (PID $pid)"
+            kill "$pid"
+            wait "$pid" 2>/dev/null || true
+        else
+            echo "mooncake_master (PID $pid) is not running"
+        fi
+        rm -f "$PID_FILE"
+    else
+        echo "No PID file found at $PID_FILE"
+    fi
+}
+
+if [[ "${1:-}" == "--stop" ]]; then
+    stop_master
+    exit 0
+fi
+
+# Ensure no stale instance
+stop_master 2>/dev/null || true
+
+CMD=(
+    mooncake_master
+    -rpc_port="$MC_RPC_PORT"
+    -rpc_thread_num="$MC_RPC_THREADS"
+    -rpc_address=0.0.0.0
+    -rpc_enable_tcp_no_delay=true
+    -enable_http_metadata_server=true
+    -http_metadata_server_host=0.0.0.0
+    -http_metadata_server_port="$MC_HTTP_PORT"
+    -enable_metric_reporting=true
+    -metrics_port="$MC_METRICS_PORT"
+    -default_kv_lease_ttl="$MC_LEASE_TTL"
+    -eviction_high_watermark_ratio="$MC_EVICT_HI"
+    -eviction_ratio="$MC_EVICT_RATIO"
+    -logtostderr
+)
+
+echo "Starting mooncake_master"
+echo "  RPC:      0.0.0.0:${MC_RPC_PORT}"
+echo "  HTTP:     0.0.0.0:${MC_HTTP_PORT}/metadata"
+echo "  Metrics:  0.0.0.0:${MC_METRICS_PORT}"
+
+if [[ "${1:-}" == "--bg" ]]; then
+    "${CMD[@]}" > "$LOG_FILE" 2>&1 &
+    echo $! > "$PID_FILE"
+    echo "  PID:      $(<"$PID_FILE") (written to $PID_FILE)"
+    echo "  Log:      $LOG_FILE"
+    echo ""
+    echo "Stop with:  bash $0 --stop"
+else
+    echo "  (foreground — Ctrl-C to stop)"
+    exec "${CMD[@]}"
+fi

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -300,6 +300,33 @@ def patch_worker_dependencies():
         }
 
 
+def test_worker_uses_data_parallel_index_in_dense_dp():
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_consumer"
+    )
+    vllm_config.parallel_config.data_parallel_rank = 0
+    vllm_config.parallel_config.data_parallel_index = 3
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(vllm_config, KVConnectorRole.WORKER)
+
+    assert connector.connector_worker.dp_rank == 3
+
+
+def test_worker_uses_local_rank_when_local_engines_only():
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_consumer"
+    )
+    vllm_config.parallel_config.data_parallel_index = 7
+    vllm_config.parallel_config.data_parallel_rank_local = 1
+    vllm_config.parallel_config.data_parallel_hybrid_lb = True
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(vllm_config, KVConnectorRole.WORKER)
+
+    assert connector.connector_worker.dp_rank == 1
+
+
 @pytest.mark.asyncio
 @patch(
     "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector.TransferEngine",

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, patch
+
+from vllm.config import set_current_vllm_config
+from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
+    mooncake_store_connector,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+    MooncakeStoreConnectorMetadata,
+)
+from vllm.v1.outputs import KVConnectorOutput
+
+from .utils import create_vllm_config
+
+
+def _make_vllm_config():
+    return create_vllm_config(
+        kv_connector="MooncakeStoreConnector",
+        kv_role="kv_both",
+    )
+
+
+def _make_block_stored() -> BlockStored:
+    return BlockStored(
+        block_hashes=[b"hash"],
+        parent_block_hash=None,
+        token_ids=[1, 2, 3],
+        block_size=16,
+        lora_id=None,
+        medium="cpu",
+        lora_name=None,
+    )
+
+
+def test_scheduler_role_initializes_store_scheduler_only():
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ) as mock_scheduler,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ) as mock_lookup_server,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+
+    mock_scheduler.assert_called_once_with(vllm_config)
+    mock_worker.assert_not_called()
+    mock_lookup_server.assert_not_called()
+    assert connector.connector_scheduler is mock_scheduler.return_value
+    assert connector.connector_worker is None
+
+
+def test_worker_role_initializes_store_worker_and_lookup_server_on_rank0():
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ) as mock_scheduler,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ) as mock_lookup_server,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    mock_scheduler.assert_not_called()
+    mock_worker.assert_called_once_with(vllm_config)
+    mock_lookup_server.assert_called_once_with(mock_worker.return_value, vllm_config)
+    assert connector.connector_scheduler is None
+    assert connector.connector_worker is mock_worker.return_value
+
+
+def test_worker_role_skips_lookup_server_on_nonzero_rank():
+    vllm_config = _make_vllm_config()
+    vllm_config.parallel_config.rank = 1
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ) as mock_lookup_server,
+    ):
+        mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    mock_worker.assert_called_once_with(vllm_config)
+    mock_lookup_server.assert_not_called()
+
+
+def test_worker_methods_delegate_to_store_worker():
+    vllm_config = _make_vllm_config()
+    kv_caches = {"layer0": MagicMock()}
+    metadata = MooncakeStoreConnectorMetadata(set(), set())
+    finished_req_ids = {"req-1"}
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    worker = mock_worker_cls.return_value
+    worker.get_finished.return_value = ({"req-1"}, {"req-2"})
+    connector.bind_connector_metadata(metadata)
+
+    connector.register_kv_caches(kv_caches)
+    result = connector.get_finished(finished_req_ids)
+
+    worker.register_kv_caches.assert_called_once_with(kv_caches)
+    worker.get_finished.assert_called_once_with(finished_req_ids, metadata)
+    assert result == ({"req-1"}, {"req-2"})
+
+
+def test_get_kv_connector_kv_cache_events_returns_none_when_empty():
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    mock_worker_cls.return_value.get_kv_events.return_value = []
+    assert connector.get_kv_connector_kv_cache_events() is None
+
+
+def test_get_kv_connector_kv_cache_events_wraps_worker_events():
+    vllm_config = _make_vllm_config()
+    event = _make_block_stored()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    mock_worker_cls.return_value.get_kv_events.return_value = [event]
+    kv_events = connector.get_kv_connector_kv_cache_events()
+
+    assert isinstance(kv_events, mooncake_store_connector.MooncakeStoreKVEvents)
+    assert kv_events.get_number_of_workers() == 1
+    assert kv_events.get_all_events() == [event]
+
+
+def test_prefer_cross_layer_blocks_from_config():
+    # Default: disabled
+    vllm_config = _make_vllm_config()
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+    assert connector.prefer_cross_layer_blocks is False
+
+    # Enabled via config
+    vllm_config_enabled = create_vllm_config(
+        kv_connector="MooncakeStoreConnector",
+        kv_role="kv_both",
+        kv_connector_extra_config={"enable_cross_layers_blocks": "true"},
+    )
+    with (
+        set_current_vllm_config(vllm_config_enabled),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector_enabled = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config_enabled, KVConnectorRole.SCHEDULER
+        )
+    assert connector_enabled.prefer_cross_layer_blocks is True
+
+
+def test_register_cross_layers_kv_cache_delegates_to_worker():
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ) as mock_worker_cls,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    fake_tensor = MagicMock()
+    fake_backend = MagicMock()
+    connector.register_cross_layers_kv_cache(fake_tensor, fake_backend)
+
+    worker = mock_worker_cls.return_value
+    worker.register_cross_layers_kv_caches.assert_called_once_with(fake_tensor)
+
+
+def test_update_connector_output_and_take_events():
+    vllm_config = _make_vllm_config()
+    event = _make_block_stored()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+
+    kv_events = mooncake_store_connector.MooncakeStoreKVEvents(num_workers=1)
+    kv_events.add_events([event])
+    connector.update_connector_output(KVConnectorOutput(kv_cache_events=kv_events))
+
+    assert connector._kv_cache_events is kv_events
+    assert list(connector.take_events()) == [event]
+    assert connector._kv_cache_events is None

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     mooncake_store_connector,
+    mooncake_store_scheduler,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     MooncakeStoreConnectorMetadata,
@@ -117,6 +118,27 @@ def test_worker_role_skips_lookup_server_on_nonzero_rank():
 
     mock_worker.assert_called_once_with(vllm_config)
     mock_lookup_server.assert_not_called()
+
+
+def test_lookup_rpc_path_uses_data_parallel_index_in_dense_dp():
+    vllm_config = _make_vllm_config()
+    vllm_config.parallel_config.data_parallel_rank = 0
+    vllm_config.parallel_config.data_parallel_index = 3
+
+    path = mooncake_store_scheduler.get_zmq_rpc_path_lookup(vllm_config)
+
+    assert path.endswith("_dp_rank3")
+
+
+def test_lookup_rpc_path_uses_local_rank_when_local_engines_only():
+    vllm_config = _make_vllm_config()
+    vllm_config.parallel_config.data_parallel_index = 7
+    vllm_config.parallel_config.data_parallel_rank_local = 1
+    vllm_config.parallel_config.data_parallel_hybrid_lb = True
+
+    path = mooncake_store_scheduler.get_zmq_rpc_path_lookup(vllm_config)
+
+    assert path.endswith("_dp_rank1")
 
 
 def test_worker_methods_delegate_to_store_worker():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -3,7 +3,9 @@
 
 import math
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import torch
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     mooncake_store_worker,
@@ -345,3 +347,199 @@ def test_recv_thread_reports_unsplittable_key_larger_than_budget():
     thread._handle_request(req)
 
     assert store.batch_get_into_multi_buffers.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers for register_kv_caches tests
+# ---------------------------------------------------------------------------
+
+
+def _auto_set_ready_event(*args, **kwargs):
+    """Side effect for mocked thread constructors that auto-sets ready_event."""
+    for arg in args:
+        if isinstance(arg, threading.Event):
+            arg.set()
+    for val in kwargs.values():
+        if isinstance(val, threading.Event):
+            val.set()
+    return MagicMock()
+
+
+def _make_bare_worker(
+    *,
+    num_gpu_blocks: int = 10,
+    block_size: int = 16,
+    kv_role: str = "kv_both",
+) -> mooncake_store_worker.MooncakeStoreWorker:
+    """Construct a MooncakeStoreWorker via __new__, bypassing __init__.
+
+    Sets only the attributes that register_kv_caches() reads so we can
+    test the stride-based layout detection without a real
+    MooncakeDistributedStore.
+    """
+    worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    worker.cache_config = MagicMock()
+    worker.cache_config.num_gpu_blocks = num_gpu_blocks
+    worker.store = MagicMock()
+    worker.store.register_buffer.return_value = 0
+    worker.use_mla = False
+    worker.token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=block_size
+    )
+    worker.kv_role = kv_role
+    worker.block_size = block_size
+    worker.tp_rank = 0
+    worker.put_step = 1
+    worker.enable_kv_events = False
+    worker.disk_offload_buffer_budget_bytes = None
+    worker.kv_send_thread = None
+    worker.kv_recv_thread = None
+    return worker
+
+
+# ---------------------------------------------------------------------------
+# register_kv_caches tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_kv_caches_blocks_first_single_segment():
+    """Blocks-first layout (FlashInfer/MLA): one segment per layer."""
+    num_blocks = 10
+    page_size_elements = 64  # elements per block
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
+
+    # Shape: (num_blocks, page_size_elements) — blocks outermost, no outer_dims
+    tensor = torch.zeros(num_blocks, page_size_elements, dtype=torch.float16)
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreSendingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreRecvingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+    ):
+        worker.register_kv_caches({"layer0": tensor})
+
+    assert len(worker.kv_caches_base_addr) == 1
+    assert worker.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
+
+    expected_block_len = tensor.untyped_storage().nbytes() // num_blocks
+    assert len(worker.block_len) == 1
+    assert worker.block_len[0] == expected_block_len
+
+    worker.store.register_buffer.assert_called_once_with(
+        tensor.untyped_storage().data_ptr(),
+        tensor.untyped_storage().nbytes(),
+    )
+
+
+def test_register_kv_caches_kv_first_two_segments():
+    """K/V-first layout (FlashAttn): two segments (K, V) per layer."""
+    num_blocks = 10
+    block_size_tokens = 16
+    num_kv_heads = 4
+    head_size = 8
+
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
+
+    # Shape: (2, num_blocks, block_size, num_kv_heads, head_size) — K/V outermost
+    tensor = torch.zeros(
+        2,
+        num_blocks,
+        block_size_tokens,
+        num_kv_heads,
+        head_size,
+        dtype=torch.float16,
+    )
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreSendingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreRecvingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+    ):
+        worker.register_kv_caches({"layer0": tensor})
+
+    # K/V-first: dim 0 has stride > page_size, so 2 segments
+    assert len(worker.kv_caches_base_addr) == 2
+    assert len(worker.block_len) == 2
+
+    el = tensor.element_size()
+    seg_stride = tensor.stride(0) * el  # stride of the K/V dim in bytes
+    base = tensor.untyped_storage().data_ptr()
+    assert worker.kv_caches_base_addr[0] == base
+    assert worker.kv_caches_base_addr[1] == base + seg_stride
+    assert worker.block_len[0] == seg_stride // num_blocks
+    assert worker.block_len[1] == seg_stride // num_blocks
+
+
+def test_register_kv_caches_cross_layer_single_segment():
+    """Cross-layer tensor: single segment with block_len = page_size * num_layers."""
+    num_blocks = 10
+    num_layers = 4
+    per_layer_page_elements = 64  # elements per layer per block
+
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
+
+    # Cross-layer blocks-first tensor: all layers packed into a single
+    # contiguous block.  Shape (num_blocks, num_layers * per_layer_page)
+    # mimics the physical layout after stride reordering.
+    total_page_elements = num_layers * per_layer_page_elements
+    tensor = torch.zeros(num_blocks, total_page_elements, dtype=torch.float16)
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreSendingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreRecvingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+    ):
+        # Use the cross-layer wrapper key, same as register_cross_layers_kv_caches
+        worker.register_kv_caches({"__cross_layer__": tensor})
+
+    assert len(worker.kv_caches_base_addr) == 1
+    assert worker.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
+
+    expected_block_len = tensor.untyped_storage().nbytes() // num_blocks
+    # block_len should be per_layer_page_size * num_layers
+    assert (
+        expected_block_len
+        == num_layers * per_layer_page_elements * tensor.element_size()
+    )
+    assert len(worker.block_len) == 1
+    assert worker.block_len[0] == expected_block_len
+
+    # Also verify via register_cross_layers_kv_caches wrapper
+    worker2 = _make_bare_worker(num_gpu_blocks=num_blocks)
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreSendingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreRecvingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+    ):
+        worker2.register_cross_layers_kv_caches(tensor)
+
+    assert worker2.kv_caches_base_addr == worker.kv_caches_base_addr
+    assert worker2.block_len == worker.block_len

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+import threading
+from unittest.mock import MagicMock
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
+    mooncake_store_worker,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    LoadSpec,
+    ReqMeta,
+)
+
+
+def _make_store_sending_thread(
+    store: MagicMock,
+) -> mooncake_store_worker.KVCacheStoreSendingThread:
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_kv_caches_base_addr([0x1000])
+    token_database.set_block_len([256])
+    thread = mooncake_store_worker.KVCacheStoreSendingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        put_step=1,
+        kv_role="kv_producer",
+        ready_event=threading.Event(),
+    )
+    thread.request_queue.task_done = MagicMock()
+    return thread
+
+
+def _make_store_recving_thread(
+    store: MagicMock,
+    *,
+    disk_offload_buffer_budget_bytes: int | None = None,
+) -> mooncake_store_worker.KVCacheStoreRecvingThread:
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_kv_caches_base_addr([0x1000])
+    token_database.set_block_len([256])
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        ready_event=threading.Event(),
+        disk_offload_buffer_budget_bytes=disk_offload_buffer_budget_bytes,
+    )
+    thread.request_queue.task_done = MagicMock()
+    return thread
+
+
+def _make_load_req(
+    req_id: str,
+    block_hashes: list[bytes],
+    *,
+    token_len: int,
+    vllm_cached_tokens: int = 0,
+) -> ReqMeta:
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=token_len,
+        block_ids=list(range(len(block_hashes))),
+        block_hashes=block_hashes,
+        load_spec=LoadSpec(
+            vllm_cached_tokens=vllm_cached_tokens,
+            kvpool_cached_tokens=token_len,
+            can_load=True,
+            token_len=token_len,
+        ),
+    )
+
+
+def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=32,
+        block_ids=[0, 1],
+        block_hashes=block_hashes,
+        can_save=True,
+        original_block_size=16,
+    )
+
+
+_DISK_OFFLOAD_SINGLE_KEY_BYTES = (
+    mooncake_store_worker._estimate_disk_offload_staging_bytes([256])
+)
+_DISK_OFFLOAD_USABLE_BUDGET_RATIO = 0.9
+_DISK_OFFLOAD_BUDGET_FOR_THREE_KEYS = 4 * _DISK_OFFLOAD_SINGLE_KEY_BYTES
+_DISK_OFFLOAD_BUDGET_FOR_SPLIT = math.ceil(
+    2 * _DISK_OFFLOAD_SINGLE_KEY_BYTES / _DISK_OFFLOAD_USABLE_BUDGET_RATIO
+)  # Allows two 256-byte chunks but not the third.
+_DISK_OFFLOAD_BUDGET_TOO_SMALL = (
+    _DISK_OFFLOAD_SINGLE_KEY_BYTES - 1
+)  # Smaller than a single 256-byte chunk.
+
+
+def test_store_sending_thread_skips_request_during_cpu_pressure():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = [
+        [-200, -200],
+        [256, 256],
+        [256, 256],
+    ]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    assert thread._store_pressure_active is True
+    assert "req-a" in thread._skip_store_requests
+    assert store.batch_put_from_multi_buffers.call_count == 1
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a2", b"a3"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 1
+
+    thread.add_stored_request("req-b")
+    thread._handle_request(_make_store_req("req-b", [b"b0", b"b1"]))
+
+    assert thread._store_pressure_active is False
+    assert "req-a" not in thread._skip_store_requests
+    assert store.batch_put_from_multi_buffers.call_count == 2
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a4", b"a5"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 3
+
+
+def test_store_sending_thread_only_skips_on_no_available_handle():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = [
+        [-500, -500],
+        [256, 256],
+    ]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    assert thread._store_pressure_active is False
+    assert "req-a" not in thread._skip_store_requests
+    assert store.batch_put_from_multi_buffers.call_count == 1
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a2", b"a3"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 2
+
+
+def test_get_disk_offload_buffer_budget_bytes_uses_effective_offload_flag(
+    monkeypatch,
+):
+    monkeypatch.delenv("MOONCAKE_ENABLE_OFFLOAD", raising=False)
+    monkeypatch.setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "2mb")
+
+    assert (
+        mooncake_store_worker._get_disk_offload_buffer_budget_bytes(enable_offload=True)
+        == 2 * 1024 * 1024
+    )
+    assert (
+        mooncake_store_worker._get_disk_offload_buffer_budget_bytes(
+            enable_offload=False
+        )
+        is None
+    )
+
+
+def test_estimate_disk_offload_staging_bytes_sums_multi_segment_sizes():
+    assert (
+        mooncake_store_worker._estimate_disk_offload_staging_bytes([256, 512]) == 12288
+    )
+
+
+def test_recv_thread_uses_single_batch_when_no_disk_offload_budget():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, 256]
+    thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+    keys, addrs, sizes = store.batch_get_into_multi_buffers.call_args.args
+    assert keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    assert sizes == [[256], [256], [256]]
+
+
+def test_recv_thread_uses_ratio_scaled_budget_for_first_pass_split():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [
+        [256],
+        [256],
+    ]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=2 * _DISK_OFFLOAD_SINGLE_KEY_BYTES,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1"],
+        token_len=32,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 2
+    first_keys = store.batch_get_into_multi_buffers.call_args_list[0].args[0]
+    second_keys = store.batch_get_into_multi_buffers.call_args_list[1].args[0]
+    assert first_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+    ]
+    assert second_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+    ]
+
+
+def test_recv_thread_splits_disk_offload_loads_by_budget():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [
+        [256, 256],
+        [256],
+    ]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 2
+
+    first_keys = store.batch_get_into_multi_buffers.call_args_list[0].args[0]
+    second_keys = store.batch_get_into_multi_buffers.call_args_list[1].args[0]
+    first_addrs = store.batch_get_into_multi_buffers.call_args_list[0].args[1]
+    second_addrs = store.batch_get_into_multi_buffers.call_args_list[1].args[1]
+    first_sizes = store.batch_get_into_multi_buffers.call_args_list[0].args[2]
+    second_sizes = store.batch_get_into_multi_buffers.call_args_list[1].args[2]
+    assert first_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+    ]
+    assert second_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    base_addr = thread.token_database.kv_caches_base_addr[0]
+    block_len = thread.token_database.block_len[0]
+    assert first_addrs == [[base_addr], [base_addr + block_len]]
+    assert second_addrs == [[base_addr + 2 * block_len]]
+    expected_size = block_len
+    assert first_sizes == [[expected_size], [expected_size]]
+    assert second_sizes == [[expected_size]]
+
+
+def test_recv_thread_stops_after_first_failing_disk_offload_sub_batch():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [-10, -10]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+
+
+def test_recv_thread_uses_soft_key_cap_for_disk_offload_split():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [
+        [256, 256],
+        [256],
+    ]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_THREE_KEYS,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 2
+    assert store.batch_get_into_multi_buffers.call_args_list[0].args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+    ]
+    assert store.batch_get_into_multi_buffers.call_args_list[1].args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+
+
+def test_recv_thread_reports_unsplittable_key_larger_than_budget():
+    store = MagicMock()
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_TOO_SMALL,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0"],
+        token_len=16,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 0

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -210,6 +210,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "MooncakeStoreConnector",
+    "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_connector",
+    "MooncakeStoreConnector",
+)
+
+KVConnectorFactory.register_connector(
     "FlexKVConnectorV1",
     "vllm.distributed.kv_transfer.kv_connector.v1.flexkv_connector",
     "FlexKVConnectorV1",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -32,6 +32,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     MooncakeBootstrapServer,
     RegisterWorkerPayload,
+    get_mooncake_dp_engine_index,
 )
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -688,9 +689,7 @@ class MooncakeConnectorWorker:
         self.seen_base_addresses: list[int] = []
 
         assert (parallel_config := vllm_config.parallel_config)
-        dp_rank = parallel_config.data_parallel_index
-        dp_local_rank = parallel_config.data_parallel_rank_local
-        self.dp_rank = dp_local_rank if parallel_config.local_engines_only else dp_rank
+        self.dp_rank = get_mooncake_dp_engine_index(parallel_config)
         pp_size = vllm_config.parallel_config.pipeline_parallel_size
         if pp_size > 1:
             raise ValueError(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -76,6 +76,14 @@ class MooncakeStoreKVEvents(KVConnectorKVEvents):
 class MooncakeStoreConnector(KVConnectorBase_V1):
     """KV connector using MooncakeDistributedStore as shared KV pool."""
 
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        extra_config = self._kv_transfer_config.kv_connector_extra_config
+        return (
+            str(extra_config.get("enable_cross_layers_blocks", "False")).lower()
+            == "true"
+        )
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -169,6 +177,12 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)
+
+    def register_cross_layers_kv_cache(
+        self, kv_cache: torch.Tensor, attn_backend: type
+    ):
+        assert self.connector_worker is not None
+        self.connector_worker.register_cross_layers_kv_caches(kv_cache)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         # No-op: loads are issued in get_finished() for compute overlap.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -171,10 +171,8 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         self.connector_worker.register_kv_caches(kv_caches)
 
     def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
-        assert self.connector_worker is not None
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-        self.connector_worker.start_load_kv(metadata)
+        # No-op: loads are issued in get_finished() for compute overlap.
+        pass
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         # No layerwise support - no-op
@@ -191,12 +189,8 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         return
 
     def wait_for_save(self):
-        if self.kv_role == "kv_consumer":
-            return
-        assert self.connector_worker is not None
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-        self.connector_worker.wait_for_save(metadata)
+        # No-op: stores are issued in get_finished() for compute overlap.
+        pass
 
     def get_finished(
         self, finished_req_ids: set[str]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MooncakeStoreConnector - KV cache connector using MooncakeDistributedStore.
+
+Unlike MooncakeConnector which does direct P2P transfer, this connector
+uses MooncakeDistributedStore as a shared KV cache pool. Both producer
+and consumer instances read/write KV to/from the store independently,
+enabling prefix caching via hash-based deduplication.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import (
+    KVCacheEvent,
+    KVConnectorKVEvents,
+    KVEventAggregator,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+    MooncakeStoreConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (
+    MooncakeStoreScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_worker import (
+    LookupKeyServer,
+    MooncakeStoreWorker,
+)
+from vllm.forward_context import ForwardContext
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class MooncakeStoreKVEvents(KVConnectorKVEvents):
+    """KV event aggregation for MooncakeStoreConnector."""
+
+    def __init__(self, num_workers: int) -> None:
+        self._aggregator = KVEventAggregator(num_workers)
+
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        self._aggregator.add_events(events)
+
+    def aggregate(self) -> "MooncakeStoreKVEvents":
+        common_events = self._aggregator.get_common_events()
+        self._aggregator.clear_events()
+        self._aggregator.add_events(common_events)
+        self._aggregator.reset_workers()
+        return self
+
+    def increment_workers(self, count: int = 1) -> None:
+        self._aggregator.increment_workers(count)
+
+    def get_all_events(self) -> list[KVCacheEvent]:
+        return self._aggregator.get_all_events()
+
+    def get_number_of_workers(self) -> int:
+        return self._aggregator.get_number_of_workers()
+
+    def clear_events(self) -> None:
+        self._aggregator.clear_events()
+        self._aggregator.reset_workers()
+
+    def __repr__(self) -> str:
+        return (
+            f"<MooncakeStoreKVEvents "
+            f"events={self.get_all_events()}>"
+        )
+
+
+class MooncakeStoreConnector(KVConnectorBase_V1):
+    """KV connector using MooncakeDistributedStore as shared KV pool."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self._kv_cache_events: MooncakeStoreKVEvents | None = None
+
+        self.connector_scheduler: MooncakeStoreScheduler | None = None
+        self.connector_worker: MooncakeStoreWorker | None = None
+
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler = MooncakeStoreScheduler(vllm_config)
+        else:
+            self.connector_worker = MooncakeStoreWorker(vllm_config)
+            if vllm_config.parallel_config.rank == 0:
+                self.lookup_server = LookupKeyServer(
+                    self.connector_worker, vllm_config
+                )
+
+    # ============================================================
+    # Scheduler-side methods
+    # ============================================================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+    ):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(
+            scheduler_output
+        )
+
+    def request_finished(
+        self,
+        request: Request,
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(
+            request, block_ids
+        )
+
+    def update_connector_output(
+        self, connector_output: KVConnectorOutput
+    ):
+        kv_cache_events = connector_output.kv_cache_events
+        if not kv_cache_events or not isinstance(
+            kv_cache_events, MooncakeStoreKVEvents
+        ):
+            return
+
+        if self._kv_cache_events is None:
+            self._kv_cache_events = kv_cache_events
+        else:
+            self._kv_cache_events.add_events(
+                kv_cache_events.get_all_events()
+            )
+            self._kv_cache_events.increment_workers(
+                kv_cache_events.get_number_of_workers()
+            )
+
+    def take_events(self) -> Iterable[KVCacheEvent]:
+        if self._kv_cache_events is not None:
+            self._kv_cache_events.aggregate()
+            yield from self._kv_cache_events.get_all_events()
+            self._kv_cache_events.clear_events()
+            self._kv_cache_events = None
+
+    # ============================================================
+    # Worker-side methods
+    # ============================================================
+
+    def register_kv_caches(
+        self, kv_caches: dict[str, torch.Tensor]
+    ):
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(kv_caches)
+
+    def start_load_kv(
+        self, forward_context: ForwardContext, **kwargs: Any
+    ) -> None:
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+        self.connector_worker.start_load_kv(metadata)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        # No layerwise support - no-op
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        # No layerwise support - no-op
+        return
+
+    def wait_for_save(self):
+        if self.kv_role == "kv_consumer":
+            return
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+        self.connector_worker.wait_for_save(metadata)
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        assert self.connector_worker is not None
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, MooncakeStoreConnectorMetadata)
+        return self.connector_worker.get_finished(
+            finished_req_ids, metadata
+        )
+
+    def get_kv_connector_kv_cache_events(
+        self,
+    ) -> MooncakeStoreKVEvents | None:
+        assert self.connector_worker is not None
+        events = self.connector_worker.get_kv_events()
+        if not events:
+            return None
+
+        kv_events = MooncakeStoreKVEvents(num_workers=1)
+        kv_events.add_events(events)
+        return kv_events

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -24,16 +24,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
-    MooncakeStoreConnectorMetadata,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (
-    MooncakeStoreScheduler,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_worker import (
-    LookupKeyServer,
-    MooncakeStoreWorker,
-)
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
@@ -42,6 +32,10 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
+
+from .mooncake_store_data import MooncakeStoreConnectorMetadata
+from .mooncake_store_scheduler import MooncakeStoreScheduler
+from .mooncake_store_worker import LookupKeyServer, MooncakeStoreWorker
 
 logger = init_logger(__name__)
 
@@ -76,10 +70,7 @@ class MooncakeStoreKVEvents(KVConnectorKVEvents):
         self._aggregator.reset_workers()
 
     def __repr__(self) -> str:
-        return (
-            f"<MooncakeStoreKVEvents "
-            f"events={self.get_all_events()}>"
-        )
+        return f"<MooncakeStoreKVEvents events={self.get_all_events()}>"
 
 
 class MooncakeStoreConnector(KVConnectorBase_V1):
@@ -107,9 +98,7 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         else:
             self.connector_worker = MooncakeStoreWorker(vllm_config)
             if vllm_config.parallel_config.rank == 0:
-                self.lookup_server = LookupKeyServer(
-                    self.connector_worker, vllm_config
-                )
+                self.lookup_server = LookupKeyServer(self.connector_worker, vllm_config)
 
     # ============================================================
     # Scheduler-side methods
@@ -141,9 +130,7 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         scheduler_output: SchedulerOutput,
     ) -> KVConnectorMetadata:
         assert self.connector_scheduler is not None
-        return self.connector_scheduler.build_connector_meta(
-            scheduler_output
-        )
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
 
     def request_finished(
         self,
@@ -151,13 +138,9 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
-        return self.connector_scheduler.request_finished(
-            request, block_ids
-        )
+        return self.connector_scheduler.request_finished(request, block_ids)
 
-    def update_connector_output(
-        self, connector_output: KVConnectorOutput
-    ):
+    def update_connector_output(self, connector_output: KVConnectorOutput):
         kv_cache_events = connector_output.kv_cache_events
         if not kv_cache_events or not isinstance(
             kv_cache_events, MooncakeStoreKVEvents
@@ -167,9 +150,7 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         if self._kv_cache_events is None:
             self._kv_cache_events = kv_cache_events
         else:
-            self._kv_cache_events.add_events(
-                kv_cache_events.get_all_events()
-            )
+            self._kv_cache_events.add_events(kv_cache_events.get_all_events())
             self._kv_cache_events.increment_workers(
                 kv_cache_events.get_number_of_workers()
             )
@@ -185,15 +166,11 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
     # Worker-side methods
     # ============================================================
 
-    def register_kv_caches(
-        self, kv_caches: dict[str, torch.Tensor]
-    ):
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)
 
-    def start_load_kv(
-        self, forward_context: ForwardContext, **kwargs: Any
-    ) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MooncakeStoreConnectorMetadata)
@@ -227,9 +204,7 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         assert self.connector_worker is not None
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MooncakeStoreConnectorMetadata)
-        return self.connector_worker.get_finished(
-            finished_req_ids, metadata
-        )
+        return self.connector_worker.get_finished(finished_req_ids, metadata)
 
     def get_kv_connector_kv_cache_events(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Data classes for MooncakeStoreConnector."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+)
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_utils import BlockHash
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class KeyMetadata:
+    """Metadata for constructing pool keys."""
+
+    model_name: str
+    tp_rank: int
+    pcp_rank: int
+    dcp_rank: int
+    pp_rank: int
+
+
+@dataclass(order=True)
+class PoolKey:
+    """Key for addressing KV cache blocks in the distributed store."""
+
+    key_metadata: KeyMetadata
+    chunk_hash: str
+
+    def __hash__(self):
+        return hash(
+            (
+                self.key_metadata.model_name,
+                self.key_metadata.tp_rank,
+                self.key_metadata.pcp_rank,
+                self.key_metadata.dcp_rank,
+                self.key_metadata.pp_rank,
+                self.chunk_hash,
+            )
+        )
+
+    def to_string(self) -> str:
+        return (
+            f"{self.key_metadata.model_name}"
+            f"@tp_rank:{self.key_metadata.tp_rank}"
+            f"@pcp{self.key_metadata.pcp_rank}"
+            f"@dcp{self.key_metadata.dcp_rank}"
+            f"@pp_rank:{self.key_metadata.pp_rank}"
+            f"@{self.chunk_hash}"
+        )
+
+
+class ChunkedTokenDatabase:
+    """Maps token positions to store keys and GPU memory addresses."""
+
+    def __init__(
+        self, metadata: KeyMetadata, block_size: int
+    ):
+        self.metadata = metadata
+        self.block_size = block_size
+        self.kv_caches_base_addr: list[int] = []
+        self.block_len: list[int] = []
+
+    def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
+        return PoolKey(self.metadata, chunk_hash)
+
+    def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
+        self.kv_caches_base_addr = kv_caches_base_addr
+
+    def set_block_len(self, block_len: list[int]):
+        self.block_len = block_len
+
+    def prepare_value(
+        self, start: int, end: int, block_ids: list[int]
+    ) -> tuple[list[int], list[int], int]:
+        """Compute memory addresses and sizes for a token range.
+
+        Returns:
+            (addr_list, size_list, block_id)
+        """
+        addr_list = []
+        size_list = []
+        block_id = block_ids[start // self.block_size]
+        length = len(self.block_len)
+        for index, base_addr in enumerate(self.kv_caches_base_addr):
+            addr = base_addr + block_id * self.block_len[index % length]
+            size = int(
+                self.block_len[index % length]
+                / self.block_size
+                * (end - start)
+            )
+            addr_list.append(addr)
+            size_list.append(size)
+        return addr_list, size_list, block_id
+
+    def process_tokens(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash] | list[str],
+        mask_num: int = 0,
+    ) -> Iterable[tuple[int, int, PoolKey]]:
+        """Process tokens and yield (start_idx, end_idx, pool_key) tuples.
+
+        Args:
+            token_len: Total number of tokens.
+            block_hashes: Block hashes for each block.
+            mask_num: Number of tokens to skip from the beginning.
+        """
+        if not block_hashes:
+            return
+        if not isinstance(block_hashes[0], str):
+            block_hashes = [
+                h.hex()  # type: ignore[union-attr]
+                for h in block_hashes
+            ]
+        for chunk_id, hash_val in enumerate(block_hashes):
+            start_idx = chunk_id * self.block_size
+            if start_idx >= token_len:
+                break
+            end_idx = min(start_idx + self.block_size, token_len)
+            if start_idx < mask_num:
+                continue
+            else:
+                yield start_idx, end_idx, self._make_key_by_hash(hash_val)
+
+
+@dataclass
+class LoadSpec:
+    """Specification for loading KV cache from external store."""
+
+    vllm_cached_tokens: int
+    kvpool_cached_tokens: int
+    can_load: bool
+    token_len: int = 0
+
+
+@dataclass
+class RequestTracker:
+    """Tracks per-request state across scheduler ticks."""
+
+    req_id: str
+    token_len: int
+    allocated_block_ids: list[int]
+    num_saved_tokens: int = 0
+    token_ids: list[int] | None = None
+
+    def update(
+        self,
+        new_block_ids: tuple[list[int], ...] | list[int],
+    ) -> None:
+        if len(new_block_ids) == 0:
+            new_block_ids = []
+        elif isinstance(new_block_ids, tuple):
+            new_block_ids = new_block_ids[0]
+        elif isinstance(new_block_ids, list):
+            pass
+        else:
+            raise ValueError(
+                f"Unsupported new_block_ids type {type(new_block_ids)}"
+            )
+        self.allocated_block_ids.extend(new_block_ids)
+
+
+@dataclass
+class ReqMeta:
+    """Per-request metadata for store put/get operations."""
+
+    req_id: str
+    token_len_chunk: int
+    block_ids: list[int]
+    block_hashes: list[BlockHash]
+
+    can_save: bool | None = None
+    load_spec: LoadSpec | None = None
+    is_last_chunk: bool | None = None
+    current_event: torch.cuda.Event | None = None
+
+    token_ids: list[int] | None = None
+    original_block_size: int | None = None
+
+    @staticmethod
+    def from_request_tracker(
+        tracker: RequestTracker,
+        block_size: int,
+        load_spec: LoadSpec | None = None,
+        skip_save: bool | None = False,
+        block_hashes: list[BlockHash] | None = None,
+        is_last_chunk: bool | None = None,
+        discard_partial_chunks: bool = True,
+        original_block_size: int | None = None,
+    ) -> Optional["ReqMeta"]:
+        """Create ReqMeta from a RequestTracker."""
+        if block_hashes is None:
+            block_hashes = []
+        input_token_len = tracker.token_len
+
+        chunk_boundary = (
+            cdiv(tracker.num_saved_tokens + 1, block_size) * block_size
+            if discard_partial_chunks
+            else 0
+        )
+        num_tokens_to_save = (
+            (input_token_len // block_size * block_size)
+            if discard_partial_chunks
+            else input_token_len
+        )
+
+        skip_save = skip_save or num_tokens_to_save < chunk_boundary
+        if skip_save and load_spec is None:
+            return None
+
+        if not skip_save:
+            tracker.num_saved_tokens = num_tokens_to_save
+
+        token_ids = None
+        if tracker.token_ids:
+            token_ids = tracker.token_ids
+
+        if load_spec is not None and load_spec.can_load:
+            logger.debug(
+                "Scheduled to load %d tokens for request %s",
+                load_spec.kvpool_cached_tokens,
+                tracker.req_id,
+            )
+        else:
+            load_spec = None
+
+        logger.debug(
+            "request:%s, meta save spec:%s, meta load spec:%s",
+            tracker.req_id,
+            not skip_save,
+            load_spec,
+        )
+        return ReqMeta(
+            req_id=tracker.req_id,
+            token_len_chunk=num_tokens_to_save,
+            block_ids=tracker.allocated_block_ids,
+            can_save=not skip_save,
+            load_spec=load_spec,
+            block_hashes=block_hashes,
+            is_last_chunk=is_last_chunk,
+            token_ids=token_ids,
+            original_block_size=original_block_size,
+        )
+
+
+class MooncakeStoreConnectorMetadata(KVConnectorMetadata):
+    """Metadata passed from scheduler to worker."""
+
+    def __init__(
+        self,
+        unfinished_request_ids: set[str],
+        preempted_req_ids: set[str],
+    ):
+        self.requests: list[ReqMeta] = []
+        self.unfinished_request_ids = unfinished_request_ids
+        self.preempted_req_ids = preempted_req_ids
+
+    def add_request(self, req_meta: ReqMeta) -> None:
+        self.requests.append(req_meta)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
@@ -62,9 +62,7 @@ class PoolKey:
 class ChunkedTokenDatabase:
     """Maps token positions to store keys and GPU memory addresses."""
 
-    def __init__(
-        self, metadata: KeyMetadata, block_size: int
-    ):
+    def __init__(self, metadata: KeyMetadata, block_size: int):
         self.metadata = metadata
         self.block_size = block_size
         self.kv_caches_base_addr: list[int] = []
@@ -93,11 +91,7 @@ class ChunkedTokenDatabase:
         length = len(self.block_len)
         for index, base_addr in enumerate(self.kv_caches_base_addr):
             addr = base_addr + block_id * self.block_len[index % length]
-            size = int(
-                self.block_len[index % length]
-                / self.block_size
-                * (end - start)
-            )
+            size = int(self.block_len[index % length] / self.block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
         return addr_list, size_list, block_id
@@ -164,9 +158,7 @@ class RequestTracker:
         elif isinstance(new_block_ids, list):
             pass
         else:
-            raise ValueError(
-                f"Unsupported new_block_ids type {type(new_block_ids)}"
-            )
+            raise ValueError(f"Unsupported new_block_ids type {type(new_block_ids)}")
         self.allocated_block_ids.extend(new_block_ids)
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -33,20 +33,14 @@ class MooncakeStoreScheduler:
 
     def __init__(self, vllm_config: VllmConfig):
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = (
-            vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-                "load_async", False
-            )
+        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "load_async", False
         )
         self.client = LookupKeyClient(vllm_config)
 
         self.load_specs: dict[str, LoadSpec] = {}
-        self.pcp_size = (
-            vllm_config.parallel_config.prefill_context_parallel_size
-        )
-        self.dcp_size = (
-            vllm_config.parallel_config.decode_context_parallel_size
-        )
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
         self.original_block_size = vllm_config.cache_config.block_size
         self._block_size = vllm_config.cache_config.block_size
         if self.pcp_size > 1:
@@ -72,9 +66,7 @@ class MooncakeStoreScheduler:
         """Check for external KV cache hit."""
         if self._discard_partial_chunks:
             token_len = (
-                len(request.prompt_token_ids)
-                // self._block_size
-                * self._block_size
+                len(request.prompt_token_ids) // self._block_size * self._block_size
             )
         else:
             token_len = len(request.prompt_token_ids)
@@ -82,9 +74,7 @@ class MooncakeStoreScheduler:
         if token_len < self._block_size:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(
-            token_len, request.block_hashes
-        )
+        num_external_hit_tokens = self.client.lookup(token_len, request.block_hashes)
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
@@ -95,8 +85,7 @@ class MooncakeStoreScheduler:
             need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
         logger.debug(
-            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, "
-            "need to load: %d",
+            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
             request.request_id,
             request.num_tokens,
             num_external_hit_tokens,
@@ -165,9 +154,7 @@ class MooncakeStoreScheduler:
             self._preempted_req_ids.discard(finished_req_id)
 
         for req_id in scheduler_output.preempted_req_ids:
-            self._preempted_req_ids.update(
-                scheduler_output.preempted_req_ids
-            )
+            self._preempted_req_ids.update(scheduler_output.preempted_req_ids)
             self._request_trackers.pop(req_id, None)
             self._unfinished_requests.pop(req_id, None)
 
@@ -196,18 +183,12 @@ class MooncakeStoreScheduler:
                 token_len=num_tokens_to_compute,
                 allocated_block_ids=unfolded_block_ids,
                 num_saved_tokens=0,
-                token_ids=request.prompt_token_ids[
-                    :num_tokens_to_compute
-                ].copy(),
+                token_ids=request.prompt_token_ids[:num_tokens_to_compute].copy(),
             )
             self._request_trackers[request.req_id] = request_tracker
 
             last_chunk_tokens_num = (
-                (
-                    len(request.prompt_token_ids)
-                    // self._block_size
-                    * self._block_size
-                )
+                (len(request.prompt_token_ids) // self._block_size * self._block_size)
                 if self._discard_partial_chunks
                 else len(request.prompt_token_ids)
             )
@@ -218,9 +199,7 @@ class MooncakeStoreScheduler:
                 load_spec=load_spec,
                 skip_save=force_skip_save,
                 block_hashes=request_real.block_hashes,
-                is_last_chunk=(
-                    request_tracker.token_len >= last_chunk_tokens_num
-                ),
+                is_last_chunk=(request_tracker.token_len >= last_chunk_tokens_num),
                 discard_partial_chunks=self._discard_partial_chunks,
                 original_block_size=self.original_block_size,
             )
@@ -277,8 +256,7 @@ class MooncakeStoreScheduler:
                         skip_save=force_skip_save,
                         block_hashes=request_real.block_hashes,
                         is_last_chunk=(
-                            request_tracker.token_len
-                            >= last_chunk_tokens_num
+                            request_tracker.token_len >= last_chunk_tokens_num
                         ),
                         discard_partial_chunks=self._discard_partial_chunks,
                         original_block_size=self.original_block_size,
@@ -286,22 +264,18 @@ class MooncakeStoreScheduler:
                 else:
                     # Decode/chunked request
                     request_tracker = self._request_trackers[req_id]
-                    num_new_tokens = (
-                        scheduler_output.num_scheduled_tokens[req_id]
-                    )
+                    num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
                     req_tuple = self._unfinished_requests.get(req_id)
                     if req_tuple:
                         request = req_tuple[0]
                         num_current_tokens = request_tracker.token_len
                         new_token_ids = request.all_token_ids[
-                            num_current_tokens : num_current_tokens
-                            + num_new_tokens
+                            num_current_tokens : num_current_tokens + num_new_tokens
                         ]
                         request_tracker.token_len += len(new_token_ids)
                     else:
                         raise ValueError(
-                            f"Request {req_id} is not in "
-                            "_unfinished_requests"
+                            f"Request {req_id} is not in _unfinished_requests"
                         )
                     num_computed_token = cached_reqs.num_computed_tokens[i]
                     if num_computed_token >= len(request.prompt_token_ids):
@@ -324,8 +298,7 @@ class MooncakeStoreScheduler:
                         skip_save=force_skip_save,
                         block_hashes=request.block_hashes,
                         is_last_chunk=(
-                            request_tracker.token_len
-                            >= last_chunk_tokens_num
+                            request_tracker.token_len >= last_chunk_tokens_num
                         ),
                         discard_partial_chunks=self._discard_partial_chunks,
                         original_block_size=self.original_block_size,
@@ -335,26 +308,18 @@ class MooncakeStoreScheduler:
                     meta.add_request(req_meta)
 
         # Handle requests with pending load specs not yet scheduled
-        request_ids = [
-            req.req_id for req in scheduler_output.scheduled_new_reqs
-        ]
+        request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]
         for request_id, (
             request,
             block_ids,
         ) in self._unfinished_requests.items():
-            if (
-                request_id not in request_ids
-                and request_id not in cached_reqs.req_ids
-            ):
+            if request_id not in request_ids and request_id not in cached_reqs.req_ids:
                 load_spec = self.load_specs.pop(request_id, None)
                 if not load_spec:
                     continue
                 num_tokens_to_compute = load_spec.kvpool_cached_tokens
-                if (
-                    num_tokens_to_compute % self._block_size != 0
-                ) and (
-                    num_tokens_to_compute
-                    == len(request.prompt_token_ids) - 1
+                if (num_tokens_to_compute % self._block_size != 0) and (
+                    num_tokens_to_compute == len(request.prompt_token_ids) - 1
                 ):
                     num_tokens_to_compute = num_tokens_to_compute + 1
                 request_tracker = RequestTracker(
@@ -412,9 +377,7 @@ class LookupKeyClient:
             bind=False,
         )
 
-    def lookup(
-        self, token_len: int, block_hashes: list[BlockHash]
-    ) -> int:
+    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
@@ -433,9 +396,7 @@ def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
     dp_rank = vllm_config.parallel_config.data_parallel_rank
     base_url = envs.VLLM_RPC_BASE_PATH
     rpc_port = 0
-    extra_config = (
-        vllm_config.kv_transfer_config.kv_connector_extra_config
-    )
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     if "lookup_rpc_port" in extra_config:
         rpc_port = extra_config["lookup_rpc_port"]
     logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Scheduler-side logic for MooncakeStoreConnector."""
+
+from typing import Any
+
+import zmq
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+    LoadSpec,
+    MooncakeStoreConnectorMetadata,
+    ReqMeta,
+    RequestTracker,
+)
+from vllm.logger import init_logger
+from vllm.utils.network_utils import make_zmq_socket
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.request import Request
+from vllm.v1.serial_utils import MsgpackEncoder
+
+logger = init_logger(__name__)
+
+
+class MooncakeStoreScheduler:
+    """Scheduler-side component for MooncakeStoreConnector."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self.load_async = (
+            vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+                "load_async", False
+            )
+        )
+        self.client = LookupKeyClient(vllm_config)
+
+        self.load_specs: dict[str, LoadSpec] = {}
+        self.pcp_size = (
+            vllm_config.parallel_config.prefill_context_parallel_size
+        )
+        self.dcp_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+        )
+        self.original_block_size = vllm_config.cache_config.block_size
+        self._block_size = vllm_config.cache_config.block_size
+        if self.pcp_size > 1:
+            self._block_size *= self.pcp_size
+        if self.dcp_size > 1:
+            self._block_size *= self.dcp_size
+
+        self._request_trackers: dict[str, RequestTracker] = {}
+        self._preempted_req_ids: set[str] = set()
+        self._discard_partial_chunks = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "discard_partial_chunks", True
+            )
+        )
+        self._unfinished_requests: dict[str, tuple[Request, list[int]]] = {}
+        self._unfinished_request_ids: set[str] = set()
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        """Check for external KV cache hit."""
+        if self._discard_partial_chunks:
+            token_len = (
+                len(request.prompt_token_ids)
+                // self._block_size
+                * self._block_size
+            )
+        else:
+            token_len = len(request.prompt_token_ids)
+
+        if token_len < self._block_size:
+            return 0, False
+
+        num_external_hit_tokens = self.client.lookup(
+            token_len, request.block_hashes
+        )
+
+        if num_external_hit_tokens == request.num_tokens:
+            num_external_hit_tokens -= 1
+
+        if num_external_hit_tokens < num_computed_tokens:
+            need_to_allocate = 0
+        else:
+            need_to_allocate = num_external_hit_tokens - num_computed_tokens
+
+        logger.debug(
+            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, "
+            "need to load: %d",
+            request.request_id,
+            request.num_tokens,
+            num_external_hit_tokens,
+            need_to_allocate,
+        )
+
+        if need_to_allocate <= 0:
+            return 0, False
+
+        self.load_specs[request.request_id] = LoadSpec(
+            vllm_cached_tokens=num_computed_tokens,
+            kvpool_cached_tokens=num_external_hit_tokens,
+            can_load=False,
+        )
+
+        return need_to_allocate, self.load_async
+
+    def update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+    ):
+        """Update state after block allocation."""
+        local_block_ids: list[int] = []
+        if num_external_tokens > 0:
+            local_block_ids = blocks.get_block_ids()[0]
+
+        self._unfinished_requests[request.request_id] = (
+            request,
+            local_block_ids,
+        )
+        self._unfinished_request_ids.add(request.request_id)
+
+        if request.request_id not in self.load_specs:
+            return
+
+        if num_external_tokens == 0:
+            self.load_specs[request.request_id].can_load = False
+            return
+
+        assert (
+            num_external_tokens > 0
+            and num_external_tokens
+            == self.load_specs[request.request_id].kvpool_cached_tokens
+            - self.load_specs[request.request_id].vllm_cached_tokens
+        ), (
+            f"Mismatch in number of tokens: {num_external_tokens} vs "
+            f"{self.load_specs[request.request_id].kvpool_cached_tokens} - "
+            f"{self.load_specs[request.request_id].vllm_cached_tokens}"
+            f" for request {request.request_id}"
+        )
+
+        self.load_specs[request.request_id].can_load = True
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        """Build connector metadata for this scheduler step."""
+        force_skip_save = self.kv_role == "kv_consumer"
+
+        for finished_req_id in scheduler_output.finished_req_ids:
+            self._request_trackers.pop(finished_req_id, None)
+            self._unfinished_requests.pop(finished_req_id, None)
+            self._unfinished_request_ids.discard(finished_req_id)
+            self._preempted_req_ids.discard(finished_req_id)
+
+        for req_id in scheduler_output.preempted_req_ids:
+            self._preempted_req_ids.update(
+                scheduler_output.preempted_req_ids
+            )
+            self._request_trackers.pop(req_id, None)
+            self._unfinished_requests.pop(req_id, None)
+
+        meta = MooncakeStoreConnectorMetadata(
+            self._unfinished_request_ids,
+            scheduler_output.preempted_req_ids,
+        )
+
+        # Handle new requests
+        for request in scheduler_output.scheduled_new_reqs:
+            load_spec = self.load_specs.pop(request.req_id, None)
+            num_tokens_to_compute = (
+                request.num_computed_tokens
+                + scheduler_output.num_scheduled_tokens[request.req_id]
+            )
+            request_tuple = self._unfinished_requests.get(request.req_id)
+            request_real = request_tuple[0]  # type: ignore[index]
+
+            if not isinstance(request.block_ids[0], list):
+                unfolded_block_ids = request.block_ids.copy()
+            else:
+                unfolded_block_ids = request.block_ids[0].copy()
+
+            request_tracker = RequestTracker(
+                req_id=request.req_id,
+                token_len=num_tokens_to_compute,
+                allocated_block_ids=unfolded_block_ids,
+                num_saved_tokens=0,
+                token_ids=request.prompt_token_ids[
+                    :num_tokens_to_compute
+                ].copy(),
+            )
+            self._request_trackers[request.req_id] = request_tracker
+
+            last_chunk_tokens_num = (
+                (
+                    len(request.prompt_token_ids)
+                    // self._block_size
+                    * self._block_size
+                )
+                if self._discard_partial_chunks
+                else len(request.prompt_token_ids)
+            )
+
+            req_meta = ReqMeta.from_request_tracker(
+                request_tracker,
+                self._block_size,
+                load_spec=load_spec,
+                skip_save=force_skip_save,
+                block_hashes=request_real.block_hashes,
+                is_last_chunk=(
+                    request_tracker.token_len >= last_chunk_tokens_num
+                ),
+                discard_partial_chunks=self._discard_partial_chunks,
+                original_block_size=self.original_block_size,
+            )
+            if req_meta is not None:
+                meta.add_request(req_meta)
+
+        # Handle cached (running) requests
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        if not force_skip_save:
+            for i, req_id in enumerate(cached_reqs.req_ids):
+                new_block_ids = cached_reqs.new_block_ids[i]
+                if not new_block_ids:
+                    continue
+
+                req_meta = None
+                if req_id in self._preempted_req_ids:
+                    # Resumed after preemption
+                    if isinstance(new_block_ids, tuple):
+                        new_block_ids = new_block_ids[0].copy()
+                    else:
+                        new_block_ids = new_block_ids.copy()
+                    self._preempted_req_ids.discard(req_id)
+                    load_spec = self.load_specs.pop(req_id, None)
+                    request_tuple = self._unfinished_requests.get(req_id)
+                    request_real = request_tuple[0]  # type: ignore[index]
+                    num_tokens_to_compute = (
+                        request_real.num_computed_tokens
+                        + scheduler_output.num_scheduled_tokens[req_id]
+                    )
+                    request_tracker = RequestTracker(
+                        req_id=req_id,
+                        token_len=num_tokens_to_compute,
+                        allocated_block_ids=new_block_ids,
+                        num_saved_tokens=0,
+                        token_ids=request_real.prompt_token_ids[
+                            :num_tokens_to_compute
+                        ].copy(),
+                    )
+                    self._request_trackers[req_id] = request_tracker
+
+                    last_chunk_tokens_num = (
+                        (
+                            len(request_real.prompt_token_ids)
+                            // self._block_size
+                            * self._block_size
+                        )
+                        if self._discard_partial_chunks
+                        else len(request_real.prompt_token_ids)
+                    )
+                    req_meta = ReqMeta.from_request_tracker(
+                        request_tracker,
+                        self._block_size,
+                        load_spec=load_spec,
+                        skip_save=force_skip_save,
+                        block_hashes=request_real.block_hashes,
+                        is_last_chunk=(
+                            request_tracker.token_len
+                            >= last_chunk_tokens_num
+                        ),
+                        discard_partial_chunks=self._discard_partial_chunks,
+                        original_block_size=self.original_block_size,
+                    )
+                else:
+                    # Decode/chunked request
+                    request_tracker = self._request_trackers[req_id]
+                    num_new_tokens = (
+                        scheduler_output.num_scheduled_tokens[req_id]
+                    )
+                    req_tuple = self._unfinished_requests.get(req_id)
+                    if req_tuple:
+                        request = req_tuple[0]
+                        num_current_tokens = request_tracker.token_len
+                        new_token_ids = request.all_token_ids[
+                            num_current_tokens : num_current_tokens
+                            + num_new_tokens
+                        ]
+                        request_tracker.token_len += len(new_token_ids)
+                    else:
+                        raise ValueError(
+                            f"Request {req_id} is not in "
+                            "_unfinished_requests"
+                        )
+                    num_computed_token = cached_reqs.num_computed_tokens[i]
+                    if num_computed_token >= len(request.prompt_token_ids):
+                        continue
+                    request_tracker.update(new_block_ids)
+
+                    last_chunk_tokens_num = (
+                        (
+                            len(request.prompt_token_ids)
+                            // self._block_size
+                            * self._block_size
+                        )
+                        if self._discard_partial_chunks
+                        else len(request.prompt_token_ids)
+                    )
+                    req_meta = ReqMeta.from_request_tracker(
+                        request_tracker,
+                        self._block_size,
+                        load_spec=None,
+                        skip_save=force_skip_save,
+                        block_hashes=request.block_hashes,
+                        is_last_chunk=(
+                            request_tracker.token_len
+                            >= last_chunk_tokens_num
+                        ),
+                        discard_partial_chunks=self._discard_partial_chunks,
+                        original_block_size=self.original_block_size,
+                    )
+
+                if req_meta is not None:
+                    meta.add_request(req_meta)
+
+        # Handle requests with pending load specs not yet scheduled
+        request_ids = [
+            req.req_id for req in scheduler_output.scheduled_new_reqs
+        ]
+        for request_id, (
+            request,
+            block_ids,
+        ) in self._unfinished_requests.items():
+            if (
+                request_id not in request_ids
+                and request_id not in cached_reqs.req_ids
+            ):
+                load_spec = self.load_specs.pop(request_id, None)
+                if not load_spec:
+                    continue
+                num_tokens_to_compute = load_spec.kvpool_cached_tokens
+                if (
+                    num_tokens_to_compute % self._block_size != 0
+                ) and (
+                    num_tokens_to_compute
+                    == len(request.prompt_token_ids) - 1
+                ):
+                    num_tokens_to_compute = num_tokens_to_compute + 1
+                request_tracker = RequestTracker(
+                    req_id=request_id,
+                    token_len=num_tokens_to_compute,
+                    allocated_block_ids=block_ids,
+                    num_saved_tokens=0,
+                )
+                self._request_trackers[request_id] = request_tracker
+                req_meta = ReqMeta.from_request_tracker(
+                    request_tracker,
+                    self._block_size,
+                    load_spec=load_spec,
+                    skip_save=None,
+                    block_hashes=request.block_hashes,
+                    discard_partial_chunks=self._discard_partial_chunks,
+                )
+                if req_meta is not None:
+                    meta.add_request(req_meta)
+
+        return meta
+
+    def request_finished(
+        self,
+        request: Request,
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Determine whether to delay freeing blocks for async save."""
+        if self.kv_role == "kv_consumer":
+            return False, None
+        tracker = self._request_trackers.get(request.request_id)
+        if tracker is not None and tracker.num_saved_tokens <= 0:
+            return False, None
+        delay_free_blocks = len(block_ids) > 0
+        if delay_free_blocks:
+            logger.debug(
+                "Delaying free of %d blocks for request %s",
+                len(block_ids),
+                request.request_id,
+            )
+        return delay_free_blocks, None
+
+
+class LookupKeyClient:
+    """ZMQ client for querying prefix cache hits from worker."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        self.encoder = MsgpackEncoder()
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        socket_path = get_zmq_rpc_path_lookup(vllm_config)
+        self.socket = make_zmq_socket(
+            self.ctx,
+            socket_path,
+            zmq.REQ,  # type: ignore[attr-defined]
+            bind=False,
+        )
+
+    def lookup(
+        self, token_len: int, block_hashes: list[BlockHash]
+    ) -> int:
+        hash_strs = [h.hex() for h in block_hashes]
+        hash_frames = self.encoder.encode(hash_strs)
+        token_len_bytes = token_len.to_bytes(4, byteorder="big")
+        all_frames = [token_len_bytes] + list(hash_frames)
+        self.socket.send_multipart(all_frames, copy=False)
+        resp = self.socket.recv()
+        result = int.from_bytes(resp, "big")
+        return result
+
+    def close(self):
+        self.socket.close(linger=0)
+
+
+def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
+    """Construct IPC path for ZMQ lookup socket."""
+    dp_rank = vllm_config.parallel_config.data_parallel_rank
+    base_url = envs.VLLM_RPC_BASE_PATH
+    rpc_port = 0
+    extra_config = (
+        vllm_config.kv_transfer_config.kv_connector_extra_config
+    )
+    if "lookup_rpc_port" in extra_config:
+        rpc_port = extra_config["lookup_rpc_port"]
+    logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)
+    return f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_dp_rank{dp_rank}"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -17,6 +17,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data i
     ReqMeta,
     RequestTracker,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
+    get_mooncake_dp_engine_index,
+)
 from vllm.logger import init_logger
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -114,10 +117,7 @@ class MooncakeStoreScheduler:
         if num_external_tokens > 0:
             local_block_ids = blocks.get_block_ids()[0]
 
-        self._unfinished_requests[request.request_id] = (
-            request,
-            local_block_ids,
-        )
+        self._unfinished_requests[request.request_id] = (request, local_block_ids)
         self._unfinished_request_ids.add(request.request_id)
 
         if request.request_id not in self.load_specs:
@@ -153,8 +153,8 @@ class MooncakeStoreScheduler:
             self._unfinished_request_ids.discard(finished_req_id)
             self._preempted_req_ids.discard(finished_req_id)
 
+        self._preempted_req_ids.update(scheduler_output.preempted_req_ids)
         for req_id in scheduler_output.preempted_req_ids:
-            self._preempted_req_ids.update(scheduler_output.preempted_req_ids)
             self._request_trackers.pop(req_id, None)
             self._unfinished_requests.pop(req_id, None)
 
@@ -393,7 +393,7 @@ class LookupKeyClient:
 
 def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
     """Construct IPC path for ZMQ lookup socket."""
-    dp_rank = vllm_config.parallel_config.data_parallel_rank
+    dp_rank = get_mooncake_dp_engine_index(vllm_config.parallel_config)
     base_url = envs.VLLM_RPC_BASE_PATH
     rpc_port = 0
     extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Scheduler-side logic for MooncakeStoreConnector."""
 
+import os
 from typing import Any
 
 import zmq
@@ -399,5 +400,6 @@ def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
     extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     if "lookup_rpc_port" in extra_config:
         rpc_port = extra_config["lookup_rpc_port"]
-    logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)
-    return f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_dp_rank{dp_rank}"
+    uid = os.getuid()
+    logger.debug("Base URL: %s, RPC Port: %s, UID: %s", base_url, rpc_port, uid)
+    return f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_uid{uid}_dp_rank{dp_rank}"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -78,7 +78,9 @@ class MooncakeStoreScheduler:
         if token_len < self._block_size:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(token_len, request.block_hashes)
+        num_external_hit_tokens = self.client.lookup(
+            token_len, request.block_hashes, num_computed_tokens
+        )
 
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
@@ -378,11 +380,21 @@ class LookupKeyClient:
             bind=False,
         )
 
-    def lookup(self, token_len: int, block_hashes: list[BlockHash]) -> int:
+    def lookup(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+        num_computed_tokens: int = 0,
+    ) -> int:
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(hash_frames)
+        num_computed_tokens_bytes = num_computed_tokens.to_bytes(
+            4, byteorder="big"
+        )
+        all_frames = [token_len_bytes, num_computed_tokens_bytes] + list(
+            hash_frames
+        )
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -1,0 +1,890 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side logic for MooncakeStoreConnector.
+
+Includes the store worker, transfer threads, lookup server,
+and MooncakeDistributedStore integration.
+"""
+
+import json
+import math
+import os
+import queue
+import re
+import threading
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import zmq
+
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_dcp_group,
+    get_pcp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    MooncakeStoreConnectorMetadata,
+    ReqMeta,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (
+    get_zmq_rpc_path_lookup,
+)
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_ip, make_zmq_socket
+from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+from vllm.v1.serial_utils import MsgpackDecoder
+
+logger = init_logger(__name__)
+
+DEFAULT_GLOBAL_SEGMENT_SIZE = 1073741824  # 1 GiB
+DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1 GiB
+
+
+@dataclass
+class MooncakeStoreConfig:
+    """Configuration for MooncakeDistributedStore."""
+
+    metadata_server: str
+    global_segment_size: int
+    local_buffer_size: int
+    protocol: str
+    device_name: str
+    master_server_address: str
+
+    @staticmethod
+    def from_file(file_path: str) -> "MooncakeStoreConfig":
+        with open(file_path) as file:
+            config = json.load(file)
+        return MooncakeStoreConfig(
+            metadata_server=config.get("metadata_server", ""),
+            global_segment_size=_parse_size(
+                config.get(
+                    "global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE
+                )
+            ),
+            local_buffer_size=_parse_size(
+                config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)
+            ),
+            protocol=config.get("protocol", "tcp"),
+            device_name=config.get("device_name", ""),
+            master_server_address=config.get("master_server_address", ""),
+        )
+
+    @staticmethod
+    def load_from_env() -> "MooncakeStoreConfig":
+        config_path = os.getenv("MOONCAKE_CONFIG_PATH")
+        if not config_path:
+            raise ValueError(
+                "The environment variable 'MOONCAKE_CONFIG_PATH' "
+                "is not set."
+            )
+        return MooncakeStoreConfig.from_file(config_path)
+
+
+def _parse_size(value: Any) -> int:
+    """Parse storage size strings with units: GB, MB, KB, B."""
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        try:
+            return int(value)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                f"Unsupported type for size: {type(value)}"
+            ) from e
+
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("Size cannot be empty.")
+
+    unit_multipliers = {
+        "gb": 1024**3,
+        "mb": 1024**2,
+        "kb": 1024,
+        "b": 1,
+    }
+    match = re.match(r"^\s*([\d.]+)\s*(gb|mb|kb|b)?\s*$", cleaned)
+    if not match:
+        raise ValueError(f"Invalid format: '{value}'")
+
+    number_str = match.group(1)
+    unit = match.group(2) or "b"
+    multiplier = unit_multipliers[unit]
+
+    try:
+        numeric_value = float(number_str)
+    except ValueError:
+        raise ValueError(
+            f"Invalid numeric value '{number_str}' in: '{value}'"
+        )
+    return int(numeric_value * multiplier)
+
+
+# ============================================================
+# Transfer Threads
+# ============================================================
+
+
+class KVTransferThread(threading.Thread):
+    """Base class for async KV cache transfer threads."""
+
+    def __init__(
+        self,
+        store: Any,
+        token_database: ChunkedTokenDatabase,
+        block_size: int,
+        tp_rank: int,
+        ready_event: threading.Event,
+        name: str,
+    ):
+        super().__init__(daemon=True, name=name)
+        self.store = store
+        self.ready_event = ready_event
+        self.block_size = block_size
+        self.tp_rank = tp_rank
+        self.token_database = token_database
+        self.done_task_lock = threading.Lock()
+        self.request_queue: queue.Queue[Any] = queue.Queue()
+        self.finished_requests: set[str] = set()
+        self.kv_event_lock = threading.Lock()
+        self.kv_events: list[BlockStored] = []
+
+    def add_request(self, request: ReqMeta) -> None:
+        self.request_queue.put(request)
+
+    def get_and_clear_finished_requests(self) -> set[str]:
+        with self.done_task_lock:
+            finished = self.finished_requests.copy()
+            self.finished_requests.clear()
+        return finished
+
+    def set_finished_request(self, req_id: str):
+        with self.done_task_lock:
+            self.finished_requests.add(req_id)
+
+    def run(self):
+        self.ready_event.set()
+        while True:
+            try:
+                request_data = self.request_queue.get()
+                if request_data is None:
+                    logger.warning("Received a None request!")
+                    self.request_queue.task_done()
+                    continue
+                self._handle_request(request_data)
+            except Exception as e:
+                logger.error("Error in %s: %s", self.name, e)
+
+    def _handle_request(self, req_meta: Any):
+        pass
+
+    def update_kv_event(self, events: list[BlockStored]):
+        with self.kv_event_lock:
+            self.kv_events.extend(events)
+
+    def get_kv_events(self) -> list[BlockStored]:
+        with self.kv_event_lock:
+            events = self.kv_events.copy()
+            self.kv_events.clear()
+        return events
+
+
+class KVCacheStoreSendingThread(KVTransferThread):
+    """Background thread for storing KV cache blocks to the store."""
+
+    def __init__(
+        self,
+        store: Any,
+        token_database: ChunkedTokenDatabase,
+        block_size: int,
+        tp_rank: int,
+        put_step: int,
+        kv_role: str,
+        ready_event: threading.Event,
+        enable_kv_event: bool = False,
+    ):
+        super().__init__(
+            store,
+            token_database,
+            block_size,
+            tp_rank,
+            ready_event,
+            name="KVCacheStoreSendingThread",
+        )
+        self.put_step = put_step
+        self.kv_role = kv_role
+        self.stored_requests: defaultdict[str, int] = defaultdict(int)
+        self.enable_kv_event = enable_kv_event
+
+    def add_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            self.stored_requests[req_id] += 1
+
+    def dec_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                self.stored_requests[req_id] -= 1
+
+    def delete_finished_stored_request(self, req_id: str):
+        with self.done_task_lock:
+            if req_id in self.stored_requests:
+                del self.stored_requests[req_id]
+
+    def _handle_request(self, req_meta: ReqMeta):
+        token_len = req_meta.token_len_chunk
+        block_ids = req_meta.block_ids
+        req_id = req_meta.req_id
+        current_event = req_meta.current_event
+
+        if req_id not in self.stored_requests:
+            self.request_queue.task_done()
+            return
+
+        starts = []
+        ends = []
+        keys = []
+        block_hashes: list[BlockHash] = []
+        for index, (start, end, key) in enumerate(
+            self.token_database.process_tokens(
+                token_len, req_meta.block_hashes
+            )
+        ):
+            starts.append(start)
+            ends.append(end)
+            keys.append(key.to_string())
+            block_hashes.append(req_meta.block_hashes[index])
+
+        # Apply put_step striding for TP
+        starts = starts[self.tp_rank % self.put_step :: self.put_step]
+        ends = ends[self.tp_rank % self.put_step :: self.put_step]
+        keys = keys[self.tp_rank % self.put_step :: self.put_step]
+        block_hashes = block_hashes[
+            self.tp_rank % self.put_step :: self.put_step
+        ]
+
+        if not keys:
+            self.dec_stored_request(req_id)
+            return
+
+        # Check which blocks already exist (dedup)
+        exists_states = self.store.batch_is_exist(keys)
+        missing_indices = [
+            i for i, exists in enumerate(exists_states) if exists != 1
+        ]
+
+        if not missing_indices:
+            self.dec_stored_request(req_id)
+            return
+
+        starts = [starts[i] for i in missing_indices]
+        ends = [ends[i] for i in missing_indices]
+        keys = [keys[i] for i in missing_indices]
+        block_hashes = [block_hashes[i] for i in missing_indices]
+
+        logger.debug(
+            "Storing KV cache for %d out of %d blocks "
+            "(missing_count=%d) for request %s",
+            len(keys),
+            token_len // self.block_size,
+            len(missing_indices),
+            req_id,
+        )
+
+        addrs = []
+        sizes = []
+        stored_events: list[BlockStored] = []
+        prev_key = None
+        new_block_hashes = [
+            maybe_convert_block_hash(bh) for bh in block_hashes
+        ]
+
+        for index, start in enumerate(starts):
+            addr, size, _ = self.token_database.prepare_value(
+                start, ends[index], block_ids
+            )
+            addrs.append(addr)
+            sizes.append(size)
+
+            if self.enable_kv_event:
+                token_ids = (
+                    req_meta.token_ids[start : ends[index]]
+                    if req_meta.token_ids is not None
+                    else None
+                )
+                stored_event = BlockStored(
+                    block_hashes=[new_block_hashes[index]],
+                    parent_block_hash=prev_key,
+                    token_ids=token_ids,
+                    block_size=req_meta.original_block_size,
+                    lora_id=None,
+                    medium="cpu",
+                    lora_name=None,
+                )
+                stored_events.append(stored_event)
+                prev_key = new_block_hashes[index]
+
+        if current_event is not None:
+            current_event.synchronize()
+
+        try:
+            res = self.store.batch_put_from_multi_buffers(
+                keys, addrs, sizes
+            )
+            for value in res:
+                if value < 0:
+                    logger.error(
+                        "Failed to put key %s, res: %s", keys, res
+                    )
+        except Exception as e:
+            logger.error("Failed to put key %s, error: %s", keys, e)
+
+        if self.enable_kv_event and stored_events:
+            self.update_kv_event(stored_events)
+
+        self.dec_stored_request(req_id)
+        self.request_queue.task_done()
+
+
+class KVCacheStoreRecvingThread(KVTransferThread):
+    """Background thread for loading KV cache blocks from the store."""
+
+    def __init__(
+        self,
+        store: Any,
+        token_database: ChunkedTokenDatabase,
+        block_size: int,
+        tp_rank: int,
+        ready_event: threading.Event,
+    ):
+        super().__init__(
+            store,
+            token_database,
+            block_size,
+            tp_rank,
+            ready_event,
+            name="KVCacheStoreRecvingThread",
+        )
+
+    def _handle_request(self, req_meta: ReqMeta):
+        token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
+        req_id = req_meta.req_id
+        mask_num = (
+            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
+            // self.block_size
+            * self.block_size
+        )
+
+        addr_list = []
+        size_list = []
+        key_list = []
+        for start, end, key in self.token_database.process_tokens(
+            token_len, req_meta.block_hashes, mask_num
+        ):
+            addr, size, _ = self.token_database.prepare_value(
+                start, end, req_meta.block_ids
+            )
+            key_list.append(key.to_string())
+            addr_list.append(addr)
+            size_list.append(size)
+
+        # Rotate lists by tp_rank for load balancing
+        key_list_c = (
+            key_list[self.tp_rank % len(key_list) :]
+            + key_list[: self.tp_rank % len(key_list)]
+        )
+        addr_list_c = (
+            addr_list[self.tp_rank % len(addr_list) :]
+            + addr_list[: self.tp_rank % len(addr_list)]
+        )
+        size_list_c = (
+            size_list[self.tp_rank % len(size_list) :]
+            + size_list[: self.tp_rank % len(size_list)]
+        )
+
+        try:
+            res = self.store.batch_get_into_multi_buffers(
+                key_list_c, addr_list_c, size_list_c
+            )
+            for value in res:
+                if value < 0:
+                    logger.error(
+                        "Failed to get key %s, res: %s",
+                        key_list_c,
+                        res,
+                    )
+        except Exception as e:
+            logger.error(
+                "Failed to get key %s, error: %s", key_list_c, e
+            )
+
+        self.set_finished_request(req_id)
+        self.request_queue.task_done()
+
+
+# ============================================================
+# Store Worker
+# ============================================================
+
+
+class MooncakeStoreWorker:
+    """Worker-side component for MooncakeStoreConnector."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        try:
+            from mooncake.store import MooncakeDistributedStore  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+                "Please install mooncake by following the instructions at "
+                "https://github.com/kvcache-ai/Mooncake/blob/main/doc/"
+                "en/build.md to run vLLM with MooncakeStoreConnector."
+            ) from e
+
+        model_config = vllm_config.model_config
+        parallel_config = vllm_config.parallel_config
+
+        self.dp_rank = parallel_config.data_parallel_rank
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.pp_size = parallel_config.pipeline_parallel_size
+        self.pp_rank = (
+            (parallel_config.rank // self.tp_size) % self.pp_size
+        )
+
+        self.pcp_size = get_pcp_group().world_size
+        self.pcp_rank = (
+            get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
+        )
+        self.dcp_size = get_dcp_group().world_size
+        self.dcp_rank = (
+            get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
+        )
+
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self.load_async = (
+            vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+                "load_async", False
+            )
+        )
+        self.original_block_size = vllm_config.cache_config.block_size
+        self.block_size = vllm_config.cache_config.block_size
+        if self.pcp_size > 1:
+            self.block_size *= self.pcp_size
+        if self.dcp_size > 1:
+            self.block_size *= self.dcp_size
+        self.num_layers = model_config.get_num_layers(parallel_config)
+
+        self.use_mla = False
+        if (
+            hasattr(model_config, "use_mla")
+            and isinstance(model_config.use_mla, bool)
+            and model_config.use_mla
+        ):
+            self.use_mla = True
+
+        if self.use_mla:
+            self.num_kv_head = 1
+        else:
+            self.num_kv_head = model_config.get_total_num_kv_heads()
+
+        if self.num_kv_head < self.tp_size:
+            self.put_step = self.tp_size // self.num_kv_head
+            self.head_or_tp_rank = self.tp_rank // self.put_step
+        else:
+            self.head_or_tp_rank = self.tp_rank
+            self.put_step = 1
+
+        self.metadata = KeyMetadata(
+            model_name=model_config.model.rstrip("/").split("/")[-1],
+            tp_rank=self.head_or_tp_rank,
+            pcp_rank=self.pcp_rank,
+            dcp_rank=self.dcp_rank,
+            pp_rank=self.pp_rank,
+        )
+
+        self.token_database = ChunkedTokenDatabase(
+            self.metadata, self.block_size
+        )
+
+        # Initialize MooncakeDistributedStore with its own TransferEngine
+        store_config = MooncakeStoreConfig.load_from_env()
+        self.store = MooncakeDistributedStore()
+
+        local_seg = get_ip()
+        ret = self.store.setup(
+            local_seg,
+            store_config.metadata_server,
+            store_config.global_segment_size,
+            store_config.local_buffer_size,
+            store_config.protocol,
+            store_config.device_name,
+            store_config.master_server_address,
+        )
+        if ret != 0:
+            msg = "Initialize MooncakeDistributedStore failed."
+            logger.error(msg)
+            raise RuntimeError(msg)
+
+        kv_event_config = vllm_config.kv_events_config
+        self.enable_kv_events = False
+        if kv_event_config and kv_event_config.enable_kv_cache_events:
+            self.enable_kv_events = True
+
+        self.kv_send_thread: KVCacheStoreSendingThread | None = None
+        self.kv_recv_thread: KVCacheStoreRecvingThread | None = None
+        self.finished_store_req: set[str] = set()
+
+    def register_kv_caches(
+        self, kv_caches: dict[str, torch.Tensor]
+    ):
+        """Register KV cache tensors and start transfer threads."""
+        _, first_kv_cache_tuple = next(iter(kv_caches.items()))
+        first_kv_cache = first_kv_cache_tuple[0]
+
+        self.num_blocks = first_kv_cache.shape[0]
+        logger.info("num_blocks: %s", self.num_blocks)
+
+        block_rank = 3
+        self.block_len: list[int] = []
+        if self.use_mla:
+            for i in range(len(first_kv_cache_tuple)):
+                block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
+                self.block_len.append(
+                    first_kv_cache_tuple[i].element_size()
+                    * math.prod(block_shape)
+                )
+        else:
+            block_shape = first_kv_cache.shape[-block_rank:]
+            self.block_len = [
+                first_kv_cache.element_size() * math.prod(block_shape)
+            ]
+
+        logger.info(
+            "Registering KV_Caches. use_mla: %s, shape %s",
+            self.use_mla,
+            first_kv_cache.shape,
+        )
+
+        self.kv_caches_base_addr: list[int] = []
+        ptrs: list[int] = []
+        lengths: list[int] = []
+        length = len(self.block_len)
+        for cache_or_caches in kv_caches.values():
+            for i, cache in enumerate(cache_or_caches, 0):
+                base_addr = cache.data_ptr()
+                region_len = self.num_blocks * self.block_len[i % length]
+                self.kv_caches_base_addr.append(base_addr)
+                ptrs.append(base_addr)
+                lengths.append(region_len)
+
+        # Register buffers
+        self.store.register_buffer(ptrs, lengths)
+
+        self.token_database.set_kv_caches_base_addr(
+            self.kv_caches_base_addr
+        )
+        self.token_database.set_block_len(self.block_len)
+
+        # Start transfer threads
+        if self.kv_role in ["kv_producer", "kv_both"]:
+            ready_event_sending = threading.Event()
+            self.kv_send_thread = KVCacheStoreSendingThread(
+                self.store,
+                self.token_database,
+                self.block_size,
+                self.tp_rank,
+                self.put_step,
+                self.kv_role,
+                ready_event_sending,
+                self.enable_kv_events,
+            )
+            self.kv_send_thread.start()
+
+        if self.load_async:
+            ready_event = threading.Event()
+            self.kv_recv_thread = KVCacheStoreRecvingThread(
+                self.store,
+                self.token_database,
+                self.block_size,
+                self.tp_rank,
+                ready_event,
+            )
+            self.kv_recv_thread.start()
+            ready_event.wait()
+
+    def start_load_kv(
+        self, metadata: MooncakeStoreConnectorMetadata,
+    ):
+        """Start loading KV cache from the store."""
+        for request in metadata.requests:
+            load_spec = request.load_spec
+            if load_spec is None or not load_spec.can_load:
+                continue
+
+            token_len = request.token_len_chunk
+            if (
+                load_spec.kvpool_cached_tokens % self.block_size != 0
+            ) and (
+                load_spec.kvpool_cached_tokens == token_len - 1
+            ):
+                token_len = load_spec.kvpool_cached_tokens + 1
+            else:
+                token_len = load_spec.kvpool_cached_tokens
+            request.load_spec.token_len = token_len
+
+            if self.load_async:
+                assert self.kv_recv_thread is not None
+                self.kv_recv_thread.add_request(request)
+            else:
+                # Synchronous load
+                addr_list = []
+                size_list = []
+                key_list = []
+                mask_num = (
+                    load_spec.vllm_cached_tokens
+                    // self.block_size
+                    * self.block_size
+                )
+                for start, end, key in (
+                    self.token_database.process_tokens(
+                        token_len, request.block_hashes, mask_num
+                    )
+                ):
+                    addr, size, _ = self.token_database.prepare_value(
+                        start, end, request.block_ids
+                    )
+                    key_list.append(key.to_string())
+                    addr_list.append(addr)
+                    size_list.append(size)
+
+                # Rotate by tp_rank for load balancing
+                key_list_c = (
+                    key_list[self.tp_rank % len(key_list) :]
+                    + key_list[: self.tp_rank % len(key_list)]
+                )
+                addr_list_c = (
+                    addr_list[self.tp_rank % len(addr_list) :]
+                    + addr_list[: self.tp_rank % len(addr_list)]
+                )
+                size_list_c = (
+                    size_list[self.tp_rank % len(size_list) :]
+                    + size_list[: self.tp_rank % len(size_list)]
+                )
+                try:
+                    self.store.batch_get_into_multi_buffers(
+                        key_list_c, addr_list_c, size_list_c
+                    )
+                except Exception as e:
+                    logger.error("Failed to get: %s", e)
+
+    def wait_for_save(
+        self, metadata: MooncakeStoreConnectorMetadata,
+    ):
+        """Record CUDA event and queue save requests."""
+        current_event = None
+        for request in metadata.requests:
+            if request.can_save:
+                current_event = torch.cuda.Event()
+                current_event.record()
+                break
+
+        for request in metadata.requests:
+            if not request.can_save:
+                continue
+
+            request.current_event = current_event
+            assert self.kv_send_thread is not None
+            self.kv_send_thread.add_stored_request(request.req_id)
+            self.kv_send_thread.add_request(request)
+
+    def get_finished(
+        self,
+        finished_req_ids: set[str],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> tuple[set[str], set[str]]:
+        """Get completed send/recv request IDs."""
+        done_sending = (
+            self._get_and_clear_finished_sending(
+                finished_req_ids, meta
+            )
+            if self.kv_role in ["kv_producer", "kv_both"]
+            else set()
+        )
+
+        done_recving = (
+            self.kv_recv_thread.get_and_clear_finished_requests()
+            if self.load_async and self.kv_recv_thread is not None
+            else set()
+        )
+
+        logger.debug(
+            "Completed send: %d, recv: %d, tp_rank: %d",
+            len(done_sending),
+            len(done_recving),
+            self.tp_rank,
+        )
+        return done_sending, done_recving
+
+    def _get_and_clear_finished_sending(
+        self,
+        finished_req_ids: set[str],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> set[str]:
+        assert self.kv_send_thread is not None
+        finished_sending: set[str] = set()
+
+        for req_id in meta.preempted_req_ids:
+            self.kv_send_thread.delete_finished_stored_request(req_id)
+
+        for req_id in self.kv_send_thread.stored_requests.copy():
+            if (
+                self.kv_send_thread.stored_requests[req_id] == 0
+                and req_id in self.finished_store_req
+            ):
+                self.finished_store_req.remove(req_id)
+                finished_sending.add(req_id)
+                self.kv_send_thread.delete_finished_stored_request(
+                    req_id
+                )
+
+        for req_id in finished_req_ids:
+            req_remain_jobs = (
+                self.kv_send_thread.stored_requests.get(req_id)
+            )
+            if req_remain_jobs == 0:
+                finished_sending.add(req_id)
+                self.kv_send_thread.delete_finished_stored_request(
+                    req_id
+                )
+            elif req_remain_jobs is not None:
+                self.finished_store_req.add(req_id)
+
+        return finished_sending
+
+    def lookup(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash],
+    ) -> int:
+        """Check how many prefix tokens exist in the store.
+
+        Checks across all TP ranks and PP ranks.
+        """
+        end = 0
+        keys: list[str] = []
+        try:
+            starts: list[int] = []
+            for start, end, key in self.token_database.process_tokens(
+                token_len, block_hashes
+            ):
+                keys.append(key.to_string())
+                starts.append(start)
+
+            # Expand keys for all TP ranks
+            multi_tp_keys = keys[:]
+            for i in range(1, min(self.tp_size, self.num_kv_head)):
+                for item in keys:
+                    new_str = item.replace(
+                        "@tp_rank:0", f"@tp_rank:{i}", 1
+                    )
+                    multi_tp_keys.append(new_str)
+
+            # Expand keys for all PP ranks
+            pp_base_keys = multi_tp_keys.copy()
+            for i in range(1, self.pp_size):
+                for item in pp_base_keys:
+                    new_str = item.replace(
+                        "@pp_rank:0", f"@pp_rank:{i}", 1
+                    )
+                    multi_tp_keys.append(new_str)
+
+            res = self.store.batch_is_exist(multi_tp_keys)
+
+            num_block = len(keys)
+            multi_tp_values = [
+                res[i * num_block : (i + 1) * num_block]
+                for i in range(
+                    min(self.tp_size, self.num_kv_head) * self.pp_size
+                )
+            ]
+            index = self._find_min_first_non_one_index(multi_tp_values)
+            if index != -1:
+                return starts[index]
+        except Exception as e:
+            logger.error("Remote connection failed in lookup: %s", e)
+            return 0
+        return end
+
+    @staticmethod
+    def _find_min_first_non_one_index(
+        arr: list[list[int]],
+    ) -> int:
+        try:
+            return min(
+                idx
+                for row in arr
+                for idx, val in enumerate(row)
+                if val != 1
+            )
+        except ValueError:
+            return -1
+
+    def get_kv_events(self) -> list[BlockStored]:
+        if self.enable_kv_events and self.kv_send_thread is not None:
+            return self.kv_send_thread.get_kv_events()
+        return []
+
+
+# ============================================================
+# Lookup Key Server
+# ============================================================
+
+
+class LookupKeyServer:
+    """ZMQ server on worker rank 0 for handling prefix lookup queries."""
+
+    def __init__(
+        self,
+        store_worker: MooncakeStoreWorker,
+        vllm_config: VllmConfig,
+    ):
+        self.decoder = MsgpackDecoder()
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+        socket_path = get_zmq_rpc_path_lookup(vllm_config)
+        self.socket = make_zmq_socket(
+            self.ctx,
+            socket_path,
+            zmq.REP,  # type: ignore[attr-defined]
+            bind=True,
+        )
+
+        self.store_worker = store_worker
+        self.running = True
+
+        def process_request():
+            while self.running:
+                all_frames = self.socket.recv_multipart(copy=False)
+                token_len = int.from_bytes(
+                    all_frames[0], byteorder="big"
+                )
+                hash_frames = all_frames[1:]
+                hashes_str = self.decoder.decode(hash_frames)
+                result = self.store_worker.lookup(
+                    token_len, hashes_str
+                )
+                response = result.to_bytes(4, "big")
+                self.socket.send(response)
+
+        self.thread = threading.Thread(
+            target=process_request, daemon=True
+        )
+        self.thread.start()
+
+    def close(self):
+        self.socket.close(linger=0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -44,6 +44,10 @@ logger = init_logger(__name__)
 DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
+DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE = 1280 * 1024 * 1024
+DISK_OFFLOAD_USABLE_BUDGET_RATIO = 0.9
+_DIRECT_IO_ALIGNMENT = 4096
+_DIRECT_IO_PADDING_BYTES = 2 * _DIRECT_IO_ALIGNMENT
 
 
 @dataclass
@@ -89,6 +93,15 @@ class MooncakeStoreConfig:
         return MooncakeStoreConfig.from_file(config_path)
 
 
+def _get_disk_offload_buffer_budget_bytes(enable_offload: bool) -> int | None:
+    if not enable_offload:
+        return None
+    value = os.getenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES")
+    if value is None:
+        return DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE
+    return _parse_size(value)
+
+
 def _parse_size(value: Any) -> int:
     """Parse storage size strings with units: GB, MB, KB, B."""
     if isinstance(value, int):
@@ -122,6 +135,65 @@ def _parse_size(value: Any) -> int:
     except ValueError as exc:
         raise ValueError(f"Invalid numeric value '{number_str}' in: '{value}'") from exc
     return int(numeric_value * multiplier)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def _estimate_disk_offload_staging_bytes(size_list: list[int]) -> int:
+    data_size = sum(size_list)
+    return _align_up(data_size, _DIRECT_IO_ALIGNMENT) + _DIRECT_IO_PADDING_BYTES
+
+
+def _get_usable_disk_offload_buffer_budget_bytes(raw_budget_bytes: int) -> int:
+    return max(1, int(raw_budget_bytes * DISK_OFFLOAD_USABLE_BUDGET_RATIO))
+
+
+def _get_usable_disk_offload_batch_key_count(num_keys: int) -> int:
+    return max(1, int(num_keys * DISK_OFFLOAD_USABLE_BUDGET_RATIO))
+
+
+def _split_disk_offload_load_batches(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+    usable_budget_bytes: int,
+    raw_budget_bytes: int,
+) -> tuple[list[tuple[list[str], list[list[int]], list[list[int]]]], str | None]:
+    max_batch_keys = _get_usable_disk_offload_batch_key_count(len(keys))
+    batches: list[tuple[list[str], list[list[int]], list[list[int]]]] = []
+    batch_keys: list[str] = []
+    batch_addrs: list[list[int]] = []
+    batch_sizes: list[list[int]] = []
+    batch_bytes = 0
+
+    for key, addr, size in zip(keys, addrs, sizes, strict=True):
+        key_bytes = _estimate_disk_offload_staging_bytes(size)
+        if key_bytes > raw_budget_bytes:
+            return [], key
+        if key_bytes > usable_budget_bytes:
+            if batch_keys:
+                batches.append((batch_keys, batch_addrs, batch_sizes))
+                batch_keys, batch_addrs, batch_sizes = [], [], []
+                batch_bytes = 0
+            batches.append(([key], [addr], [size]))
+            continue
+        if batch_keys and (
+            batch_bytes + key_bytes > usable_budget_bytes
+            or len(batch_keys) >= max_batch_keys
+        ):
+            batches.append((batch_keys, batch_addrs, batch_sizes))
+            batch_keys, batch_addrs, batch_sizes = [], [], []
+            batch_bytes = 0
+        batch_keys.append(key)
+        batch_addrs.append(addr)
+        batch_sizes.append(size)
+        batch_bytes += key_bytes
+
+    if batch_keys:
+        batches.append((batch_keys, batch_addrs, batch_sizes))
+    return batches, None
 
 
 # ============================================================
@@ -409,6 +481,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         block_size: int,
         tp_rank: int,
         ready_event: threading.Event,
+        disk_offload_buffer_budget_bytes: int | None = None,
     ):
         super().__init__(
             store,
@@ -417,6 +490,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             tp_rank,
             ready_event,
             name="KVCacheStoreRecvingThread",
+        )
+        self.disk_offload_buffer_budget_bytes = disk_offload_buffer_budget_bytes
+        self.usable_disk_offload_buffer_budget_bytes = (
+            None
+            if disk_offload_buffer_budget_bytes is None
+            else _get_usable_disk_offload_buffer_budget_bytes(
+                disk_offload_buffer_budget_bytes
+            )
         )
 
     def _handle_request(self, req_meta: ReqMeta):
@@ -455,23 +536,70 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             + size_list[: self.tp_rank % len(size_list)]
         )
 
-        try:
-            res = self.store.batch_get_into_multi_buffers(
-                key_list_c, addr_list_c, size_list_c
+        load_batches = [(key_list_c, addr_list_c, size_list_c)]
+        if self.usable_disk_offload_buffer_budget_bytes is not None:
+            total_staging_bytes = sum(
+                _estimate_disk_offload_staging_bytes(size) for size in size_list_c
             )
-            failed = [
-                (key, value)
-                for key, value in zip(key_list_c, res, strict=False)
-                if value < 0
-            ]
-            if failed:
-                logger.error(
-                    "Failed to get %d Mooncake keys, first failures: %s",
-                    len(failed),
-                    failed[:3],
+            usable_batch_keys = _get_usable_disk_offload_batch_key_count(
+                len(key_list_c)
+            )
+            if (
+                total_staging_bytes > self.usable_disk_offload_buffer_budget_bytes
+                or len(key_list_c) > usable_batch_keys
+            ):
+                assert self.disk_offload_buffer_budget_bytes is not None
+                load_batches, oversized_key = _split_disk_offload_load_batches(
+                    key_list_c,
+                    addr_list_c,
+                    size_list_c,
+                    self.usable_disk_offload_buffer_budget_bytes,
+                    self.disk_offload_buffer_budget_bytes,
                 )
+                if oversized_key is not None:
+                    oversized_key_index = key_list_c.index(oversized_key)
+                    oversized_key_bytes = _estimate_disk_offload_staging_bytes(
+                        size_list_c[oversized_key_index]
+                    )
+                    logger.warning(
+                        "Skipping Mooncake load for request %s because key %s "
+                        "requires %d staging bytes, exceeding budget %d",
+                        req_id,
+                        oversized_key,
+                        oversized_key_bytes,
+                        self.disk_offload_buffer_budget_bytes,
+                    )
+                    self.set_finished_request(req_id)
+                    self.request_queue.task_done()
+                    return
+
+        current_batch_keys: list[str] = key_list_c
+        try:
+            for batch_keys, batch_addrs, batch_sizes in load_batches:
+                current_batch_keys = batch_keys
+                res = self.store.batch_get_into_multi_buffers(
+                    batch_keys, batch_addrs, batch_sizes
+                )
+                failed = [
+                    (key, value)
+                    for key, value in zip(batch_keys, res, strict=True)
+                    if value < 0
+                ]
+                if failed:
+                    logger.warning(
+                        "Failed to get %d Mooncake keys from sub-batch "
+                        "(batch_keys=%d, first_failures=%s)",
+                        len(failed),
+                        len(batch_keys),
+                        failed[:3],
+                    )
+                    break
         except Exception as e:
-            logger.error("Failed to get key %s, error: %s", key_list_c[:3], e)
+            logger.warning(
+                "Failed to get Mooncake sub-batch %s, error: %s",
+                current_batch_keys[:3],
+                e,
+            )
 
         self.set_finished_request(req_id)
         self.request_queue.task_done()
@@ -572,6 +700,10 @@ class MooncakeStoreWorker:
             msg = "Initialize MooncakeDistributedStore failed."
             logger.error(msg)
             raise RuntimeError(msg)
+
+        self.disk_offload_buffer_budget_bytes = _get_disk_offload_buffer_budget_bytes(
+            store_config.enable_offload
+        )
 
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False
@@ -685,6 +817,7 @@ class MooncakeStoreWorker:
             self.block_size,
             self.tp_rank,
             ready_event_recving,
+            disk_offload_buffer_budget_bytes=self.disk_offload_buffer_budget_bytes,
         )
         self.kv_recv_thread.start()
         ready_event_recving.wait()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -1026,6 +1026,9 @@ class LookupKeyServer:
         self.decoder = MsgpackDecoder()
         self.ctx = zmq.Context()  # type: ignore[attr-defined]
         socket_path = get_zmq_rpc_path_lookup(vllm_config)
+        self._ipc_path = socket_path.removeprefix("ipc://")
+        if os.path.exists(self._ipc_path):
+            os.unlink(self._ipc_path)
         self.socket = make_zmq_socket(
             self.ctx,
             socket_path,
@@ -1051,3 +1054,5 @@ class LookupKeyServer:
 
     def close(self):
         self.socket.close(linger=0)
+        if os.path.exists(self._ipc_path):
+            os.unlink(self._ipc_path)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -26,18 +26,22 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.kv_events import BlockStored
-from vllm.logger import init_logger
-from vllm.utils.network_utils import get_ip, make_zmq_socket
-from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
-from vllm.v1.serial_utils import MsgpackDecoder
-
-from .mooncake_store_data import (
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     MooncakeStoreConnectorMetadata,
     ReqMeta,
 )
-from .mooncake_store_scheduler import get_zmq_rpc_path_lookup
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (  # noqa: E501
+    get_zmq_rpc_path_lookup,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
+    get_mooncake_dp_engine_index,
+)
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_ip, make_zmq_socket
+from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+from vllm.v1.serial_utils import MsgpackDecoder
 
 logger = init_logger(__name__)
 
@@ -626,7 +630,7 @@ class MooncakeStoreWorker:
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
 
-        self.dp_rank = parallel_config.data_parallel_rank
+        self.dp_rank = get_mooncake_dp_engine_index(parallel_config)
         self.tp_rank = get_tensor_model_parallel_rank()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.pp_size = parallel_config.pipeline_parallel_size
@@ -725,7 +729,7 @@ class MooncakeStoreWorker:
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register KV cache tensors and start transfer threads."""
-        # TODO(yifan): we haven't supported hybrid HMA yet.
+        # TODO(yifan): we haven't supported HMA yet.
         first_kv_cache = next(iter(kv_caches.values()))
 
         # num_blocks from cache_config is authoritative (set after

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -41,8 +41,9 @@ from .mooncake_store_scheduler import get_zmq_rpc_path_lookup
 
 logger = init_logger(__name__)
 
-DEFAULT_GLOBAL_SEGMENT_SIZE = 1073741824  # 1 GiB
-DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1 GiB
+DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
+DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
+MOONCAKE_NO_AVAILABLE_HANDLE = -200
 
 
 @dataclass
@@ -219,6 +220,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.enable_kv_event = enable_kv_event
 
+        # Pause store requests when CPU/disk offloading is under pressure.
+        self._store_pressure_active = False
+        self._skip_store_requests: set[str] = set()
+
     def add_stored_request(self, req_id: str):
         with self.done_task_lock:
             self.stored_requests[req_id] += 1
@@ -232,6 +237,26 @@ class KVCacheStoreSendingThread(KVTransferThread):
         with self.done_task_lock:
             if req_id in self.stored_requests:
                 del self.stored_requests[req_id]
+            self._skip_store_requests.discard(req_id)
+
+    def _should_skip_request(self, req_id: str) -> bool:
+        with self.done_task_lock:
+            return self._store_pressure_active and req_id in self._skip_store_requests
+
+    def _mark_request_skipped_for_pressure(self, req_id: str) -> bool:
+        with self.done_task_lock:
+            already_skipped = req_id in self._skip_store_requests
+            self._store_pressure_active = True
+            self._skip_store_requests.add(req_id)
+        return already_skipped
+
+    def _clear_store_pressure(self) -> bool:
+        with self.done_task_lock:
+            if not self._store_pressure_active and not self._skip_store_requests:
+                return False
+            self._store_pressure_active = False
+            self._skip_store_requests.clear()
+        return True
 
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.token_len_chunk
@@ -240,6 +265,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
         current_event = req_meta.current_event
 
         if req_id not in self.stored_requests:
+            self.request_queue.task_done()
+            return
+        if self._should_skip_request(req_id):
+            logger.debug(
+                "Skipping Mooncake store for request %s while CPU/disk offloading "
+                "is under pressure",
+                req_id,
+            )
+            self.dec_stored_request(req_id)
             self.request_queue.task_done()
             return
 
@@ -328,7 +362,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 # Compute total bytes attempted for this batch
                 total_bytes = sum(sum(s) if isinstance(s, list) else s for s in sizes)
                 failed_codes = set(res[i] for i in failed)
-                logger.error(
+                logger.warning(
                     "batch_put failed: %d/%d keys failed "
                     "(codes=%s, batch_bytes=%d, num_keys=%d), "
                     "first_key=%s",
@@ -338,6 +372,22 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     total_bytes,
                     len(keys),
                     keys[0] if keys else "N/A",
+                )
+                if (
+                    MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                    and not self._mark_request_skipped_for_pressure(req_id)
+                ):
+                    logger.warning(
+                        "Detected Mooncake CPU/disk offloading pressure "
+                        "(NO_AVAILABLE_HANDLE); skipping future store "
+                        "batches for request %s until a later store "
+                        "batch succeeds",
+                        req_id,
+                    )
+            elif self._clear_store_pressure():
+                logger.info(
+                    "Mooncake CPU/offload pressure cleared after a "
+                    "successful store batch"
                 )
         except Exception as e:
             logger.error("Failed to put key %s, error: %s", keys, e)
@@ -599,11 +649,15 @@ class MooncakeStoreWorker:
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, shape %s, "
-            "num_blocks: %d, block_len: %s",
+            "num_blocks: %d, block_len: %s, "
+            "per_key_bytes: %d, "
+            "num_segments: %d",
             self.use_mla,
             first_kv_cache.shape,
             self.num_blocks,
             list(set(self.block_len)),
+            sum(self.block_len),
+            len(self.kv_caches_base_addr),
         )
 
         self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -714,6 +714,15 @@ class MooncakeStoreWorker:
         self.kv_recv_thread: KVCacheStoreRecvingThread | None = None
         self.finished_store_req: set[str] = set()
 
+    def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
+        """Register a cross-layers KV cache tensor.
+
+        Wraps the unified tensor in a single-entry dict so that the
+        existing stride-based logic in register_kv_caches() produces
+        the correct single-segment result (block_len = page_size * num_layers).
+        """
+        self.register_kv_caches({"__cross_layer__": kv_cache})
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register KV cache tensors and start transfer threads."""
         # TODO(yifan): we haven't supported hybrid HMA yet.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -323,9 +323,22 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         try:
             res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
-            for value in res:
-                if value < 0:
-                    logger.error("Failed to put key %s, res: %s", keys, res)
+            failed = [i for i, v in enumerate(res) if v < 0]
+            if failed:
+                # Compute total bytes attempted for this batch
+                total_bytes = sum(sum(s) if isinstance(s, list) else s for s in sizes)
+                failed_codes = set(res[i] for i in failed)
+                logger.error(
+                    "batch_put failed: %d/%d keys failed "
+                    "(codes=%s, batch_bytes=%d, num_keys=%d), "
+                    "first_key=%s",
+                    len(failed),
+                    len(keys),
+                    failed_codes,
+                    total_bytes,
+                    len(keys),
+                    keys[0] if keys else "N/A",
+                )
         except Exception as e:
             logger.error("Failed to put key %s, error: %s", keys, e)
 
@@ -396,15 +409,19 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             res = self.store.batch_get_into_multi_buffers(
                 key_list_c, addr_list_c, size_list_c
             )
-            for value in res:
-                if value < 0:
-                    logger.error(
-                        "Failed to get key %s, res: %s",
-                        key_list_c,
-                        res,
-                    )
+            failed = [
+                (key, value)
+                for key, value in zip(key_list_c, res, strict=False)
+                if value < 0
+            ]
+            if failed:
+                logger.error(
+                    "Failed to get %d Mooncake keys, first failures: %s",
+                    len(failed),
+                    failed[:3],
+                )
         except Exception as e:
-            logger.error("Failed to get key %s, error: %s", key_list_c, e)
+            logger.error("Failed to get key %s, error: %s", key_list_c[:3], e)
 
         self.set_finished_request(req_id)
         self.request_queue.task_done()
@@ -443,9 +460,8 @@ class MooncakeStoreWorker:
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
 
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-            "load_async", False
-        )
+        # NOTE(yifan): enforce load_async for now for better compute-I/O overlap.
+        self.load_async = True
         self.cache_config = vllm_config.cache_config
         self.original_block_size = self.cache_config.block_size
         self.block_size = self.cache_config.block_size
@@ -608,24 +624,44 @@ class MooncakeStoreWorker:
             )
             self.kv_send_thread.start()
 
-        if self.load_async:
-            ready_event = threading.Event()
-            self.kv_recv_thread = KVCacheStoreRecvingThread(
-                self.store,
-                self.token_database,
-                self.block_size,
-                self.tp_rank,
-                ready_event,
-            )
-            self.kv_recv_thread.start()
-            ready_event.wait()
+        ready_event_recving = threading.Event()
+        self.kv_recv_thread = KVCacheStoreRecvingThread(
+            self.store,
+            self.token_database,
+            self.block_size,
+            self.tp_rank,
+            ready_event_recving,
+        )
+        self.kv_recv_thread.start()
+        ready_event_recving.wait()
 
     def start_load_kv(
         self,
         metadata: MooncakeStoreConnectorMetadata,
     ):
-        """Start loading KV cache from the store."""
-        for request in metadata.requests:
+        """No-op: loads are issued in get_finished() for overlap."""
+        pass
+
+    def wait_for_save(
+        self,
+        metadata: MooncakeStoreConnectorMetadata,
+    ):
+        """No-op: stores are issued in get_finished() for overlap."""
+        pass
+
+    def get_finished(
+        self,
+        finished_req_ids: set[str],
+        meta: MooncakeStoreConnectorMetadata,
+    ) -> tuple[set[str], set[str]]:
+        """Issue all I/O and get completed send/recv request IDs.
+
+        All load and store I/O requests are issued here (after model
+        compute is launched on the compute stream) for better
+        compute-I/O overlap.
+        """
+        # Issue async loads
+        for request in meta.requests:
             load_spec = request.load_spec
             if load_spec is None or not load_spec.can_load:
                 continue
@@ -639,74 +675,28 @@ class MooncakeStoreWorker:
                 token_len = load_spec.kvpool_cached_tokens
             load_spec.token_len = token_len
 
-            if self.load_async:
-                assert self.kv_recv_thread is not None
-                self.kv_recv_thread.add_request(request)
-            else:
-                # Synchronous load
-                addr_list = []
-                size_list = []
-                key_list = []
-                mask_num = (
-                    load_spec.vllm_cached_tokens // self.block_size * self.block_size
-                )
-                for start, end, key in self.token_database.process_tokens(
-                    token_len, request.block_hashes, mask_num
-                ):
-                    addr, size, _ = self.token_database.prepare_value(
-                        start, end, request.block_ids
-                    )
-                    key_list.append(key.to_string())
-                    addr_list.append(addr)
-                    size_list.append(size)
+            assert self.kv_recv_thread is not None
+            self.kv_recv_thread.add_request(request)
 
-                # Rotate by tp_rank for load balancing
-                key_list_c = (
-                    key_list[self.tp_rank % len(key_list) :]
-                    + key_list[: self.tp_rank % len(key_list)]
-                )
-                addr_list_c = (
-                    addr_list[self.tp_rank % len(addr_list) :]
-                    + addr_list[: self.tp_rank % len(addr_list)]
-                )
-                size_list_c = (
-                    size_list[self.tp_rank % len(size_list) :]
-                    + size_list[: self.tp_rank % len(size_list)]
-                )
-                try:
-                    self.store.batch_get_into_multi_buffers(
-                        key_list_c, addr_list_c, size_list_c
-                    )
-                except Exception as e:
-                    logger.error("Failed to get: %s", e)
+        assert self.load_async, "load_async must be True for better performance."
+        # Issue stores with CUDA event synchronization
+        if self.kv_role in ["kv_producer", "kv_both"]:
+            current_event = None
+            for request in meta.requests:
+                if request.can_save:
+                    current_event = torch.cuda.Event()
+                    current_event.record()
+                    break
 
-    def wait_for_save(
-        self,
-        metadata: MooncakeStoreConnectorMetadata,
-    ):
-        """Record CUDA event and queue save requests."""
-        current_event = None
-        for request in metadata.requests:
-            if request.can_save:
-                current_event = torch.cuda.Event()
-                current_event.record()
-                break
+            for request in meta.requests:
+                if not request.can_save:
+                    continue
+                request.current_event = current_event
+                assert self.kv_send_thread is not None
+                self.kv_send_thread.add_stored_request(request.req_id)
+                self.kv_send_thread.add_request(request)
 
-        for request in metadata.requests:
-            if not request.can_save:
-                continue
-
-            request.current_event = current_event
-            assert self.kv_send_thread is not None
-            self.kv_send_thread.add_stored_request(request.req_id)
-            self.kv_send_thread.add_request(request)
-
-    def get_finished(
-        self,
-        finished_req_ids: set[str],
-        meta: MooncakeStoreConnectorMetadata,
-    ) -> tuple[set[str], set[str]]:
-        """Get completed send/recv request IDs."""
+        # Check completion of previously queued transfers
         done_sending = (
             self._get_and_clear_finished_sending(finished_req_ids, meta)
             if self.kv_role in ["kv_producer", "kv_both"]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -441,8 +441,9 @@ class MooncakeStoreWorker:
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "load_async", False
         )
-        self.original_block_size = vllm_config.cache_config.block_size
-        self.block_size = vllm_config.cache_config.block_size
+        self.cache_config = vllm_config.cache_config
+        self.original_block_size = self.cache_config.block_size
+        self.block_size = self.cache_config.block_size
         if self.pcp_size > 1:
             self.block_size *= self.pcp_size
         if self.dcp_size > 1:
@@ -512,26 +513,74 @@ class MooncakeStoreWorker:
         # TODO(yifan): we haven't supported hybrid HMA yet.
         first_kv_cache = next(iter(kv_caches.values()))
 
-        self.num_blocks = first_kv_cache.shape[0]
-        logger.info("num_blocks: %s", self.num_blocks)
+        # num_blocks from cache_config is authoritative (set after
+        # profiling, before KV cache allocation).
+        assert self.cache_config.num_gpu_blocks is not None
+        self.num_blocks = self.cache_config.num_gpu_blocks
 
-        # Per-block byte size: total tensor bytes / number of blocks.
-        # Works for both MLA (3D: num_blocks, block_size, head_size) and
-        # non-MLA (5D: num_blocks, 2, block_size, num_kv_heads, head_size).
-        self.block_len: list[int] = [first_kv_cache.nbytes // self.num_blocks]
+        # Detect the KV cache memory layout using the stride-based
+        # approach from simple_kv_offload/worker.py.
+        #
+        # The physical layout varies across attention backends:
+        #   FlashAttn/ROCm : (2, num_blocks, ...) → K/V outermost
+        #   FlashInfer/MLA : (num_blocks, ...)    → blocks outermost
+        #
+        # We derive page_size_bytes = storage.nbytes() // num_blocks,
+        # then classify dims: any dim whose byte-stride exceeds
+        # page_size_bytes must be an outer segment dim (e.g. the K/V
+        # dim of size 2).  For those backends we register each segment
+        # (K, V) as a separate base-address so that the per-block
+        # offset arithmetic in prepare_value() stays correct.
+        storage = first_kv_cache.untyped_storage()
+        el = first_kv_cache.element_size()
+        page_size_bytes = storage.nbytes() // self.num_blocks
+        outer_dims = [
+            d
+            for d in range(first_kv_cache.ndim)
+            if first_kv_cache.stride(d) * el > page_size_bytes
+        ]
+
+        # Register buffers with the store (deduplicate shared storages)
+        # and record per-segment base addresses for every layer.
+        seen_ptrs: set[int] = set()
+        self.kv_caches_base_addr: list[int] = []
+        self.block_len: list[int] = []
+
+        for cache in kv_caches.values():
+            cache_storage = cache.untyped_storage()
+            base_addr = cache_storage.data_ptr()
+            region_len = cache_storage.nbytes()
+
+            if base_addr not in seen_ptrs:
+                seen_ptrs.add(base_addr)
+                ret = self.store.register_buffer(base_addr, region_len)
+                if ret != 0:
+                    logger.error(
+                        "register_buffer failed for addr %#x len %d: %d",
+                        base_addr,
+                        region_len,
+                        ret,
+                    )
+
+            if not outer_dims:
+                # Blocks-first layout (FlashInfer / MLA): one segment.
+                self.kv_caches_base_addr.append(base_addr)
+                self.block_len.append(page_size_bytes)
+            else:
+                # K/V-first layout (FlashAttn / ROCm): split segments.
+                seg_stride = cache.stride(outer_dims[0]) * el
+                for idx in range(cache.shape[outer_dims[0]]):
+                    self.kv_caches_base_addr.append(base_addr + idx * seg_stride)
+                    self.block_len.append(seg_stride // self.num_blocks)
 
         logger.info(
-            "Registering KV_Caches. use_mla: %s, shape %s",
+            "Registering KV_Caches. use_mla: %s, shape %s, "
+            "num_blocks: %d, block_len: %s",
             self.use_mla,
             first_kv_cache.shape,
+            self.num_blocks,
+            list(set(self.block_len)),
         )
-
-        self.kv_caches_base_addr: list[int] = []
-        for cache in kv_caches.values():
-            base_addr = cache.data_ptr()
-            region_len = cache.nbytes
-            self.kv_caches_base_addr.append(base_addr)
-            self.store.register_buffer(base_addr, region_len)
 
         self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
         self.token_database.set_block_len(self.block_len)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -55,11 +55,15 @@ class MooncakeStoreConfig:
     protocol: str
     device_name: str
     master_server_address: str
+    enable_offload: bool = False
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
+        enable_offload = config.get("enable_offload", False) or os.getenv(
+            "MOONCAKE_ENABLE_OFFLOAD", ""
+        ).lower() in ("1", "true")
         return MooncakeStoreConfig(
             metadata_server=config.get("metadata_server", ""),
             global_segment_size=_parse_size(
@@ -71,6 +75,7 @@ class MooncakeStoreConfig:
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address", ""),
+            enable_offload=enable_offload,
         )
 
     @staticmethod
@@ -485,15 +490,18 @@ class MooncakeStoreWorker:
         self.store = MooncakeDistributedStore()
 
         local_seg = get_ip()
-        ret = self.store.setup(
-            local_seg,
-            store_config.metadata_server,
-            store_config.global_segment_size,
-            store_config.local_buffer_size,
-            store_config.protocol,
-            store_config.device_name,
-            store_config.master_server_address,
-        )
+        config_dict = {
+            "local_hostname": local_seg,
+            "metadata_server": store_config.metadata_server,
+            "global_segment_size": str(store_config.global_segment_size),
+            "local_buffer_size": str(store_config.local_buffer_size),
+            "protocol": store_config.protocol,
+            "rdma_devices": store_config.device_name,
+            "master_server_addr": store_config.master_server_address,
+        }
+        if store_config.enable_offload:
+            config_dict["enable_offload"] = "true"
+        ret = self.store.setup(config_dict)
         if ret != 0:
             msg = "Initialize MooncakeDistributedStore failed."
             logger.error(msg)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -7,7 +7,6 @@ and MooncakeDistributedStore integration.
 """
 
 import json
-import math
 import os
 import queue
 import threading
@@ -510,23 +509,16 @@ class MooncakeStoreWorker:
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register KV cache tensors and start transfer threads."""
-        _, first_kv_cache_tuple = next(iter(kv_caches.items()))
-        first_kv_cache = first_kv_cache_tuple[0]
+        # TODO(yifan): we haven't supported hybrid HMA yet.
+        first_kv_cache = next(iter(kv_caches.values()))
 
         self.num_blocks = first_kv_cache.shape[0]
         logger.info("num_blocks: %s", self.num_blocks)
 
-        block_rank = 3
-        self.block_len: list[int] = []
-        if self.use_mla:
-            for i in range(len(first_kv_cache_tuple)):
-                block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
-                self.block_len.append(
-                    first_kv_cache_tuple[i].element_size() * math.prod(block_shape)
-                )
-        else:
-            block_shape = first_kv_cache.shape[-block_rank:]
-            self.block_len = [first_kv_cache.element_size() * math.prod(block_shape)]
+        # Per-block byte size: total tensor bytes / number of blocks.
+        # Works for both MLA (3D: num_blocks, block_size, head_size) and
+        # non-MLA (5D: num_blocks, 2, block_size, num_kv_heads, head_size).
+        self.block_len: list[int] = [first_kv_cache.nbytes // self.num_blocks]
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, shape %s",
@@ -535,19 +527,11 @@ class MooncakeStoreWorker:
         )
 
         self.kv_caches_base_addr: list[int] = []
-        ptrs: list[int] = []
-        lengths: list[int] = []
-        length = len(self.block_len)
-        for cache_or_caches in kv_caches.values():
-            for i, cache in enumerate(cache_or_caches, 0):
-                base_addr = cache.data_ptr()
-                region_len = self.num_blocks * self.block_len[i % length]
-                self.kv_caches_base_addr.append(base_addr)
-                ptrs.append(base_addr)
-                lengths.append(region_len)
-
-        # Register buffers
-        self.store.register_buffer(ptrs, lengths)
+        for cache in kv_caches.values():
+            base_addr = cache.data_ptr()
+            region_len = cache.nbytes
+            self.kv_caches_base_addr.append(base_addr)
+            self.store.register_buffer(base_addr, region_len)
 
         self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
         self.token_database.set_block_len(self.block_len)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -10,12 +10,12 @@ import json
 import math
 import os
 import queue
-import re
 import threading
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
+import regex as re
 import torch
 import zmq
 
@@ -27,19 +27,18 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.kv_events import BlockStored
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_ip, make_zmq_socket
+from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+from vllm.v1.serial_utils import MsgpackDecoder
+
+from .mooncake_store_data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     MooncakeStoreConnectorMetadata,
     ReqMeta,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (
-    get_zmq_rpc_path_lookup,
-)
-from vllm.logger import init_logger
-from vllm.utils.network_utils import get_ip, make_zmq_socket
-from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
-from vllm.v1.serial_utils import MsgpackDecoder
+from .mooncake_store_scheduler import get_zmq_rpc_path_lookup
 
 logger = init_logger(__name__)
 
@@ -65,9 +64,7 @@ class MooncakeStoreConfig:
         return MooncakeStoreConfig(
             metadata_server=config.get("metadata_server", ""),
             global_segment_size=_parse_size(
-                config.get(
-                    "global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE
-                )
+                config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
             ),
             local_buffer_size=_parse_size(
                 config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)
@@ -82,8 +79,7 @@ class MooncakeStoreConfig:
         config_path = os.getenv("MOONCAKE_CONFIG_PATH")
         if not config_path:
             raise ValueError(
-                "The environment variable 'MOONCAKE_CONFIG_PATH' "
-                "is not set."
+                "The environment variable 'MOONCAKE_CONFIG_PATH' is not set."
             )
         return MooncakeStoreConfig.from_file(config_path)
 
@@ -96,9 +92,7 @@ def _parse_size(value: Any) -> int:
         try:
             return int(value)
         except (TypeError, ValueError) as e:
-            raise TypeError(
-                f"Unsupported type for size: {type(value)}"
-            ) from e
+            raise TypeError(f"Unsupported type for size: {type(value)}") from e
 
     cleaned = value.strip().lower()
     if not cleaned:
@@ -120,10 +114,8 @@ def _parse_size(value: Any) -> int:
 
     try:
         numeric_value = float(number_str)
-    except ValueError:
-        raise ValueError(
-            f"Invalid numeric value '{number_str}' in: '{value}'"
-        )
+    except ValueError as exc:
+        raise ValueError(f"Invalid numeric value '{number_str}' in: '{value}'") from exc
     return int(numeric_value * multiplier)
 
 
@@ -252,9 +244,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         keys = []
         block_hashes: list[BlockHash] = []
         for index, (start, end, key) in enumerate(
-            self.token_database.process_tokens(
-                token_len, req_meta.block_hashes
-            )
+            self.token_database.process_tokens(token_len, req_meta.block_hashes)
         ):
             starts.append(start)
             ends.append(end)
@@ -265,9 +255,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         starts = starts[self.tp_rank % self.put_step :: self.put_step]
         ends = ends[self.tp_rank % self.put_step :: self.put_step]
         keys = keys[self.tp_rank % self.put_step :: self.put_step]
-        block_hashes = block_hashes[
-            self.tp_rank % self.put_step :: self.put_step
-        ]
+        block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
 
         if not keys:
             self.dec_stored_request(req_id)
@@ -275,9 +263,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         # Check which blocks already exist (dedup)
         exists_states = self.store.batch_is_exist(keys)
-        missing_indices = [
-            i for i, exists in enumerate(exists_states) if exists != 1
-        ]
+        missing_indices = [i for i, exists in enumerate(exists_states) if exists != 1]
 
         if not missing_indices:
             self.dec_stored_request(req_id)
@@ -301,9 +287,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         sizes = []
         stored_events: list[BlockStored] = []
         prev_key = None
-        new_block_hashes = [
-            maybe_convert_block_hash(bh) for bh in block_hashes
-        ]
+        new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
 
         for index, start in enumerate(starts):
             addr, size, _ = self.token_database.prepare_value(
@@ -334,14 +318,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
             current_event.synchronize()
 
         try:
-            res = self.store.batch_put_from_multi_buffers(
-                keys, addrs, sizes
-            )
+            res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
             for value in res:
                 if value < 0:
-                    logger.error(
-                        "Failed to put key %s, res: %s", keys, res
-                    )
+                    logger.error("Failed to put key %s, res: %s", keys, res)
         except Exception as e:
             logger.error("Failed to put key %s, error: %s", keys, e)
 
@@ -420,9 +400,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                         res,
                     )
         except Exception as e:
-            logger.error(
-                "Failed to get key %s, error: %s", key_list_c, e
-            )
+            logger.error("Failed to get key %s, error: %s", key_list_c, e)
 
         self.set_finished_request(req_id)
         self.request_queue.task_done()
@@ -453,24 +431,16 @@ class MooncakeStoreWorker:
         self.tp_rank = get_tensor_model_parallel_rank()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.pp_size = parallel_config.pipeline_parallel_size
-        self.pp_rank = (
-            (parallel_config.rank // self.tp_size) % self.pp_size
-        )
+        self.pp_rank = (parallel_config.rank // self.tp_size) % self.pp_size
 
         self.pcp_size = get_pcp_group().world_size
-        self.pcp_rank = (
-            get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
-        )
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
         self.dcp_size = get_dcp_group().world_size
-        self.dcp_rank = (
-            get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
-        )
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
 
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        self.load_async = (
-            vllm_config.kv_transfer_config.kv_connector_extra_config.get(
-                "load_async", False
-            )
+        self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "load_async", False
         )
         self.original_block_size = vllm_config.cache_config.block_size
         self.block_size = vllm_config.cache_config.block_size
@@ -508,9 +478,7 @@ class MooncakeStoreWorker:
             pp_rank=self.pp_rank,
         )
 
-        self.token_database = ChunkedTokenDatabase(
-            self.metadata, self.block_size
-        )
+        self.token_database = ChunkedTokenDatabase(self.metadata, self.block_size)
 
         # Initialize MooncakeDistributedStore with its own TransferEngine
         store_config = MooncakeStoreConfig.load_from_env()
@@ -540,9 +508,7 @@ class MooncakeStoreWorker:
         self.kv_recv_thread: KVCacheStoreRecvingThread | None = None
         self.finished_store_req: set[str] = set()
 
-    def register_kv_caches(
-        self, kv_caches: dict[str, torch.Tensor]
-    ):
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register KV cache tensors and start transfer threads."""
         _, first_kv_cache_tuple = next(iter(kv_caches.items()))
         first_kv_cache = first_kv_cache_tuple[0]
@@ -556,14 +522,11 @@ class MooncakeStoreWorker:
             for i in range(len(first_kv_cache_tuple)):
                 block_shape = first_kv_cache_tuple[i].shape[-block_rank:]
                 self.block_len.append(
-                    first_kv_cache_tuple[i].element_size()
-                    * math.prod(block_shape)
+                    first_kv_cache_tuple[i].element_size() * math.prod(block_shape)
                 )
         else:
             block_shape = first_kv_cache.shape[-block_rank:]
-            self.block_len = [
-                first_kv_cache.element_size() * math.prod(block_shape)
-            ]
+            self.block_len = [first_kv_cache.element_size() * math.prod(block_shape)]
 
         logger.info(
             "Registering KV_Caches. use_mla: %s, shape %s",
@@ -586,9 +549,7 @@ class MooncakeStoreWorker:
         # Register buffers
         self.store.register_buffer(ptrs, lengths)
 
-        self.token_database.set_kv_caches_base_addr(
-            self.kv_caches_base_addr
-        )
+        self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
         self.token_database.set_block_len(self.block_len)
 
         # Start transfer threads
@@ -619,7 +580,8 @@ class MooncakeStoreWorker:
             ready_event.wait()
 
     def start_load_kv(
-        self, metadata: MooncakeStoreConnectorMetadata,
+        self,
+        metadata: MooncakeStoreConnectorMetadata,
     ):
         """Start loading KV cache from the store."""
         for request in metadata.requests:
@@ -628,15 +590,13 @@ class MooncakeStoreWorker:
                 continue
 
             token_len = request.token_len_chunk
-            if (
-                load_spec.kvpool_cached_tokens % self.block_size != 0
-            ) and (
+            if (load_spec.kvpool_cached_tokens % self.block_size != 0) and (
                 load_spec.kvpool_cached_tokens == token_len - 1
             ):
                 token_len = load_spec.kvpool_cached_tokens + 1
             else:
                 token_len = load_spec.kvpool_cached_tokens
-            request.load_spec.token_len = token_len
+            load_spec.token_len = token_len
 
             if self.load_async:
                 assert self.kv_recv_thread is not None
@@ -647,14 +607,10 @@ class MooncakeStoreWorker:
                 size_list = []
                 key_list = []
                 mask_num = (
-                    load_spec.vllm_cached_tokens
-                    // self.block_size
-                    * self.block_size
+                    load_spec.vllm_cached_tokens // self.block_size * self.block_size
                 )
-                for start, end, key in (
-                    self.token_database.process_tokens(
-                        token_len, request.block_hashes, mask_num
-                    )
+                for start, end, key in self.token_database.process_tokens(
+                    token_len, request.block_hashes, mask_num
                 ):
                     addr, size, _ = self.token_database.prepare_value(
                         start, end, request.block_ids
@@ -684,7 +640,8 @@ class MooncakeStoreWorker:
                     logger.error("Failed to get: %s", e)
 
     def wait_for_save(
-        self, metadata: MooncakeStoreConnectorMetadata,
+        self,
+        metadata: MooncakeStoreConnectorMetadata,
     ):
         """Record CUDA event and queue save requests."""
         current_event = None
@@ -710,9 +667,7 @@ class MooncakeStoreWorker:
     ) -> tuple[set[str], set[str]]:
         """Get completed send/recv request IDs."""
         done_sending = (
-            self._get_and_clear_finished_sending(
-                finished_req_ids, meta
-            )
+            self._get_and_clear_finished_sending(finished_req_ids, meta)
             if self.kv_role in ["kv_producer", "kv_both"]
             else set()
         )
@@ -749,19 +704,13 @@ class MooncakeStoreWorker:
             ):
                 self.finished_store_req.remove(req_id)
                 finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(
-                    req_id
-                )
+                self.kv_send_thread.delete_finished_stored_request(req_id)
 
         for req_id in finished_req_ids:
-            req_remain_jobs = (
-                self.kv_send_thread.stored_requests.get(req_id)
-            )
+            req_remain_jobs = self.kv_send_thread.stored_requests.get(req_id)
             if req_remain_jobs == 0:
                 finished_sending.add(req_id)
-                self.kv_send_thread.delete_finished_stored_request(
-                    req_id
-                )
+                self.kv_send_thread.delete_finished_stored_request(req_id)
             elif req_remain_jobs is not None:
                 self.finished_store_req.add(req_id)
 
@@ -790,18 +739,14 @@ class MooncakeStoreWorker:
             multi_tp_keys = keys[:]
             for i in range(1, min(self.tp_size, self.num_kv_head)):
                 for item in keys:
-                    new_str = item.replace(
-                        "@tp_rank:0", f"@tp_rank:{i}", 1
-                    )
+                    new_str = item.replace("@tp_rank:0", f"@tp_rank:{i}", 1)
                     multi_tp_keys.append(new_str)
 
             # Expand keys for all PP ranks
             pp_base_keys = multi_tp_keys.copy()
             for i in range(1, self.pp_size):
                 for item in pp_base_keys:
-                    new_str = item.replace(
-                        "@pp_rank:0", f"@pp_rank:{i}", 1
-                    )
+                    new_str = item.replace("@pp_rank:0", f"@pp_rank:{i}", 1)
                     multi_tp_keys.append(new_str)
 
             res = self.store.batch_is_exist(multi_tp_keys)
@@ -809,9 +754,7 @@ class MooncakeStoreWorker:
             num_block = len(keys)
             multi_tp_values = [
                 res[i * num_block : (i + 1) * num_block]
-                for i in range(
-                    min(self.tp_size, self.num_kv_head) * self.pp_size
-                )
+                for i in range(min(self.tp_size, self.num_kv_head) * self.pp_size)
             ]
             index = self._find_min_first_non_one_index(multi_tp_values)
             if index != -1:
@@ -826,12 +769,7 @@ class MooncakeStoreWorker:
         arr: list[list[int]],
     ) -> int:
         try:
-            return min(
-                idx
-                for row in arr
-                for idx, val in enumerate(row)
-                if val != 1
-            )
+            return min(idx for row in arr for idx, val in enumerate(row) if val != 1)
         except ValueError:
             return -1
 
@@ -870,20 +808,14 @@ class LookupKeyServer:
         def process_request():
             while self.running:
                 all_frames = self.socket.recv_multipart(copy=False)
-                token_len = int.from_bytes(
-                    all_frames[0], byteorder="big"
-                )
+                token_len = int.from_bytes(all_frames[0], byteorder="big")
                 hash_frames = all_frames[1:]
                 hashes_str = self.decoder.decode(hash_frames)
-                result = self.store_worker.lookup(
-                    token_len, hashes_str
-                )
+                result = self.store_worker.lookup(token_len, hashes_str)
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
 
-        self.thread = threading.Thread(
-            target=process_request, daemon=True
-        )
+        self.thread = threading.Thread(target=process_request, daemon=True)
         self.thread.start()
 
     def close(self):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -951,20 +951,30 @@ class MooncakeStoreWorker:
         self,
         token_len: int,
         block_hashes: list[BlockHash],
+        num_computed_tokens: int = 0,
     ) -> int:
         """Check how many prefix tokens exist in the store.
 
-        Checks across all TP ranks and PP ranks.
+        Checks across all TP ranks and PP ranks. Blocks whose start offset is
+        below ``num_computed_tokens`` are assumed to already be served by
+        vLLM's local prefix cache and are skipped to avoid probing the
+        external store for keys whose results would be subtracted out.
         """
-        end = 0
+        # num_computed_tokens is block-aligned from the local prefix cache and
+        # bounded by the prompt length, so mask_num <= token_len holds.
+        mask_num = num_computed_tokens // self.block_size * self.block_size
+        end = mask_num
         keys: list[str] = []
         try:
             starts: list[int] = []
             for start, end, key in self.token_database.process_tokens(
-                token_len, block_hashes
+                token_len, block_hashes, mask_num=mask_num
             ):
                 keys.append(key.to_string())
                 starts.append(start)
+
+            if not keys:
+                return end
 
             # Expand keys for all TP ranks
             multi_tp_keys = keys[:]
@@ -1043,9 +1053,14 @@ class LookupKeyServer:
             while self.running:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
-                hash_frames = all_frames[1:]
+                num_computed_tokens = int.from_bytes(
+                    all_frames[1], byteorder="big"
+                )
+                hash_frames = all_frames[2:]
                 hashes_str = self.decoder.decode(hash_frames)
-                result = self.store_worker.lookup(token_len, hashes_str)
+                result = self.store_worker.lookup(
+                    token_len, hashes_str, num_computed_tokens
+                )
                 response = result.to_bytes(4, "big")
                 self.socket.send(response)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
@@ -8,12 +8,22 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from vllm.config import ParallelConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import EngineId
 from vllm.logger import init_logger
 
 WorkerAddr = str
 
 logger = init_logger(__name__)
+
+
+def get_mooncake_dp_engine_index(parallel_config: ParallelConfig) -> int:
+    """Return the per-engine DP index used for Mooncake side channels."""
+    if parallel_config.local_engines_only:
+        assert parallel_config.data_parallel_rank_local is not None
+        return parallel_config.data_parallel_rank_local
+
+    return parallel_config.data_parallel_index
 
 
 class RegisterWorkerPayload(BaseModel):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -33,6 +33,7 @@ from vllm.v1.outputs import KVConnectorOutput
 if TYPE_CHECKING:
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.forward_context import ForwardContext
+    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -218,6 +219,11 @@ class MultiConnector(KVConnectorBase_V1):
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         for c in self._connectors:
             c.register_kv_caches(kv_caches)
+
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+        for c in self._connectors:
+            if hasattr(c, "bind_gpu_block_pool"):
+                c.bind_gpu_block_pool(gpu_block_pool)
 
     # We must override the base class method here because we need to bind
     # the metadata to each connector in the order of the connectors in the


### PR DESCRIPTION
## Summary

When vLLM's local prefix cache already covers the leading part of a prompt, there is no benefit to probing the external Mooncake store for those same blocks — the scheduler subtracts those hits out again. This PR plumbs `num_computed_tokens` from the scheduler down to `MooncakeStoreWorker.lookup()` so we skip those blocks up front.

- `MooncakeStoreScheduler.get_num_new_matched_tokens` now passes `num_computed_tokens` into `LookupKeyClient.lookup(...)`.
- `LookupKeyClient` serializes `num_computed_tokens` as a 4-byte big-endian frame in the ZMQ multipart message; `LookupKeyServer` reads it and forwards it to the worker.
- `MooncakeStoreWorker.lookup` computes `mask_num = num_computed_tokens // block_size * block_size`, passes it as `mask_num=` to `ChunkedTokenDatabase.process_tokens`, and returns `mask_num` (not 0) when the resulting key list is empty so the scheduler keeps the local-cache credit.

## Wire-format change (breaking between scheduler ↔ worker processes)

Lookup ZMQ frames go from `[token_len][hash_frames...]` to `[token_len][num_computed_tokens][hash_frames...]`. Client and server must be deployed together.

## Test plan

- [ ] `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py -v`
- [ ] End-to-end run with a prompt whose local-cache prefix is non-empty; confirm `batch_is_exist` is called with fewer keys and `num_external_hit_tokens` no longer double-counts the local prefix.

## Notes

- AI assistance (Claude) was used while preparing this change; the submitter reviewed every line.
- Cherry-pick from the metrics branch was part of this work; the `MooncakeStoreConnectorStats`-dependent tests from that branch were intentionally **not** brought over because this branch does not yet have the stats infrastructure — those tests should land alongside the metrics merge.
- A stray `export export LD_LIBRARY_PATH=...` line in `scripts/mooncake/start_mooncake_master.sh` (dev-machine leftover) was dropped before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)