### PR TITLE
mooncake: per-tier load logging + mndp config for disk-offload bench

### DIFF
--- a/mndp.yaml
+++ b/mndp.yaml
@@ -5,36 +5,43 @@
 # final Mooncake --kv-transfer-config for each worker node.
 
 model: nvidia/Kimi-K2.5-NVFP4
-mode: remote
+mode: local
 precheck: true
 collect_env: true
-router_port: 30000
+router_port: auto
+prometheus_port: auto
 
 pre_serve:
   - cmd: >-
       bash scripts/mooncake/start_mooncake_master.sh
       --bg
+      --enable-offload
       --env-file {log_dir}/mooncake_master.env
-    repo_path: /home/${USER}/code/vllm-mooncake
+    repo_path: /home/${USER}/repos/vllm-mooncake
+    env:
+      # Short lease TTL so memory replicas become evictable shortly after
+      # NotifyOffloadSuccess; otherwise BatchEvict skips every candidate
+      # (default 1800000 ms = 30 min) and the CPU pool plateaus at 95%.
+      MC_LEASE_TTL: "30000"
 
 serving:
   roles:
     - role: worker
-      count: 2
+      count: 1
       nodes_per_instance: 1
       gpus_per_node: 4
-      base_port: 8000
+      base_port: 8100
       vllm_engine:
-        repo_path: /home/${USER}/code/vllm-mooncake
+        repo_path: /home/${USER}/repos/vllm-mooncake
         cmd: >-
-          bash /home/${USER}/code/vllm-mooncake/scripts/mooncake/run_vllm_with_mooncake_owner.sh
+          bash /home/${USER}/repos/vllm-mooncake/scripts/mooncake/run_vllm_with_mooncake_owner.sh
           vllm serve {model}
           --port {port}
           --trust-remote-code
           --language-model-only
           --load-format dummy
           --enforce-eager
-          -tp 4
+          -dp 4
           -O3
           --gpu-memory-utilization 0.9
           --max-model-len 131072
@@ -48,10 +55,12 @@ serving:
           --disable-uvicorn-access-log
           --disable-hybrid-kv-cache-manager
         env:
+          GLOG_v: "1"
+          VLLM_MOONCAKE_STORE_TIER_LOG: "1"
           MC_MASTER_ENV_FILE: "{log_dir}/mooncake_master.env"
-          MC_OWNER_CPU_MEM_GIB: "700"
-          # MC_OWNER_DISK_GIB: "1000"
-          # MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
+          MC_OWNER_CPU_MEM_GIB: "70"
+          MC_OWNER_DISK_GIB: "1000"
+          MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
           VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
           VLLM_USE_FLASHINFER_MOE_FP4: "1"
           VLLM_FLASHINFER_MOE_BACKEND: latency
@@ -92,11 +101,14 @@ serving:
 
   # ---- Router (round-robin, no PD disaggregation) ----
   router:
+    repo_path: /home/${USER}/repos/router-internal
     cmd: >-
-      vllm-router
-      --policy round_robin
+      cargo run --release --
+      --policy consistent_hash
+      --prometheus-port {prometheus_port}
       --host 0.0.0.0
       --port {router_port}
+      --intra-node-data-parallel-size 4
       {worker_flags}
     health_check:
       url: http://localhost:{router_port}/health
@@ -108,6 +120,7 @@ serving:
     slurm:
       partition: normal
       time_limit: "12:00:00"
+      # nodelist: "gb200-rack1-[10,11]"
       grace_period_s: 120
 
 post_serve:
@@ -132,4 +145,4 @@ post_serve:
       --save-result
   - vmon: stop
   - cmd: bash scripts/mooncake/start_mooncake_master.sh --stop
-    repo_path: /home/${USER}/code/vllm-mooncake
+    repo_path: /home/${USER}/repos/vllm-mooncake

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import logging
 import math
 import sys
 import threading
@@ -295,6 +296,20 @@ def test_get_configured_worker_rnic_rejects_short_explicit_csv(monkeypatch):
         )
 
 
