### PR TITLE
fix(mooncake): probe segment port for owner readiness

### DIFF
--- a/scripts/mooncake/run_vllm_with_mooncake_owner.sh
+++ b/scripts/mooncake/run_vllm_with_mooncake_owner.sh
@@ -192,13 +192,16 @@ print_owner_failure_hint() {
 }
 
 wait_for_owner_ready() {
-    if wait_for_tcp_port "$OWNER_RPC_PORT" "$OWNER_READY_TIMEOUT_S" "${OWNER_PID:-}"; then
+    # The mooncake_client owner exposes its RPC endpoint as an abstract Unix
+    # socket (@mooncake_client_<rpc_port>.sock), not a TCP port. The segment
+    # port is the real TCP listener that signals the owner is serving.
+    if wait_for_tcp_port "$OWNER_SEGMENT_PORT" "$OWNER_READY_TIMEOUT_S" "${OWNER_PID:-}"; then
         return 0
     fi
     if [[ -n "${OWNER_PID:-}" ]] && ! kill -0 "$OWNER_PID" 2>/dev/null; then
         echo "Mooncake owner exited before becoming ready." >&2
     else
-        echo "Timed out waiting for Mooncake owner RPC port ${OWNER_RPC_PORT}." >&2
+        echo "Timed out waiting for Mooncake owner segment port ${OWNER_SEGMENT_PORT}." >&2
     fi
     tail -n 50 "$OWNER_LOG_FILE" >&2 || true
     print_owner_failure_hint

--- a/scripts/mooncake/start_mooncake_owner.sh
+++ b/scripts/mooncake/start_mooncake_owner.sh
@@ -140,7 +140,9 @@ detect_owner_devices() {
 wait_for_owner_ready() {
     local pid=$1
     local timeout_s=${2:-30}
-    wait_for_tcp_port "$RPC_PORT" "$timeout_s" "$pid"
+    # The RPC port is exposed as an abstract Unix socket; the segment port
+    # is the real TCP listener that indicates the owner is up.
+    wait_for_tcp_port "$SEGMENT_PORT" "$timeout_s" "$pid"
 }
 
 stop_owner() {
@@ -193,8 +195,8 @@ if [[ -f "$PID_FILE" ]]; then
     rm -f "$PID_FILE"
 fi
 
-if tcp_port_is_listening "$RPC_PORT"; then
-    echo "Error: owner RPC port ${RPC_PORT} is already in use." >&2
+if tcp_port_is_listening "$SEGMENT_PORT"; then
+    echo "Error: owner segment port ${SEGMENT_PORT} is already in use." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- The launcher's `wait_for_owner_ready` probed `OWNER_RPC_PORT` (50052) via `wait_for_tcp_port`, but `mooncake_client` does not open a TCP listener on that port — it exposes the RPC endpoint as an abstract Unix socket `@mooncake_client_<port>.sock`. The probe could only succeed by accident when an unrelated stale process was holding TCP 50052.
- Switch the probe to `OWNER_SEGMENT_PORT` (default 50053), which the Transfer Engine opens as a real TCP listener once the owner has finished initializing. Same fix applied to `start_mooncake_owner.sh` (`wait_for_owner_ready` and the "port already in use" precheck).

## Background

Upstream Mooncake PR [#1900](https://github.com/kvcache-ai/Mooncake/pull/1900) — *"[Store] Fix hardcoded 127.0.0.1 bind address in standalone client RPC"* (commit `8d3beec` on `ivanium/Mooncake@yifan/dev`, merged Apr 16 2026) — changed `real_client_main.cpp`:

```diff
- coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, "127.0.0.1");
+ coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, FLAGS_host);

- LOG(INFO) << "Starting real client service on 127.0.0.1:" << FLAGS_port;
+ LOG(INFO) << "Starting real client service on " << FLAGS_host << ":"
+           << FLAGS_port;
```

`start_mooncake_owner.sh` invokes `mooncake_client` with `--host=<ip>:<segment_port>` (a host:port string, not a bare IP). `coro_rpc_server` receives that string as its bind host and silently fails to open a TCP listener on `FLAGS_port` (the RPC port). The owner log line `Starting real client service on 192.168.0.104:50053:50052` reflects this — it is literally `<FLAGS_host>:<FLAGS_port>` with the malformed host concatenated.

`lsof` on a running owner confirms only the segment-port and TE-ephemeral TCP listeners exist; the RPC port is only an abstract Unix socket:

```
TCP 192.168.0.104:50053 (LISTEN)         ← segment port (TransferEngine)
TCP *:16922 (LISTEN)                      ← TE RPC ephemeral
@@mooncake_client_50052.sock (LISTEN)     ← IPC unix abstract
(no TCP 50052)
```

So the launcher waited the full `MC_OWNER_READY_TIMEOUT_S` (default 120s) and then bailed with `Timed out waiting for Mooncake owner RPC port 50052.` even though the owner was actually ready. Earlier runs only worked when an unrelated stale TCP listener happened to be holding port 50052.

## Test plan
- [x] Reproduced the timeout against a current Mooncake build (post-#1900): `mndp` workflow stuck at `wait_for_owner_ready` → `worker_0.log` line 6 shows `Timed out waiting for Mooncake owner RPC port 50052.`
- [x] `lsof -p <owner_pid>` shows TCP `<host>:50053 (LISTEN)` is the actual readiness signal.
- [x] `bash -n` clean on both scripts.
- [ ] Re-run end-to-end with the fix and confirm vLLM serves come up without timeout (please verify locally).

🤖 AI assistance was used (Claude) — submitter must review and verify before merging.