### PR TITLE
mooncake: read preferred_segment from environment

### DIFF
--- a/scripts/mooncake/run_vllm_with_mooncake_owner.sh
+++ b/scripts/mooncake/run_vllm_with_mooncake_owner.sh
@@ -359,6 +359,9 @@ if [[ -z "${OWNER_HOST//[[:space:]]/}" ]]; then
     exit 1
 fi
 
+export MOONCAKE_PREFERRED_SEGMENT="${OWNER_HOST}:${OWNER_SEGMENT_PORT}"
+echo "Mooncake preferred segment: $MOONCAKE_PREFERRED_SEGMENT"
+
 OWNER_CMD=(
     bash "${SCRIPT_DIR}/start_mooncake_owner.sh"
     --cpu-mem-size "$OWNER_CPU_MEM_GIB"

--- a/scripts/mooncake/run_vllm_with_mooncake_owner.sh
+++ b/scripts/mooncake/run_vllm_with_mooncake_owner.sh
@@ -344,11 +344,6 @@ if [[ "$MOONCAKE_PROTOCOL" == "rdma" || "$MOONCAKE_PROTOCOL" == "efa" ]]; then
     fi
 fi
 
-if command_has_kv_transfer_config "$@"; then
-    echo "Error: run_vllm_with_mooncake_owner.sh injects Mooncake --kv-transfer-config automatically. Remove the explicit --kv-transfer-config from the wrapped command." >&2
-    exit 1
-fi
-
 prepare_owner_disk_path
 
 if [[ -z "${OWNER_HOST//[[:space:]]/}" ]]; then
@@ -385,8 +380,6 @@ if [[ -n "$OWNER_HOST" ]]; then
     OWNER_CMD+=(--host "$OWNER_HOST")
 fi
 
-KV_TRANSFER_CONFIG_JSON="$(build_kv_transfer_config_json)"
-
 echo "Mooncake master: $MOONCAKE_MASTER"
 echo "Mooncake metadata server: $MOONCAKE_TE_META_DATA_SERVER"
 if [[ -n "${MC_GID_INDEX:-}" ]]; then
@@ -399,7 +392,13 @@ if [[ -n "${OWNER_DEVICE:-}" ]]; then
     echo "Detected owner RNICs: $OWNER_DEVICE"
 fi
 
-SERVER_CMD=("$@" "--kv-transfer-config" "$KV_TRANSFER_CONFIG_JSON")
+if command_has_kv_transfer_config "$@"; then
+    echo "Wrapped command already has --kv-transfer-config; skipping wrapper auto-inject."
+    SERVER_CMD=("$@")
+else
+    KV_TRANSFER_CONFIG_JSON="$(build_kv_transfer_config_json)"
+    SERVER_CMD=("$@" "--kv-transfer-config" "$KV_TRANSFER_CONFIG_JSON")
+fi
 
 trap cleanup EXIT INT TERM
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -218,6 +218,23 @@ def test_get_configured_preferred_segment_returns_explicit_override():
     )
 
 
+def test_get_configured_preferred_segment_prefers_explicit_over_env(monkeypatch):
+    monkeypatch.setenv("MOONCAKE_PREFERRED_SEGMENT", "10.0.0.8:50053")
+
+    assert (
+        rdma_utils.get_configured_preferred_segment(
+            {"preferred_segment": "10.0.0.7:50053"}
+        )
+        == "10.0.0.7:50053"
+    )
+
+
+def test_get_configured_preferred_segment_returns_env_override(monkeypatch):
+    monkeypatch.setenv("MOONCAKE_PREFERRED_SEGMENT", "10.0.0.8:50053")
+
+    assert rdma_utils.get_configured_preferred_segment({}) == "10.0.0.8:50053"
+
+
 def test_get_configured_preferred_segment_rejects_empty_override():
     with pytest.raises(ValueError, match="preferred_segment"):
         rdma_utils.get_configured_preferred_segment({"preferred_segment": "  "})

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -3,9 +3,6 @@
 """Minimal Mooncake requester config helpers."""
 
 import os
-import re
-import socket
-import urllib.request
 from collections.abc import Mapping
 from typing import Any
 