+class _ReplicaDesc:
+    def __init__(self, tier: str):
+        self.tier = tier
+
+    def is_memory_replica(self) -> bool:
+        return self.tier == "memory"
+
+    def is_disk_replica(self) -> bool:
+        return self.tier == "disk"
+
+    def is_local_disk_replica(self) -> bool:
+        return self.tier == "disk"
+
+
 def test_store_sending_thread_skips_request_during_cpu_pressure():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
@@ -407,7 +422,8 @@ def test_estimate_disk_offload_staging_bytes_sums_multi_segment_sizes():
     )
 
 
-def test_recv_thread_uses_single_batch_when_no_disk_offload_budget():
+def test_recv_thread_uses_single_batch_when_no_disk_offload_budget(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
     store = MagicMock()
     store.batch_get_into_multi_buffers.return_value = [256, 256, 256]
     thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
@@ -428,6 +444,52 @@ def test_recv_thread_uses_single_batch_when_no_disk_offload_budget():
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
     ]
     assert sizes == [[256], [256], [256]]
+    store.batch_get_replica_desc.assert_not_called()
+
+
+def test_recv_thread_logs_tier_summary_when_enabled(monkeypatch, caplog_vllm):
+    monkeypatch.setenv("VLLM_MOONCAKE_STORE_TIER_LOG", "1")
+    caplog_vllm.set_level(logging.INFO, logger=mooncake_store_worker.logger.name)
+
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, -10]
+    thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+    expected_keys = [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    store.batch_get_replica_desc.return_value = {
+        expected_keys[0]: [_ReplicaDesc("memory")],
+        expected_keys[1]: [_ReplicaDesc("disk")],
+        expected_keys[2]: [],
+    }
+
+    thread._handle_request(req)
+
+    assert store.batch_get_replica_desc.call_args.args == (expected_keys,)
+    assert store.method_calls[0][0] == "batch_get_replica_desc"
+    assert store.method_calls[1][0] == "batch_get_into_multi_buffers"
+
+    messages = [record.getMessage() for record in caplog_vllm.records]
+    assert any(
+        "Mooncake load tier summary" in message
+        and "req_id=req-a" in message
+        and "batch_keys=3" in message
+        and "memory_keys=1" in message
+        and "disk_keys=1" in message
+        and "unknown_keys=1" in message
+        and "success_keys=2" in message
+        and "failed_keys=1" in message
+        and "bytes_by_tier={'memory': 256, 'disk': 256, 'unknown': 0}" in message
+        for message in messages
+    )
 
 
 def test_recv_thread_uses_ratio_scaled_budget_for_first_pass_split():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -19,6 +19,7 @@ import regex as re
 import torch
 import zmq
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_dcp_group,
@@ -217,6 +218,97 @@ def _split_disk_offload_load_batches(
     if batch_keys:
         batches.append((batch_keys, batch_addrs, batch_sizes))
     return batches, None
+
+
+def _call_replica_predicate(replica_desc: Any, method_name: str) -> bool:
+    method = getattr(replica_desc, method_name, None)
+    if method is None:
+        return False
+    try:
+        return bool(method())
+    except Exception:
+        return False
+
+
+def _classify_replica_tier(replica_descs: Any) -> str:
+    if not replica_descs:
+        return "unknown"
+    try:
+        replica_desc = replica_descs[0]
+    except (IndexError, KeyError, TypeError):
+        return "unknown"
+
+    if _call_replica_predicate(replica_desc, "is_memory_replica"):
+        return "memory"
+    if _call_replica_predicate(
+        replica_desc, "is_disk_replica"
+    ) or _call_replica_predicate(replica_desc, "is_local_disk_replica"):
+        return "disk"
+    return "unknown"
+
+
+def _get_replica_tiers_by_key(store: Any, keys: list[str]) -> dict[str, str]:
+    tiers_by_key = {key: "unknown" for key in keys}
+    try:
+        replica_descs_by_key = store.batch_get_replica_desc(keys)
+    except Exception as e:
+        logger.warning(
+            "Failed to get Mooncake replica descriptors for tier logging "
+            "(batch_keys=%d, error=%s); marking tiers unknown",
+            len(keys),
+            e,
+        )
+        return tiers_by_key
+
+    for key in keys:
+        if hasattr(replica_descs_by_key, "get"):
+            replica_descs = replica_descs_by_key.get(key)
+        else:
+            try:
+                replica_descs = replica_descs_by_key[key]
+            except (KeyError, TypeError):
+                replica_descs = None
+        tiers_by_key[key] = _classify_replica_tier(replica_descs)
+    return tiers_by_key
+
+
+def _log_mooncake_load_tier_summary(
+    req_id: str,
+    batch_keys: list[str],
+    load_results: list[int],
+    tiers_by_key: dict[str, str],
+) -> None:
+    tier_counts = {"memory": 0, "disk": 0, "unknown": 0}
+    bytes_by_tier = {"memory": 0, "disk": 0, "unknown": 0}
+    success_keys = 0
+    failed_keys = 0
+
+    for index, key in enumerate(batch_keys):
+        tier = tiers_by_key.get(key, "unknown")
+        if tier not in tier_counts:
+            tier = "unknown"
+        tier_counts[tier] += 1
+
+        value = load_results[index] if index < len(load_results) else -1
+        if value >= 0:
+            success_keys += 1
+            bytes_by_tier[tier] += int(value)
+        else:
+            failed_keys += 1
+
+    logger.info(
+        "Mooncake load tier summary: req_id=%s batch_keys=%d "
+        "memory_keys=%d disk_keys=%d unknown_keys=%d "
+        "success_keys=%d failed_keys=%d bytes_by_tier=%s",
+        req_id,
+        len(batch_keys),
+        tier_counts["memory"],
+        tier_counts["disk"],
+        tier_counts["unknown"],
+        success_keys,
+        failed_keys,
+        bytes_by_tier,
+    )
 
 
 # ============================================================
@@ -610,9 +702,16 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         try:
             for batch_keys, batch_addrs, batch_sizes in load_batches:
                 current_batch_keys = batch_keys
+                tiers_by_key: dict[str, str] | None = None
+                if envs.VLLM_MOONCAKE_STORE_TIER_LOG:
+                    tiers_by_key = _get_replica_tiers_by_key(self.store, batch_keys)
                 res = self.store.batch_get_into_multi_buffers(
                     batch_keys, batch_addrs, batch_sizes
                 )
+                if tiers_by_key is not None:
+                    _log_mooncake_load_tier_summary(
+                        req_id, batch_keys, res, tiers_by_key
+                    )
                 failed = [
                     (key, value)
                     for key, value in zip(batch_keys, res, strict=True)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
+    VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
@@ -1317,6 +1318,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for Mooncake handshake between remote agents.
     "VLLM_MOONCAKE_BOOTSTRAP_PORT": lambda: int(
         os.getenv("VLLM_MOONCAKE_BOOTSTRAP_PORT", "8998")
+    ),
+    # If set, log MooncakeStoreConnector load bytes grouped by replica tier.
+    "VLLM_MOONCAKE_STORE_TIER_LOG": lambda: (
+        os.getenv("VLLM_MOONCAKE_STORE_TIER_LOG", "False").lower() in ("true", "1")
     ),
     # Flashinfer MoE backend for vLLM's fused Mixture-of-Experts support.
     # Both require compute capability 10.0 or above.


### PR DESCRIPTION
## Summary

Companion vLLM-side change to the Mooncake disk-read fix at ivanium/Mooncake#5. Two commits:

1. **`mooncake: add per-tier load logging behind VLLM_MOONCAKE_STORE_TIER_LOG`** (cherry-picked from `434e1ff4f`)

   Adds an opt-in summary log on the KV store recv path that groups load results by replica tier (memory / disk / unknown), reporting per-tier key counts, success/failure counts, and bytes loaded per request. Replica descriptors are queried via `batch_get_replica_desc` only when the env var is enabled, so the default path is unchanged.

   Used end-to-end to validate the Mooncake disk-tier read-back fix: the absence of `disk_keys=N` lines pre-fix (always 0) vs ~370 such lines per run post-fix is what caught and confirmed the bugs in ivanium/Mooncake#5.

   Sample output line:
   ```
   [mooncake_store_worker.py:299] Mooncake load tier summary:
     req_id=...-conv-90-turn2-... batch_keys=1064
     memory_keys=0 disk_keys=1064 unknown_keys=0
     success_keys=1064 failed_keys=0
     bytes_by_tier={'memory': 0, 'disk': 1196310528, 'unknown': 0}
   ```

   Test additions cover both branches (env unset → no descriptor lookup, env set → tier classification + log).

2. **`mndp: enable disk offload + 30s lease + GLOG_v=1 + tier-log`**

   Updates the reference `mndp.yaml` to exercise the disk-tier offload path. Mix of:

   **Upstream-worthy additions** (recommend keeping):
   - `pre_serve.cmd` adds `--enable-offload` so the master starts with `enable_offload=1`.
   - `pre_serve.env` adds `MC_LEASE_TTL: \"30000\"` (30 s). Without this, the default 30-min lease prevents `BatchEvict` from finding any expired candidates for the duration of the run and the CPU pool plateaus at 95 % — the measured fix on this benchmark is to lower the lease so memory replicas become evictable shortly after `NotifyOffloadSuccess`.
   - Worker `env` adds `GLOG_v: \"1\"` so `NotifyOffloadSuccess` and other VLOG-gated diagnostics are visible.
   - Worker `env` adds `VLLM_MOONCAKE_STORE_TIER_LOG: \"1\"` to enable the new logging from commit (1).
   - Worker `env` adds `MC_OWNER_CPU_MEM_GIB: \"70\"` to size the owner pool for typical conversational workloads.

   **Environment-specific changes** (review/discard as appropriate for upstream):
   - `mode: remote → local` and `router_port: 30000 → auto` — single-node testing default; remote/Slurm multi-node setups would prefer the original.
   - `repo_path: /home/${USER}/code/... → /home/${USER}/repos/...` — local path convention; the upstream might prefer the original path.
   - `count: 2 → 1`, `base_port: 8000 → 8100` — single-node topology.
   - `-tp 4 → -dp 4` — DP setup matches my single-GB200 test rig; multi-node TP may be the intended default upstream.

   I'd suggest squashing the env-specific bits out of this commit before merge, OR splitting into two commits (\"add disk-offload knobs\" + \"single-node test config\") so reviewers can take just the first. Happy to amend if preferred.

## Validation

Used together with the Mooncake disk-read fix (ivanium/Mooncake#5) on a 23-min Kimi-K2.5-NVFP4 multi-turn benchmark, 100 conversations × 3 turns, 32 concurrent, 70 K input tokens, prefix ratios 0.1 global / 0.8 conversation. Last run: `model-ci/logs/mndp/2026-04-28/20260428_065757`.

| Metric | Pre-fix | Post-fix (run 065757) |
|---|---|---|
| `disk_keys > 0` lines in tier-summary | **0 / 217** | **371 / 400** |
| Memory-only hits (`memory_keys>0, disk_keys=0`) | rest | 29 |
| `failed_keys` total | 1064 × N | **0** |
| `-600 INVALID_PARAMS` per-key errors | many | **0** |
| `-900 RPC_FAIL` per-key errors | many | **0** |
| Bytes served from disk tier | **0 GB** | **302.16 GB** |
| Bytes served from memory tier | ~33 GB | 63.10 GB |
| vmon `external_cache_hit_rate` distinct values | `{0, 0.444, 0.796, 0.889}` | `{0, 0.444, 0.572, 0.697, 0.761, 0.774, 0.81, 0.863, 0.889}` |

The new tier-log lines are what made the disk-tier breakage observable — pre-fix we saw `disk_keys=0` consistently in 217/217 lines despite 67 GB on disk (write side worked, read side broken). Post-fix we see explicit `disk_keys=1064 success_keys=1064` lines confirming the read-back path is delivering KV blocks from the SSD tier.

## Related

- ivanium/Mooncake#5 — the Mooncake-side fix (Bugs A-E + review hardening) that makes `disk_keys > 0` actually possible. Without that PR, this logging would still report `disk_keys=0` everywhere.
- Built on top of `61b4eba1f` (PR #31, segment-port readiness probe) which is now in `feat/mooncake-store-int-owner-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)