### PR TITLE
mooncake: honour enable_offload in disk-offload budget; drop count-trigger

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -70,9 +70,6 @@ class MooncakeStoreConfig:
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
-        enable_offload = bool(config.get("enable_offload", False)) or os.getenv(
-            "MOONCAKE_ENABLE_OFFLOAD", ""
-        ).lower() in ("1", "true")
         return MooncakeStoreConfig(
             metadata_server=_get_config_or_env_value(
                 config, "metadata_server", "MOONCAKE_TE_META_DATA_SERVER", ""
@@ -87,7 +84,9 @@ class MooncakeStoreConfig:
             master_server_address=_get_config_or_env_value(
                 config, "master_server_address", "MOONCAKE_MASTER", ""
             ),
-            enable_offload=enable_offload,
+            enable_offload=_get_bool_config_or_env_value(
+                config, "enable_offload", "MOONCAKE_ENABLE_OFFLOAD", False
+            ),
         )
 
     @staticmethod
@@ -107,6 +106,15 @@ def _get_config_or_env_value(
     if env_value not in (None, ""):
         return env_value
     return config.get(key, default)
+
+
+def _get_bool_config_or_env_value(
+    config: Mapping[str, Any], key: str, env_var: str, default: bool
+) -> bool:
+    env_value = os.getenv(env_var)
+    if env_value:
+        return env_value.strip().lower() in ("1", "true")
+    return bool(config.get(key, default))
 
 
 def _get_requester_local_buffer_size(config: Mapping[str, Any]) -> int:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -64,11 +64,15 @@ class MooncakeStoreConfig:
     protocol: str
     device_name: str
     master_server_address: str
+    enable_offload: bool = False
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
+        enable_offload = bool(config.get("enable_offload", False)) or os.getenv(
+            "MOONCAKE_ENABLE_OFFLOAD", ""
+        ).lower() in ("1", "true")
         return MooncakeStoreConfig(
             metadata_server=_get_config_or_env_value(
                 config, "metadata_server", "MOONCAKE_TE_META_DATA_SERVER", ""
@@ -83,6 +87,7 @@ class MooncakeStoreConfig:
             master_server_address=_get_config_or_env_value(
                 config, "master_server_address", "MOONCAKE_MASTER", ""
             ),
+            enable_offload=enable_offload,
         )
 
     @staticmethod
@@ -118,7 +123,9 @@ def _get_kv_connector_extra_config(vllm_config: VllmConfig) -> Mapping[str, Any]
     return kv_transfer_config.kv_connector_extra_config
 
 
-def _get_disk_offload_buffer_budget_bytes() -> int:
+def _get_disk_offload_buffer_budget_bytes(enable_offload: bool) -> int | None:
+    if not enable_offload:
+        return None
     value = os.getenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES")
     if value is None:
         return DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE
@@ -746,7 +753,9 @@ class MooncakeStoreWorker:
             self.store_replicate_config = ReplicateConfig()
             self.store_replicate_config.preferred_segment = preferred_segment
 
-        self.disk_offload_buffer_budget_bytes = _get_disk_offload_buffer_budget_bytes()
+        self.disk_offload_buffer_budget_bytes = _get_disk_offload_buffer_budget_bytes(
+            store_config.enable_offload
+        )
 
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -180,10 +180,6 @@ def _get_usable_disk_offload_buffer_budget_bytes(raw_budget_bytes: int) -> int:
     return max(1, int(raw_budget_bytes * DISK_OFFLOAD_USABLE_BUDGET_RATIO))
 
 
-def _get_usable_disk_offload_batch_key_count(num_keys: int) -> int:
-    return max(1, int(num_keys * DISK_OFFLOAD_USABLE_BUDGET_RATIO))
-
-
 def _split_disk_offload_load_batches(
     keys: list[str],
     addrs: list[list[int]],
@@ -191,7 +187,6 @@ def _split_disk_offload_load_batches(
     usable_budget_bytes: int,
     raw_budget_bytes: int,
 ) -> tuple[list[tuple[list[str], list[list[int]], list[list[int]]]], str | None]:
-    max_batch_keys = _get_usable_disk_offload_batch_key_count(len(keys))
     batches: list[tuple[list[str], list[list[int]], list[list[int]]]] = []
     batch_keys: list[str] = []
     batch_addrs: list[list[int]] = []
@@ -209,10 +204,7 @@ def _split_disk_offload_load_batches(
                 batch_bytes = 0
             batches.append(([key], [addr], [size]))
             continue
-        if batch_keys and (
-            batch_bytes + key_bytes > usable_budget_bytes
-            or len(batch_keys) >= max_batch_keys
-        ):
+        if batch_keys and batch_bytes + key_bytes > usable_budget_bytes:
             batches.append((batch_keys, batch_addrs, batch_sizes))
             batch_keys, batch_addrs, batch_sizes = [], [], []
             batch_bytes = 0
@@ -581,13 +573,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             total_staging_bytes = sum(
                 _estimate_disk_offload_staging_bytes(size) for size in size_list_c
             )
-            usable_batch_keys = _get_usable_disk_offload_batch_key_count(
-                len(key_list_c)
-            )
-            if (
-                total_staging_bytes > self.usable_disk_offload_buffer_budget_bytes
-                or len(key_list_c) > usable_batch_keys
-            ):
+            if total_staging_bytes > self.usable_disk_offload_buffer_budget_bytes:
                 assert self.disk_offload_buffer_budget_bytes is not None
                 load_batches, oversized_key = _split_disk_offload_load_batches(
                     key_list_c,


### PR DESCRIPTION
## Problem

On the owner-client path, `_get_disk_offload_buffer_budget_bytes()` always returns the 1.25 GB SSD-staging cap — regardless of whether SSD offload is configured. The split-trigger predicate in `KVCacheStoreRecvingThread` then fires on every load whose `len(keys) > int(len(keys) * 0.9)` — i.e. whenever there are 2 or more keys — doubling master GET-RPC pressure even though SSD offload isn't enabled.

The non-owner-client path already has an `enable_offload` guard. This PR mirrors it on the owner-client path, then removes the always-true count predicate.

## Changes

- Add `enable_offload: bool = False` to `MooncakeStoreConfig`. `from_file()` reads it from the JSON config (key `enable_offload`) or the `MOONCAKE_ENABLE_OFFLOAD` env var.
- `_get_disk_offload_buffer_budget_bytes(enable_offload)` returns `None` when offload is off, so the existing `usable_disk_offload_buffer_budget_bytes is not None` gate keeps the split path skipped.
- Drop `_get_usable_disk_offload_batch_key_count` and both call sites; the byte budget is the legitimate split constraint.

## Validation

Kimi-K2.5-NVFP4 reference workload (mtc=96, num_prompts=192, turns=10, output=300, prefix-conv=0.75) on GB200 NVL72:

| P:D | before TTFT | after TTFT | non-owner ref | items/req |
|-----|------------:|-----------:|--------------:|----------:|
| 2p2d | 45 765 ms | 44 081 ms | 42 944 ms | 410 → 820 |
| 3p3d | 33 630 ms | 32 666 ms | 32 189 ms | 410 → 820 |

Closes the previously observed −6.2 % (2p2d) / −4.3 % (3p3d) TTFT gap between the owner-client and non-owner architectures down to inside run-to-run noise.

### Compare links (MQA dashboard, --dev schema)

- 2p2d (baseline → patched → non-owner): https://mqa.inferact.ai/perf/compare?ids=b829d076-6ee0-4f12-9bea-b87aee0dfca4,3186d8ae-84f1-414c-852a-d03adaecf2db,9ab5cd47-6d54-4d7f-8d85-56a49181b998
- 3p3d (baseline → patched → non-owner): https://mqa.inferact.ai/perf/compare?ids=c224a8d4-7a24-4377-83a3-f7037de2d0f7,6949e69d-ba14-4768-a41f-cf89f6522a43,521d382d-4430-4e94-9946-dea97325bf59

🤖 Generated with [Claude Code](https://claude.com/claude-code)