### PR TITLE
[Mooncake] Docker: build Mooncake from fork + libyaml-cpp0.7 runtime install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -796,6 +796,50 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
         ); \
+        # Install mooncake-transfer-engine from the zhewenl/Mooncake-rdma fork
+        # (based on ivanium/Mooncake@yifan/dev). The fork adds the dmabuf
+        # sub-allocation-address fix that upstream kvcache-ai/Mooncake lacks:
+        # upstream calls ibv_reg_dmabuf_mr with a tensor's sub-address instead
+        # of the true CUDA allocation base, which EFAULTs on vLLM KV caches
+        # that are sub-views of a larger PyTorch allocation. The fork also
+        # carries a glog 0.4 compat shim for Ubuntu 22.04.
+        # Built from source on both x86_64 and aarch64 — the upstream x86_64
+        # wheel has the dmabuf bug, and the upstream aarch64 wheel additionally
+        # needs glibc 2.39 (Ubuntu 24.04+) which the 22.04 base doesn't provide.
+        MOONCAKE_BUILD_PKGS="cmake ninja-build git \
+            libgoogle-glog-dev libgtest-dev libjsoncpp-dev libunwind-dev \
+            libpython3-dev libboost-all-dev libssl-dev \
+            libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+            libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+            libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev pkg-config patchelf"; \
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends ${MOONCAKE_BUILD_PKGS} && \
+        git clone --branch compat/ubuntu-22.04 --depth 1 --recurse-submodules \
+            https://github.com/zhewenl/Mooncake-rdma.git /tmp/Mooncake && \
+        cd /tmp/Mooncake/extern/yalantinglibs && mkdir -p build && cd build && \
+        cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF && \
+        cmake --build . -j$(nproc) && cmake --install . && \
+        cd /tmp/Mooncake && \
+        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH} && \
+        mkdir -p build && cd build && \
+        cmake .. -DUSE_CUDA=ON -DWITH_NVIDIA_PEERMEM=OFF -DUSE_MNNVL=ON \
+            -DPython3_EXECUTABLE=$(which python3) \
+            -DPYTHON_EXECUTABLE=$(which python3) && \
+        make -j$(nproc) && make install && \
+        strings /usr/local/lib/python${PYTHON_VERSION}/dist-packages/mooncake/engine*.so \
+            | grep -q "cuMemGetAddressRange" || \
+            { echo "ERROR: mooncake dmabuf fix missing in built binary"; exit 1; } && \
+        cd / && rm -rf /tmp/Mooncake && \
+        apt-get purge -y ${MOONCAKE_BUILD_PKGS} && \
+        apt-get install -y --no-install-recommends \
+            libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
+            libjemalloc2 libhiredis0.14 libcurl4 && \
+        apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
+        if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
+            ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \
+        elif [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.12 ]; then \
+            ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so; \
+        fi; \
     fi
 
 ENV VLLM_USAGE_SOURCE production-docker-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -833,7 +833,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         apt-get purge -y ${MOONCAKE_BUILD_PKGS} && \
         apt-get install -y --no-install-recommends \
             libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
-            libjemalloc2 libhiredis0.14 libcurl4 && \
+            libjemalloc2 libhiredis0.14 libcurl4 libyaml-cpp0.7 && \
         apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
         if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
             ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \

--- a/docker/Dockerfile.mooncake-layer
+++ b/docker/Dockerfile.mooncake-layer
@@ -1,0 +1,67 @@
+ARG BASE_IMAGE=inferactinc/public:crusoe-kimi-pd-20260415
+FROM ${BASE_IMAGE}
+
+# Rebuild mooncake-transfer-engine from zhewenl/Mooncake-rdma (compat/ubuntu-22.04)
+# on top of an already-built image whose mooncake wheel has the dmabuf
+# sub-allocation-address bug (upstream kvcache-ai/Mooncake v0.3.10.post*).
+#
+# The fork is based on ivanium/Mooncake@yifan/dev, plus a LOG_EVERY_T→LOG shim
+# for glog 0.4 (Ubuntu 22.04 ships glog 0.4; the fork requires 0.6). It fixes
+# ibv_reg_dmabuf_mr to resolve the true CUDA allocation base via
+# cuMemGetAddressRange, so vLLM KV caches (sub-views of a larger PyTorch
+# allocation) register successfully instead of returning EFAULT.
+#
+# WITH_NVIDIA_PEERMEM=OFF enables the dmabuf code path (nvidia-peermem is not
+# loadable on GB200, and dmabuf works on H200/H100 too).
+#
+# Usage:
+#   docker build -f docker/Dockerfile.mooncake-layer \
+#     --build-arg BASE_IMAGE=inferactinc/dev:svf-x86_64-cu130-b641ede \
+#     -t inferactinc/dev:svf-x86_64-cu130-b641ede-mcfix .
+RUN set -e && \
+    PY=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build git wget unzip \
+        libibverbs-dev libgoogle-glog-dev libgtest-dev libjsoncpp-dev \
+        libunwind-dev libnuma-dev libpython3-dev libboost-all-dev libssl-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+        libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+        libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev \
+        pkg-config patchelf libc6-dev libc-bin && \
+    git clone --branch compat/ubuntu-22.04 --depth 1 --recurse-submodules \
+        https://github.com/zhewenl/Mooncake-rdma.git /tmp/Mooncake && \
+    cd /tmp/Mooncake/extern/yalantinglibs && mkdir -p build && cd build && \
+    cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF && \
+    cmake --build . -j$(nproc) && cmake --install . && \
+    cd /tmp/Mooncake && \
+    export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH} && \
+    mkdir -p build && cd build && \
+    cmake .. -DUSE_CUDA=ON -DWITH_NVIDIA_PEERMEM=OFF -DUSE_MNNVL=ON \
+        -DPython3_EXECUTABLE=$(which python3) \
+        -DPYTHON_EXECUTABLE=$(which python3) && \
+    make -j$(nproc) && make install && \
+    strings /usr/local/lib/python${PY}/dist-packages/mooncake/engine*.so \
+        | grep -q "cuMemGetAddressRange" || \
+        { echo "ERROR: mooncake dmabuf fix missing in built binary"; exit 1; } && \
+    echo "VERIFIED: dmabuf sub-address fix compiled" && \
+    cd / && rm -rf /tmp/Mooncake && \
+    apt-get purge -y \
+        cmake ninja-build git wget unzip \
+        libgoogle-glog-dev libgtest-dev libjsoncpp-dev \
+        libunwind-dev libpython3-dev libboost-all-dev libssl-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+        libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+        libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev \
+        pkg-config patchelf && \
+    apt-get install -y --no-install-recommends \
+        libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
+        libjemalloc2 libhiredis0.14 libcurl4 && \
+    apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
+    if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
+        ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \
+    elif [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.12 ]; then \
+        ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so; \
+    fi
+
+ENTRYPOINT ["vllm", "serve"]

--- a/docker/Dockerfile.mooncake-layer
+++ b/docker/Dockerfile.mooncake-layer
@@ -56,7 +56,7 @@ RUN set -e && \
         pkg-config patchelf && \
     apt-get install -y --no-install-recommends \
         libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
-        libjemalloc2 libhiredis0.14 libcurl4 && \
+        libjemalloc2 libhiredis0.14 libcurl4 libyaml-cpp0.7 && \
     apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
     if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
         ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -2,4 +2,12 @@ lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1 # Required for disaggregated prefill
 nixl-cu12 >= 0.7.1, <= 0.10.1
 nixl-cu13 >= 0.7.1, <= 0.10.1
-mooncake-transfer-engine >= 0.3.8
+# mooncake-transfer-engine is built from source in docker/Dockerfile
+# (both x86_64 and aarch64) from the zhewenl/Mooncake-rdma fork. The fork
+# adds a dmabuf sub-allocation-address fix that upstream kvcache-ai/Mooncake
+# lacks: with WITH_NVIDIA_PEERMEM=OFF, upstream calls ibv_reg_dmabuf_mr with
+# a tensor's sub-address into a larger PyTorch allocation, which EFAULTs on
+# vLLM KV caches (sub-views of a single torch.cuda.memory_pool allocation).
+# The aarch64 path additionally needs this fork because the upstream aarch64
+# wheel is built for glibc 2.39 (Ubuntu 24.04+), incompatible with our
+# Ubuntu 22.04 base (glibc 2.35).


### PR DESCRIPTION
## Summary

Docker-only branch carrying two commits on top of `feat/mooncake-store-int`:

- `4d21f450` — `chore(docker): build Mooncake from zhewenl/Mooncake-rdma fork`. Cherry-picked from [Inferact/vllm-svf#159](https://github.com/Inferact/vllm-svf/pull/159). Builds `mooncake-transfer-engine` from the fork's `compat/ubuntu-22.04` branch on x86_64 and aarch64. Adds a standalone `docker/Dockerfile.mooncake-layer` for rebuilding the binary on top of an already-built image. Comments out the `mooncake-transfer-engine` pip pin in `requirements/kv_connectors.txt` because the wheel is replaced by the source build.

- `6d76a532` — `docker: install libyaml-cpp0.7 in runtime stage`. Installs `libyaml-cpp0.7` in the runtime apt layer of `docker/Dockerfile` and `docker/Dockerfile.mooncake-layer` so the standalone `mooncake_master` C++ binary, which links against `libyaml-cpp.so.0.7`, can start.

## Scope change

Earlier revisions of this branch also carried the HMA-support cherry-picks from [ivanium/vllm#33](https://github.com/ivanium/vllm/pull/33). Those have been dropped — this branch is now docker-only. Use #33 directly for the connector-side HMA work.

## Status

Draft. Reviewable combined branch for image builds.