@@ -15,10 +12,7 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-_SEGMENT_METRIC_RE = re.compile(
-    r'^segment_total_capacity_bytes\{segment="([^"]+)"\}\s+', re.MULTILINE
-)
-_AUTO_DETECT_TIMEOUT_SECONDS = 2.0
+_PREFERRED_SEGMENT_ENV = "MOONCAKE_PREFERRED_SEGMENT"
 
 
 def normalize_string_override(value: Any) -> str | None:
@@ -51,59 +45,6 @@ def get_requester_local_hostname(local_ip: str) -> str:
     return local_ip
 
 
-def _enumerate_local_ipv4_addresses() -> set[str]:
-    """Return all local non-loopback IPv4 addresses across every NIC."""
-    try:
-        import psutil
-    except ImportError:
-        return set()
-    addresses: set[str] = set()
-    try:
-        for _, addrs in psutil.net_if_addrs().items():
-            for addr in addrs:
-                if addr.family != socket.AF_INET:
-                    continue
-                if not addr.address or addr.address.startswith("127."):
-                    continue
-                addresses.add(addr.address)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("Mooncake could not enumerate local IPs: %s", exc)
-    return addresses
-
-
-def _fetch_master_segments(metrics_url: str) -> list[str]:
-    """Pull `segment_total_capacity_bytes` labels from the master /metrics page."""
-    try:
-        with urllib.request.urlopen(  # noqa: S310 - operator-controlled URL
-            metrics_url, timeout=_AUTO_DETECT_TIMEOUT_SECONDS
-        ) as resp:
-            text = resp.read().decode("utf-8", errors="replace")
-    except Exception as exc:
-        logger.debug(
-            "Mooncake could not fetch master metrics from %s: %s", metrics_url, exc
-        )
-        return []
-    return _SEGMENT_METRIC_RE.findall(text)
-
-
-def _auto_detect_preferred_segment(metrics_url: str) -> str | None:
-    """Pick the master segment whose host matches a local IP, or None."""
-    local_ips = _enumerate_local_ipv4_addresses()
-    if not local_ips:
-        return None
-    for segment in _fetch_master_segments(metrics_url):
-        host, _, _ = segment.partition(":")
-        if host in local_ips:
-            logger.info(
-                "Mooncake auto-detected local owner segment %s from master "
-                "/metrics (matched local IP %s)",
-                segment,
-                host,
-            )
-            return segment
-    return None
-
-
 def get_configured_preferred_segment(
     extra_config: Mapping[str, Any],
 ) -> str | None:
@@ -115,16 +56,15 @@ def get_configured_preferred_segment(
             "Mooncake preferred_segment override must be a non-empty string"
         )
 
-    # Auto-detect: query master /metrics, find the segment whose host matches
-    # any local IP. This is best-effort — failures fall back to None (random
-    # allocator), so the worker still functions in deployments without an
-    # accessible master HTTP endpoint.
-    metrics_url = normalize_string_override(
-        extra_config.get("master_metrics_url")
-    ) or normalize_string_override(os.getenv("MOONCAKE_MASTER_METRICS_URL"))
-    if metrics_url is None:
-        return None
-    return _auto_detect_preferred_segment(metrics_url)
+    env_value = normalize_string_override(os.getenv(_PREFERRED_SEGMENT_ENV))
+    if env_value is not None:
+        logger.info(
+            "Mooncake preferred_segment from %s: %s",
+            _PREFERRED_SEGMENT_ENV,
+            env_value,
+        )
+        return env_value
+    return None
 
 
 def _get_explicit_worker_rnic(device_list: str) -> str:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -3,6 +3,9 @@
 """Minimal Mooncake requester config helpers."""
 
 import os
+import re
+import socket
+import urllib.request
 from collections.abc import Mapping
 from typing import Any
 
@@ -11,6 +14,11 @@ import torch
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+_SEGMENT_METRIC_RE = re.compile(
+    r'^segment_total_capacity_bytes\{segment="([^"]+)"\}\s+', re.MULTILINE
+)
+_AUTO_DETECT_TIMEOUT_SECONDS = 2.0
 
 
 def normalize_string_override(value: Any) -> str | None:
@@ -43,6 +51,59 @@ def get_requester_local_hostname(local_ip: str) -> str:
     return local_ip
 
 
