### PR TITLE
Update mooncake instructions

### DIFF
--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -4,18 +4,7 @@
 
 ### 1. Install Mooncake
 
-We need to use our own version of Mooncake for GB200.
-
-#### Option A: Install from pre-built wheel (recommended)
-
-NOTE: this wheel is pre-compiled only for Grace-Blackwell and Grace-Hopper (ARM64) platforms. For AMD64 (including Intel platforms), users still need to go with Option B and manual compile for now. We will add a pre-compiled wheel later.
-
-```bash
-# Make sure your vllm venv is activated
-uv pip install scripts/mooncake/mooncake_transfer_engine-0.3.10.post1-cp312-cp312-manylinux_2_39_aarch64.whl
-```
-
-#### Option B: Build from source
+We need to use our own version of Mooncake for GB200. Build from source against the `yifan/dev` branch of [`ivanium/Mooncake`](https://github.com/ivanium/Mooncake).
 
 ```shell
 git clone https://github.com/ivanium/Mooncake
@@ -27,6 +16,11 @@ git checkout yifan/dev
 # NOTE: Please ensure to activate vllm venv before installing
 ./scripts/dev_install.sh
 ```
+
+Build flags (set in `dev_compile.sh`):
+- `-DUSE_CUDA=ON`
+- `-DWITH_NVIDIA_PEERMEM=OFF` (required on GB200 — peermem kernel module won't load)
+- `-DUSE_MNNVL=ON`
 
 ### 2. Verify Installation
 


### PR DESCRIPTION
## Summary

- **Removes** the bundled `mooncake_transfer_engine-0.3.10.post1-...whl` from `scripts/mooncake/`
- **Updates** `scripts/mooncake/README.md` to instruct building from source against [`ivanium/Mooncake@yifan/dev`](https://github.com/ivanium/Mooncake/tree/yifan/dev), which has the correct segment-owner-derived `PushOffloadingQueue` routing
- Adds a `strings ... | grep getClientByName` verification step so users can confirm the fix is in their installed binary

## Why drop the wheel

The previous bundled `.post1` wheel was built from a downstream tree that included commit [`1979502`](https://github.com/ivanium/Mooncake/commit/1979502) ("feat: fix & support disk offloading") which **regressed** `PushOffloadingQueue` back to keying by the requester's `client_id`. In our external-owner architecture that lookup never matches the disk-segment owner's `client_id`, so every offload enqueue silently failed and CPU memory eventually saturated. Same root cause as upstream issue [kvcache-ai/Mooncake#1948](https://github.com/kvcache-ai/Mooncake/issues/1948).

`upstream/yifan/dev` does **not** carry that regression — it still has the original segment-owner routing introduced in [`455e11a`](https://github.com/kvcache-ai/Mooncake/commit/455e11a) (Dec 2025). Building from that branch is sufficient; no Mooncake source edits required.

## Why source-only (no replacement wheel)

Wheels go stale and add another "which version is canonical" question. The build is one command (`./scripts/dev_compile.sh`) once dependencies are present, and the README now also documents the GB200-specific flags. If we want to ship a wheel later, it's a separate change with explicit version pinning.

## End-to-end verification

Verified working with a manually-built wheel from `ivanium/Mooncake@yifan/dev` HEAD `71b62121` on Kimi-K2.5-NVFP4 dp=4 multi-turn benchmark (run `20260427_043254`):

| Signal | Old wheel (.post1) | This branch's instructions (build from yifan/dev) |
|---|---|---|
| `NotifyOffloadSuccess.*keys_count=[1-9]` (owner log) | 0 (only init) | **61 RPCs, max 238 keys/batch** |
| Total keys offloaded to SSD | 0 | **29,036** |
| `Segment X not found` / `UNABLE_OFFLOADING` (master) | n/a | **0 / 0** |
| `/mnt/data/$USER/mooncake_offload/.../*.bucket` | empty | 244+ buckets, 16 GB |
| Bench outcome | failed in ~10 min on insufficient_space | **all 100 conversations × 3 turns succeeded (1,381s, 0 failed)** |

## What's in the diff

```
 scripts/mooncake/README.md                                                  |  26 ++--
 scripts/mooncake/mooncake_transfer_engine-0.3.10.post1-cp312-cp312-...whl   | Bin 95381336 -> 0 bytes
```

## Test plan

- [x] Built from `ivanium/Mooncake@yifan/dev` HEAD `71b62121`, verified `getClientByName` symbol present in compiled `mooncake_master`
- [x] Installed locally on GB200 (aarch64 Ubuntu 24.04), ran end-to-end vigil pipeline
- [x] Verified routing fix in production (counts above)
- [ ] Reviewer to confirm `scripts/mooncake/dev_install.sh` instructions still work in their environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)