+def _enumerate_local_ipv4_addresses() -> set[str]:
+    """Return all local non-loopback IPv4 addresses across every NIC."""
+    try:
+        import psutil
+    except ImportError:
+        return set()
+    addresses: set[str] = set()
+    try:
+        for _, addrs in psutil.net_if_addrs().items():
+            for addr in addrs:
+                if addr.family != socket.AF_INET:
+                    continue
+                if not addr.address or addr.address.startswith("127."):
+                    continue
+                addresses.add(addr.address)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Mooncake could not enumerate local IPs: %s", exc)
+    return addresses
+
+
+def _fetch_master_segments(metrics_url: str) -> list[str]:
+    """Pull `segment_total_capacity_bytes` labels from the master /metrics page."""
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - operator-controlled URL
+            metrics_url, timeout=_AUTO_DETECT_TIMEOUT_SECONDS
+        ) as resp:
+            text = resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:
+        logger.debug(
+            "Mooncake could not fetch master metrics from %s: %s", metrics_url, exc
+        )
+        return []
+    return _SEGMENT_METRIC_RE.findall(text)
+
+
+def _auto_detect_preferred_segment(metrics_url: str) -> str | None:
+    """Pick the master segment whose host matches a local IP, or None."""
+    local_ips = _enumerate_local_ipv4_addresses()
+    if not local_ips:
+        return None
+    for segment in _fetch_master_segments(metrics_url):
+        host, _, _ = segment.partition(":")
+        if host in local_ips:
+            logger.info(
+                "Mooncake auto-detected local owner segment %s from master "
+                "/metrics (matched local IP %s)",
+                segment,
+                host,
+            )
+            return segment
+    return None
+
+
 def get_configured_preferred_segment(
     extra_config: Mapping[str, Any],
 ) -> str | None:
@@ -53,7 +114,17 @@ def get_configured_preferred_segment(
         raise ValueError(
             "Mooncake preferred_segment override must be a non-empty string"
         )
-    return None
+
+    # Auto-detect: query master /metrics, find the segment whose host matches
+    # any local IP. This is best-effort — failures fall back to None (random
+    # allocator), so the worker still functions in deployments without an
+    # accessible master HTTP endpoint.
+    metrics_url = normalize_string_override(
+        extra_config.get("master_metrics_url")
+    ) or normalize_string_override(os.getenv("MOONCAKE_MASTER_METRICS_URL"))
+    if metrics_url is None:
+        return None
+    return _auto_detect_preferred_segment(metrics_url)
 
 
 def _get_explicit_worker_rnic(device_list: str) -> str:


### PR DESCRIPTION
## Problem

Owner-client deployments need MooncakeStore puts to prefer the node-local owner segment. With a shared YAML recipe, `preferred_segment` is per-instance state and should be injected by the launcher or owner wrapper after it determines the node-local advertised host.

## Changes

- Keep explicit `extra_config.preferred_segment` as the highest-priority override for backwards compatibility and manual overrides.
- Export `MOONCAKE_PREFERRED_SEGMENT=<owner_host>:<owner_segment_port>` from `run_vllm_with_mooncake_owner.sh`.
- Read `MOONCAKE_PREFERRED_SEGMENT` as the narrow vLLM fallback when no explicit `preferred_segment` is configured.
- Let the owner wrapper skip default `--kv-transfer-config` injection when the wrapped vLLM command already supplies one, so PD MultiConnector recipes can still use the managed owner path.
- Avoid scraping Mooncake master `/metrics`; topology selection stays with the component that starts the node-local owner and knows its advertised `host:port`.

## Why this is not duplicating an existing PR

I checked the related open work in this fork before updating the PR. This is the small wrapper + vLLM consumer path for the owner-wrapper-provided `MOONCAKE_PREFERRED_SEGMENT` hint, and no open PR in this fork currently carries that complete path.

## Validation

```bash
bash -n scripts/mooncake/run_vllm_with_mooncake_owner.sh

uv run --active --no-sync /home/aoshen/code/uv_envs/py312/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py \
  -k 'get_configured_preferred_segment' -v
```

Result: `4 passed, 26 deselected`.

## AI assistance

AI assistance was used. The submitting human should review every changed line and validate the deployment behavior before merge.

Co-authored-by: OpenAI Codex <codex@openai.com>