### PR TITLE
docker: install libyaml-cpp0.7 in runtime stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -796,6 +796,50 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             # clean up -dev packages, keep runtime libraries
             rm -rf /var/lib/apt/lists/* \
         ); \
+        # Install mooncake-transfer-engine from the zhewenl/Mooncake-rdma fork
+        # (based on ivanium/Mooncake@yifan/dev). The fork adds the dmabuf
+        # sub-allocation-address fix that upstream kvcache-ai/Mooncake lacks:
+        # upstream calls ibv_reg_dmabuf_mr with a tensor's sub-address instead
+        # of the true CUDA allocation base, which EFAULTs on vLLM KV caches
+        # that are sub-views of a larger PyTorch allocation. The fork also
+        # carries a glog 0.4 compat shim for Ubuntu 22.04.
+        # Built from source on both x86_64 and aarch64 — the upstream x86_64
+        # wheel has the dmabuf bug, and the upstream aarch64 wheel additionally
+        # needs glibc 2.39 (Ubuntu 24.04+) which the 22.04 base doesn't provide.
+        MOONCAKE_BUILD_PKGS="cmake ninja-build git \
+            libgoogle-glog-dev libgtest-dev libjsoncpp-dev libunwind-dev \
+            libpython3-dev libboost-all-dev libssl-dev \
+            libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+            libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+            libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev pkg-config patchelf"; \
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends ${MOONCAKE_BUILD_PKGS} && \
+        git clone --branch compat/ubuntu-22.04 --depth 1 --recurse-submodules \
+            https://github.com/zhewenl/Mooncake-rdma.git /tmp/Mooncake && \
+        cd /tmp/Mooncake/extern/yalantinglibs && mkdir -p build && cd build && \
+        cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF && \
+        cmake --build . -j$(nproc) && cmake --install . && \
+        cd /tmp/Mooncake && \
+        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH} && \
+        mkdir -p build && cd build && \
+        cmake .. -DUSE_CUDA=ON -DWITH_NVIDIA_PEERMEM=OFF -DUSE_MNNVL=ON \
+            -DPython3_EXECUTABLE=$(which python3) \
+            -DPYTHON_EXECUTABLE=$(which python3) && \
+        make -j$(nproc) && make install && \
+        strings /usr/local/lib/python${PYTHON_VERSION}/dist-packages/mooncake/engine*.so \
+            | grep -q "cuMemGetAddressRange" || \
+            { echo "ERROR: mooncake dmabuf fix missing in built binary"; exit 1; } && \
+        cd / && rm -rf /tmp/Mooncake && \
+        apt-get purge -y ${MOONCAKE_BUILD_PKGS} && \
+        apt-get install -y --no-install-recommends \
+            libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
+            libjemalloc2 libhiredis0.14 libcurl4 && \
+        apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
+        if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
+            ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \
+        elif [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.12 ]; then \
+            ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so; \
+        fi; \
     fi
 
 ENV VLLM_USAGE_SOURCE production-docker-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -833,7 +833,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         apt-get purge -y ${MOONCAKE_BUILD_PKGS} && \
         apt-get install -y --no-install-recommends \
             libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
-            libjemalloc2 libhiredis0.14 libcurl4 && \
+            libjemalloc2 libhiredis0.14 libcurl4 libyaml-cpp0.7 && \
         apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
         if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
             ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \

--- a/docker/Dockerfile.mooncake-layer
+++ b/docker/Dockerfile.mooncake-layer
@@ -1,0 +1,67 @@
+ARG BASE_IMAGE=inferactinc/public:crusoe-kimi-pd-20260415
+FROM ${BASE_IMAGE}
+
+# Rebuild mooncake-transfer-engine from zhewenl/Mooncake-rdma (compat/ubuntu-22.04)
+# on top of an already-built image whose mooncake wheel has the dmabuf
+# sub-allocation-address bug (upstream kvcache-ai/Mooncake v0.3.10.post*).
+#
+# The fork is based on ivanium/Mooncake@yifan/dev, plus a LOG_EVERY_T→LOG shim
+# for glog 0.4 (Ubuntu 22.04 ships glog 0.4; the fork requires 0.6). It fixes
+# ibv_reg_dmabuf_mr to resolve the true CUDA allocation base via
+# cuMemGetAddressRange, so vLLM KV caches (sub-views of a larger PyTorch
+# allocation) register successfully instead of returning EFAULT.
+#
+# WITH_NVIDIA_PEERMEM=OFF enables the dmabuf code path (nvidia-peermem is not
+# loadable on GB200, and dmabuf works on H200/H100 too).
+#
+# Usage:
+#   docker build -f docker/Dockerfile.mooncake-layer \
+#     --build-arg BASE_IMAGE=inferactinc/dev:svf-x86_64-cu130-b641ede \
+#     -t inferactinc/dev:svf-x86_64-cu130-b641ede-mcfix .
+RUN set -e && \
+    PY=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build git wget unzip \
+        libibverbs-dev libgoogle-glog-dev libgtest-dev libjsoncpp-dev \
+        libunwind-dev libnuma-dev libpython3-dev libboost-all-dev libssl-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+        libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+        libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev \
+        pkg-config patchelf libc6-dev libc-bin && \
+    git clone --branch compat/ubuntu-22.04 --depth 1 --recurse-submodules \
+        https://github.com/zhewenl/Mooncake-rdma.git /tmp/Mooncake && \
+    cd /tmp/Mooncake/extern/yalantinglibs && mkdir -p build && cd build && \
+    cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF && \
+    cmake --build . -j$(nproc) && cmake --install . && \
+    cd /tmp/Mooncake && \
+    export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH} && \
+    mkdir -p build && cd build && \
+    cmake .. -DUSE_CUDA=ON -DWITH_NVIDIA_PEERMEM=OFF -DUSE_MNNVL=ON \
+        -DPython3_EXECUTABLE=$(which python3) \
+        -DPYTHON_EXECUTABLE=$(which python3) && \
+    make -j$(nproc) && make install && \
+    strings /usr/local/lib/python${PY}/dist-packages/mooncake/engine*.so \
+        | grep -q "cuMemGetAddressRange" || \
+        { echo "ERROR: mooncake dmabuf fix missing in built binary"; exit 1; } && \
+    echo "VERIFIED: dmabuf sub-address fix compiled" && \
+    cd / && rm -rf /tmp/Mooncake && \
+    apt-get purge -y \
+        cmake ninja-build git wget unzip \
+        libgoogle-glog-dev libgtest-dev libjsoncpp-dev \
+        libunwind-dev libpython3-dev libboost-all-dev libssl-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev libyaml-cpp-dev protobuf-compiler-grpc \
+        libcurl4-openssl-dev libhiredis-dev liburing-dev libjemalloc-dev \
+        libmsgpack-dev libzstd-dev libasio-dev libxxhash-dev \
+        pkg-config patchelf && \
+    apt-get install -y --no-install-recommends \
+        libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
+        libjemalloc2 libhiredis0.14 libcurl4 && \
+    apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
+    if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
+        ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \
+    elif [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.12 ]; then \
+        ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so; \
+    fi
+
+ENTRYPOINT ["vllm", "serve"]

--- a/docker/Dockerfile.mooncake-layer
+++ b/docker/Dockerfile.mooncake-layer
@@ -56,7 +56,7 @@ RUN set -e && \
         pkg-config patchelf && \
     apt-get install -y --no-install-recommends \
         libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2 \
-        libjemalloc2 libhiredis0.14 libcurl4 && \
+        libjemalloc2 libhiredis0.14 libcurl4 libyaml-cpp0.7 && \
     apt-get autoremove -y && rm -rf /var/lib/apt/lists/* && \
     if [ ! -f /usr/local/cuda/lib64/libcudart.so ] && [ -f /usr/local/cuda/lib64/libcudart.so.13 ]; then \
         ln -s libcudart.so.13 /usr/local/cuda/lib64/libcudart.so; \

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -2,4 +2,12 @@ lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, <= 0.10.1 # Required for disaggregated prefill
 nixl-cu12 >= 0.7.1, <= 0.10.1
 nixl-cu13 >= 0.7.1, <= 0.10.1
-mooncake-transfer-engine >= 0.3.8
+# mooncake-transfer-engine is built from source in docker/Dockerfile
+# (both x86_64 and aarch64) from the zhewenl/Mooncake-rdma fork. The fork
+# adds a dmabuf sub-allocation-address fix that upstream kvcache-ai/Mooncake
+# lacks: with WITH_NVIDIA_PEERMEM=OFF, upstream calls ibv_reg_dmabuf_mr with
+# a tensor's sub-address into a larger PyTorch allocation, which EFAULTs on
+# vLLM KV caches (sub-views of a single torch.cuda.memory_pool allocation).
+# The aarch64 path additionally needs this fork because the upstream aarch64
+# wheel is built for glibc 2.39 (Ubuntu 24.04+), incompatible with our
+# Ubuntu 22.04 base (glibc 2.35).

--- a/tests/v1/kv_connector/unit/test_mooncake_lookup_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_lookup_coordinator.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MooncakeLookupCoordinator.
+
+These tests build the synthetic block pool directly from per-(chunk, group)
+exists results and verify that ``find_longest_cache_hit`` produces the
+expected hit length. No vllm scheduler / worker / Mooncake instances
+required.
+"""
+
+import pytest
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+    MooncakeLookupCoordinator,
+)
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
+
+
+def _make_block_hashes(n: int) -> list[BlockHash]:
+    """Distinct 8-byte block hashes for testing concat behavior."""
+    return [BlockHash(i.to_bytes(8, "big")) for i in range(n)]
+
+
+def _fa_spec(block_size: int = 16) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+    )
+
+
+def _swa_spec(block_size: int = 16, sliding_window: int = 64) -> SlidingWindowSpec:
+    return SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=sliding_window,
+    )
+
+
+def _make_config(specs: list) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer{i}"], spec) for i, spec in enumerate(specs)
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# FA-only: aggregator should match a flat "first-miss in chunk space" walk.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cpu_test
+def test_fa_only_full_hit():
+    """All chunks present → hit length == max."""
+    block_size = 16
+    config = _make_config([_fa_spec(block_size=block_size)])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)  # 8 chunks * 16 tokens = 128 tokens
+    exists = {(i, 0): 1 for i in range(8)}
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    assert hit == 128
+
+
+@pytest.mark.cpu_test
+def test_fa_only_first_chunk_miss():
+    """Miss at chunk 0 caps hit at 0."""
+    block_size = 16
+    config = _make_config([_fa_spec(block_size=block_size)])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {(i, 0): (1 if i > 0 else 0) for i in range(8)}
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    assert hit == 0
+
+
+@pytest.mark.cpu_test
+def test_fa_only_mid_chunk_miss():
+    """Miss at chunk 3 → hit length = 3 * block_size."""
+    block_size = 16
+    config = _make_config([_fa_spec(block_size=block_size)])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {(i, 0): (0 if i == 3 else 1) for i in range(8)}
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    # FA's manager walks 0..max, breaks on first miss → 3 chunks hit.
+    assert hit == 3 * block_size
+
+
+# ---------------------------------------------------------------------------
+# FA + SWA: SWA's window shifts as FA shrinks max_length (the bug fix).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cpu_test
+def test_fa_plus_swa_all_hit():
+    """All FA chunks + last 3 SWA chunks present → full hit."""
+    block_size = 16
+    sliding_window = 32  # → blocks_per_sw = ceil((32-1)/16) = 2 contiguous blocks
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {}
+    for cid in range(8):
+        exists[(cid, 0)] = 1
+        exists[(cid, 1)] = 1
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    assert hit == 128
+
+
+@pytest.mark.cpu_test
+def test_fa_plus_swa_fa_miss_caps_hit():
+    """FA misses at chunk 5; SWA window for the FA-clipped length must hit too."""
+    block_size = 16
+    sliding_window = 32
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {}
+    for cid in range(8):
+        exists[(cid, 0)] = 1 if cid != 5 else 0
+        exists[(cid, 1)] = 1  # SWA: every chunk has the byte
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    # FA caps to 5 chunks (80 tokens). SWA window at 80 has all chunks present.
+    assert hit == 5 * block_size
+
+
+@pytest.mark.cpu_test
+def test_fa_plus_swa_swa_window_miss_at_clipped_length():
+    """The bug-fix scenario:
+
+    FA hits everything (8 chunks). At max_length=128, SWA's window is
+    last 2 contiguous chunks (chunks 6, 7). Suppose SWA chunks 6, 7 hit
+    but chunks 4, 5 miss. The single-pass aggregation today would say
+    "all queried hits, return 128." With the iterative coordinator,
+    the answer should still be 128 because SWA's window at 128 only
+    needs chunks 6, 7 — earlier chunks aren't in window.
+    """
+    block_size = 16
+    sliding_window = 32
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {}
+    for cid in range(8):
+        exists[(cid, 0)] = 1  # FA all hit
+        # SWA: chunks 4, 5 absent (they aren't in window at full max_length)
+        exists[(cid, 1)] = 1 if cid not in (4, 5) else 0
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    assert hit == 128
+
+
+@pytest.mark.cpu_test
+def test_fa_plus_swa_iterative_shrink():
+    """The exact scenario the iterative loop is for.
+
+    FA misses at chunk 5 (hit = 80 tokens after FA).
+    SWA window at 80: last 2 chunks of cdiv(80,16)=5 chunks → chunks 3, 4.
+    But SWA chunks 3, 4 are absent (only chunks 6, 7 saved).
+    Coordinator must converge to a smaller hit_length where SWA window
+    is fully populated, not return 80.
+    """
+    block_size = 16
+    sliding_window = 32
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {}
+    for cid in range(8):
+        exists[(cid, 0)] = 1 if cid != 5 else 0  # FA miss at chunk 5
+        # SWA: only the LAST two chunks (6, 7) are saved, simulating
+        # full-prompt save with no chunked-prefill backfill.
+        exists[(cid, 1)] = 1 if cid in (6, 7) else 0
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=128)
+    # FA caps at 80; SWA window at 80 needs chunks 3, 4 which aren't there.
+    # Shrinks further. SWA window at 64 needs chunks 2, 3, ... none there
+    # either. Eventually 0.
+    assert hit == 0
+
+
+@pytest.mark.cpu_test
+def test_plan_store_returns_only_resident_group_chunks():
+    """Store planning should be spec/coordinator-owned, not worker SWA math.
+
+    FA has all 8 chunks resident. SWA's block table contains two physical
+    blocks, which correspond to the last two logical chunks for this request.
+    The worker should be able to consume this plan without knowing why group 1
+    is clipped.
+    """
+    block_size = 16
+    sliding_window = 32
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    block_ids = [list(range(8)), [100, 101]]
+
+    chunks = coord.plan_store_chunks(
+        token_len=8 * block_size,
+        block_hashes=hashes,
+        block_ids=block_ids,
+    )
+
+    assert [(c.group_id, c.chunk_id, c.start, c.end) for c in chunks] == [
+        *((0, i, i * block_size, (i + 1) * block_size) for i in range(8)),
+        (1, 6, 6 * block_size, 7 * block_size),
+        (1, 7, 7 * block_size, 8 * block_size),
+    ]
+
+
+@pytest.mark.cpu_test
+def test_plan_store_dsv4_shaped_resident_counts():
+    """DSV4-shaped groups store exactly their resident physical chunks."""
+    group_block_sizes = [256, 64, 64, 4, 8]
+    config = _make_config(
+        [_fa_spec(block_size=block_size) for block_size in group_block_sizes]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=4)
+    token_len = 12_000
+    hashes = _make_block_hashes(token_len // 4)
+    block_ids = [
+        list(range(47)),
+        list(range(3)),
+        list(range(3)),
+        list(range(3)),
+        list(range(17)),
+    ]
+
+    chunks = coord.plan_store_chunks(token_len, hashes, block_ids)
+
+    per_group_count = [0] * len(group_block_sizes)
+    chunk_ids_by_group: dict[int, list[int]] = {g: [] for g in range(5)}
+    for chunk in chunks:
+        per_group_count[chunk.group_id] += 1
+        chunk_ids_by_group[chunk.group_id].append(chunk.chunk_id)
+
+    assert per_group_count == [47, 3, 3, 3, 17]
+    assert chunk_ids_by_group[1] == [185, 186, 187]
+    assert chunk_ids_by_group[4][0] == 1483
+    assert chunk_ids_by_group[4][-1] == 1499
+
+
+@pytest.mark.cpu_test
+def test_dsv4_iter_group_chunks_emits_native_group_chunks():
+    """Coordinator chunking uses each group's native block size and right edge."""
+    group_block_sizes = [256, 64, 64, 4, 8]
+    config = _make_config(
+        [_fa_spec(block_size=block_size) for block_size in group_block_sizes]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=4)
+    token_len = 12_000
+    hashes = _make_block_hashes(token_len // 4)
+
+    by_group: dict[int, list[tuple[int, int, int]]] = {g: [] for g in range(5)}
+    for chunk in coord.iter_group_chunks(token_len, hashes):
+        by_group[chunk.group_id].append((chunk.start, chunk.end, chunk.hash_index))
+
+    assert [len(by_group[g]) for g in range(5)] == [47, 188, 188, 3000, 1500]
+    assert by_group[0][0] == (0, 256, 63)
+    assert by_group[0][1] == (256, 512, 127)
+    assert by_group[0][46] == (11776, 12000, 2999)
+    assert by_group[1][187] == (11968, 12000, 2999)
+    assert by_group[3][2999] == (11996, 12000, 2999)
+
+
+@pytest.mark.cpu_test
+def test_hit_blocks_can_be_converted_to_load_chunks():
+    """The coordinator should preserve block identity through vLLM managers.
+
+    ``find_longest_cache_hit`` returns null/skipped blocks for SWA prefix
+    positions and real blocks for the loaded window. The load plan must include
+    only the real Mooncake chunks.
+    """
+    block_size = 16
+    sliding_window = 32
+    config = _make_config(
+        [
+            _fa_spec(block_size=block_size),
+            _swa_spec(block_size=block_size, sliding_window=sliding_window),
+        ]
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(8)
+    exists = {}
+    for cid in range(8):
+        exists[(cid, 0)] = 1
+        exists[(cid, 1)] = 1 if cid in (6, 7) else 0
+    coord.block_pool = coord.build_block_pool(exists, hashes)
+
+    hit_blocks, hit = coord.find_longest_cache_hit(
+        hashes,
+        max_cache_hit_length=8 * block_size,
+    )
+    chunks = coord.plan_load_chunks_from_hit_blocks(hit_blocks)
+
+    assert hit == 8 * block_size
+    assert [(c.group_id, c.chunk_id) for c in chunks] == [
+        *((0, i) for i in range(8)),
+        (1, 6),
+        (1, 7),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Concat-hash mapping for HMA (group_block_size > hash_block_size).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cpu_test
+def test_concat_hash_lookup_for_larger_group_block_size():
+    """An HMA group whose block_size is 2 × hash_block_size needs concat hashes.
+
+    Build 16-byte block_hashes at hash_bs=8. A group with block_size=16
+    will probe with concat(h0+h1), concat(h2+h3), etc. Our pool must
+    answer 'cached' for those concat hashes when both halves were
+    saved by Mooncake.
+    """
+    hash_bs = 8
+    fa_block_size = 16  # 2 × hash_bs
+    config = _make_config([_fa_spec(block_size=fa_block_size)])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=hash_bs)
+    # 8 hashes at hash_bs → 4 chunks at FA's block_size=16.
+    hashes = _make_block_hashes(8)
+    # Mooncake: chunks 0, 1 saved; chunks 2, 3 missing.
+    exists = {
+        (0, 0): 1,
+        (1, 0): 1,
+        (2, 0): 0,
+        (3, 0): 0,
+    }
+    pool = coord.build_block_pool(exists, hashes)
+    # Token length = 4 chunks × 16 tokens = 64. FA breaks at first miss → 32.
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=64)
+    assert hit == 2 * fa_block_size
+
+
+# ---------------------------------------------------------------------------
+# Edge cases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.cpu_test
+def test_empty_block_hashes_returns_zero():
+    config = _make_config([_fa_spec()])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=16)
+    pool = coord.build_block_pool({}, [])
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit([], max_cache_hit_length=0)
+    assert hit == 0
+
+
+@pytest.mark.cpu_test
+def test_eagle_group_ids_preserved_through_unwrap():
+    """``is_eagle_group`` flags must propagate from the input config
+    into ``self.eagle_group_ids`` and ``self.eagle_attn_group_indices``.
+
+    Regression: previously the unwrap dropped the flag and __init__
+    set both eagle sets empty, silently disabling the parent's
+    extra-block match-and-drop and over-reporting hit length by one
+    block under spec-decode.
+    """
+    block_size = 16
+    fa = _fa_spec(block_size=block_size)
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer0"], fa, is_eagle_group=False),
+            KVCacheGroupSpec(["layer1"], fa, is_eagle_group=True),
+        ],
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    assert coord.eagle_group_ids == {1}
+    # Both groups have identical specs → merge into one attention_group;
+    # that attention_group contains group_id 1 → flagged eagle.
+    assert coord.eagle_attn_group_indices == {0}
+
+
+@pytest.mark.cpu_test
+def test_eagle_preserved_through_uniform_type_wrap():
+    """Unwrap from UniformTypeKVCacheSpecs MUST preserve is_eagle_group
+    on the new KVCacheGroupSpec — otherwise spec-decode workloads
+    silently lose EAGLE handling on the worker side.
+    """
+    from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
+    block_size = 16
+    fa = _fa_spec(block_size=block_size)
+    wrapped = UniformTypeKVCacheSpecs(
+        block_size=block_size, kv_cache_specs={"layer1": fa}
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer0"], fa, is_eagle_group=False),
+            KVCacheGroupSpec(["layer1"], wrapped, is_eagle_group=True),
+        ],
+    )
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    assert coord.eagle_group_ids == {1}
+
+
+@pytest.mark.cpu_test
+def test_use_eagle_flags_all_groups_when_none_annotated():
+    """Mirror parent ``KVCacheCoordinator.__init__`` fallback: when
+    ``use_eagle=True`` is passed and no group is explicitly flagged
+    via ``is_eagle_group``, treat all groups as eagle.
+
+    Without this, an EAGLE-enabled config without per-group annotations
+    would over-report hit length by one block (the parent's
+    extra-block match-and-drop wouldn't fire).
+    """
+    block_size = 16
+    config = _make_config([_fa_spec(block_size=block_size)])
+    # use_eagle=True, no is_eagle_group annotations
+    coord = MooncakeLookupCoordinator(
+        config, hash_block_size=block_size, use_eagle=True
+    )
+    # Expect ALL groups treated as eagle.
+    assert coord.eagle_group_ids == {0}
+    # use_eagle=False (default): no auto-annotation
+    coord2 = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    assert coord2.eagle_group_ids == set()
+
+
+@pytest.mark.cpu_test
+def test_hash_block_size_misalignment_raises():
+    """``HybridKVCacheCoordinator.__init__`` asserts every group's
+    ``block_size`` is divisible by ``hash_block_size``. Skipping the
+    parent's ``__init__`` means we have to recreate the invariant —
+    otherwise ``scale = block_size // hash_block_size`` silently
+    rounds and the concat hash mapping doesn't match vllm's
+    ``BlockHashListWithBlockSize``.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+        HashBlockSizeMisalignedError,
+    )
+
+    config = _make_config([_fa_spec(block_size=15)])  # 15 % 4 != 0
+    with pytest.raises(HashBlockSizeMisalignedError):
+        MooncakeLookupCoordinator(config, hash_block_size=4)
+
+
+@pytest.mark.cpu_test
+def test_unknown_manager_spec_raises():
+    """Unknown spec types fail closed at construction.
+
+    Caller (worker) catches ``UnknownManagerSpecError`` and disables external
+    hits. Silently skipping the unknown group would let the coordinator return
+    a hit length that ignored that group, producing a false external hit when
+    its data isn't in the store.
+    """
+    from dataclasses import dataclass
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+        UnknownManagerSpecError,
+    )
+    from vllm.v1.kv_cache_interface import KVCacheSpec
+
+    @dataclass(frozen=True, kw_only=True)
+    class _UnknownSpec(KVCacheSpec):
+        block_size: int
+        # Not registered in spec_manager_map → coordinator must refuse.
+
+    block_size = 16
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer0"], _fa_spec(block_size=block_size)),
+            KVCacheGroupSpec(["layer1"], _UnknownSpec(block_size=block_size)),
+        ],
+    )
+    with pytest.raises(UnknownManagerSpecError):
+        MooncakeLookupCoordinator(config, hash_block_size=block_size)
+
+
+@pytest.mark.cpu_test
+def test_uniform_type_wrapped_specs_unwrap():
+    """Worker-side configs wrap groups in UniformTypeKVCacheSpecs.
+
+    Regression: previously the coordinator did
+    ``spec_manager_map[type(spec)]`` directly and crashed with
+    ``KeyError: <class UniformTypeKVCacheSpecs>`` on DSV4-Flash
+    startup. The fix drills into ``kv_cache_specs`` to reach a
+    concrete inner spec.
+    """
+    from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
+    block_size = 16
+    inner_fa = _fa_spec(block_size=block_size)
+    wrapped = UniformTypeKVCacheSpecs(
+        block_size=block_size,
+        kv_cache_specs={"layer0": inner_fa},
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer0"], wrapped)],
+    )
+
+    # Should NOT raise KeyError. Coordinator unwraps and finds
+    # FullAttentionManager for the inner FullAttentionSpec.
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    assert len(coord.attention_groups) == 1
+    spec, group_ids, _manager_cls = coord.attention_groups[0]
+    assert group_ids == [0]
+    # Probe spec is the unwrapped inner spec, not the wrapper.
+    assert spec is inner_fa
+
+
+@pytest.mark.cpu_test
+def test_error_exists_treated_as_miss():
+    """exists == -1 (Mooncake error) folds to miss — never a false hit."""
+    block_size = 16
+    config = _make_config([_fa_spec(block_size=block_size)])
+    coord = MooncakeLookupCoordinator(config, hash_block_size=block_size)
+    hashes = _make_block_hashes(4)
+    exists = {(0, 0): 1, (1, 0): -1, (2, 0): 1, (3, 0): 1}
+    pool = coord.build_block_pool(exists, hashes)
+    coord.block_pool = pool
+    _hit_blocks, hit = coord.find_longest_cache_hit(hashes, max_cache_hit_length=64)
+    # Chunk 1 errored → treated as miss → hit = 1 chunk.
+    assert hit == block_size

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -64,7 +64,7 @@ def test_scheduler_role_initializes_store_scheduler_only():
             vllm_config, KVConnectorRole.SCHEDULER
         )
 
-    mock_scheduler.assert_called_once_with(vllm_config)
+    mock_scheduler.assert_called_once_with(vllm_config, kv_cache_config=None)
     mock_worker.assert_not_called()
     mock_lookup_server.assert_not_called()
     assert connector.connector_scheduler is mock_scheduler.return_value
@@ -94,7 +94,7 @@ def test_worker_role_initializes_store_worker_and_lookup_server_on_rank0():
         )
 
     mock_scheduler.assert_not_called()
-    mock_worker.assert_called_once_with(vllm_config)
+    mock_worker.assert_called_once_with(vllm_config, kv_cache_config=None)
     mock_lookup_server.assert_called_once_with(mock_worker.return_value, vllm_config)
     assert connector.connector_scheduler is None
     assert connector.connector_worker is mock_worker.return_value
@@ -119,7 +119,7 @@ def test_worker_role_skips_lookup_server_on_nonzero_rank():
             vllm_config, KVConnectorRole.WORKER
         )
 
-    mock_worker.assert_called_once_with(vllm_config)
+    mock_worker.assert_called_once_with(vllm_config, kv_cache_config=None)
     mock_lookup_server.assert_not_called()
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector_hma.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MooncakeStoreConnector HMA support."""
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_scheduler import (  # noqa: E501
+    MooncakeStoreScheduler,
+)
+
+from .utils import create_vllm_config, make_kv_cache_config
+
+
+def _make_scheduler(
+    swa_enabled: bool,
+    sw_size: int = 2048,
+    block_size: int = 16,
+    disable_hma: bool = False,
+):
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeStoreConnector",
+        kv_role="kv_both",
+        block_size=block_size,
+    )
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = disable_hma
+    kv_cache_config = make_kv_cache_config(
+        block_size=block_size,
+        swa_enabled=swa_enabled,
+        sw_size=sw_size,
+    )
+    return MooncakeStoreScheduler(vllm_config, kv_cache_config=kv_cache_config)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "swa_enabled,expected_blocks_per_sw",
+    [
+        (True, [0, 2048 // 16 + 1]),  # FA=0, SWA=128+1=129
+        (False, [0]),
+    ],
+)
+def test_blocks_per_sw(swa_enabled, expected_blocks_per_sw):
+    scheduler = _make_scheduler(swa_enabled=swa_enabled)
+    assert scheduler.blocks_per_sw == expected_blocks_per_sw
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "swa_enabled,disable_hma,expected_is_hma",
+    [
+        (True, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_is_hma_required(swa_enabled, disable_hma, expected_is_hma):
+    scheduler = _make_scheduler(swa_enabled=swa_enabled, disable_hma=disable_hma)
+    assert scheduler._is_hma_required is expected_is_hma
+
+
+@pytest.mark.cpu_test
+def test_get_sw_clipped_blocks_clips_swa_keeps_fa():
+    # sw_size=128 tokens / block_size=16 = 8 blocks + 1 = 9 blocks_per_sw
+    scheduler = _make_scheduler(swa_enabled=True, sw_size=128)
+    assert scheduler.blocks_per_sw == [0, 9]
+
+    fa_blocks = list(range(20))
+    sw_blocks = list(range(100, 120))
+    clipped = scheduler.get_sw_clipped_blocks((fa_blocks, sw_blocks))
+
+    assert clipped[0] == fa_blocks  # FA untouched
+    assert clipped[1] == sw_blocks[-9:]  # SWA clipped to last 9
+    assert len(clipped[1]) == 9
+
+
+@pytest.mark.cpu_test
+def test_get_sw_clipped_blocks_noop_when_not_hma():
+    scheduler = _make_scheduler(swa_enabled=False)
+    assert scheduler._is_hma_required is False
+    block_ids = ([1, 2, 3],)
+    assert scheduler.get_sw_clipped_blocks(block_ids) == [[1, 2, 3]]
+
+
+# ---------------------------------------------------------------------------
+# Task 2: per-group block_ids end-to-end
+# ---------------------------------------------------------------------------
+from unittest.mock import MagicMock  # noqa: E402
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (  # noqa: E402,E501
+    RequestTracker,
+)
+
+
+@pytest.mark.cpu_test
+def test_request_tracker_update_extends_each_group():
+    """update() must extend the matching group, not flatten."""
+    tracker = RequestTracker(
+        req_id="r1",
+        token_len=0,
+        allocated_block_ids=[[1, 2], [10, 11]],
+    )
+    tracker.update(([3, 4], [12, 13]))
+    assert tracker.allocated_block_ids == [[1, 2, 3, 4], [10, 11, 12, 13]]
+
+
+@pytest.mark.cpu_test
+def test_request_tracker_update_accepts_flat_list_as_single_group():
+    """Legacy flat list extends group 0 (single-group compat)."""
+    tracker = RequestTracker(
+        req_id="r1",
+        token_len=0,
+        allocated_block_ids=[[1, 2]],
+    )
+    tracker.update([3, 4])
+    assert tracker.allocated_block_ids == [[1, 2, 3, 4]]
+
+
+@pytest.mark.cpu_test
+def test_scheduler_request_finished_clips_swa_group():
+    """request_finished must clip SWA group on the way to delay-free state."""
+    scheduler = _make_scheduler(swa_enabled=True, sw_size=128, block_size=16)
+    fa_blocks = list(range(20))
+    sw_blocks = list(range(100, 120))
+
+    request = MagicMock()
+    request.request_id = "r-finished"
+    request.kv_transfer_params = {}
+    scheduler._request_trackers["r-finished"] = RequestTracker(
+        req_id="r-finished",
+        token_len=20 * 16,
+        allocated_block_ids=[fa_blocks, sw_blocks],
+        num_saved_tokens=20 * 16,
+    )
+
+    delay, _ = scheduler.request_finished(request, (fa_blocks, sw_blocks))
+    assert delay is True
+
+
+# ---------------------------------------------------------------------------
+# Task 3: ChunkedTokenDatabase group-aware prepare_value
+# ---------------------------------------------------------------------------
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (  # noqa: E402,E501
+    ChunkedTokenDatabase,
+    GroupLayout,
+    KeyMetadata,
+)
+
+
+@pytest.mark.cpu_test
+def test_prepare_value_picks_right_group_block_ids():
+    """A layer in the SWA group must address through SWA's clipped block ids."""
+    block_size = 16
+    metadata = KeyMetadata(
+        model_name="m",
+        tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+    )
+    db = ChunkedTokenDatabase(metadata, block_size=block_size)
+
+    fa_layout = GroupLayout(base_addrs=[0x1000], block_lens=[256])
+    sw_layout = GroupLayout(base_addrs=[0x2000], block_lens=[256])
+    db.set_groups([fa_layout, sw_layout], layer_to_group=[0, 1])
+
+    # 20 chunks total. SWA holds last 9.
+    fa_block_ids = list(range(20))
+    sw_block_ids = list(range(100, 109))
+    block_ids_per_group = [fa_block_ids, sw_block_ids]
+
+    # Chunk 19 (last): SWA local index = 19 - (20 - 9) = 8 → 108.
+    addr_list, size_list, _ = db.prepare_value(
+        start=19 * block_size,
+        end=20 * block_size,
+        block_ids=block_ids_per_group,
+    )
+    assert len(addr_list) == 2
+    assert addr_list[0] == 0x1000 + 19 * 256  # FA: block 19
+    assert addr_list[1] == 0x2000 + 108 * 256  # SWA: block 108
+
+
+@pytest.mark.cpu_test
+def test_prepare_value_single_group_unchanged():
+    """N=1 (single full-attention group) must produce the same addresses as before."""
+    block_size = 16
+    metadata = KeyMetadata(
+        model_name="m",
+        tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+    )
+    db = ChunkedTokenDatabase(metadata, block_size=block_size)
+
+    layout = GroupLayout(base_addrs=[0x1000, 0x2000], block_lens=[256, 256])
+    db.set_groups([layout], layer_to_group=[0, 0])
+
+    block_ids_per_group = [[5, 6, 7, 8]]
+    addr_list, _, _ = db.prepare_value(
+        start=2 * block_size,
+        end=3 * block_size,
+        block_ids=block_ids_per_group,
+    )
+    assert addr_list == [0x1000 + 7 * 256, 0x2000 + 7 * 256]
+
+
+@pytest.mark.cpu_test
+def test_is_chunk_savable_intersection_of_groups():
+    """A chunk is savable iff it lies within every group's window."""
+    block_size = 16
+    metadata = KeyMetadata(
+        model_name="m",
+        tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+    )
+    db = ChunkedTokenDatabase(metadata, block_size=block_size)
+    db.set_groups(
+        [
+            GroupLayout(base_addrs=[0x1000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x2000], block_lens=[256]),
+        ],
+        layer_to_group=[0, 1],
+    )
+
+    fa = list(range(20))
+    sw = list(range(100, 109))  # group_start_chunk = 11
+    block_ids = [fa, sw]
+
+    assert db.is_chunk_savable(start=5 * block_size, block_ids=block_ids) is False
+    assert db.is_chunk_savable(start=11 * block_size, block_ids=block_ids) is True
+    assert db.is_chunk_savable(start=19 * block_size, block_ids=block_ids) is True
+    assert db.is_chunk_savable(start=20 * block_size, block_ids=block_ids) is False
+
+
+# ---------------------------------------------------------------------------
+# Task 4: worker register_kv_caches buckets layers by KV cache group
+# ---------------------------------------------------------------------------
+from unittest.mock import patch  # noqa: E402
+
+import torch  # noqa: E402
+
+
+@pytest.mark.cpu_test
+def test_register_kv_caches_buckets_by_kv_cache_group():
+    """Mixed FA + SWA layers must be split into two GroupLayouts."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
+        mooncake_store_worker,
+    )
+
+    block_size = 16
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeStoreConnector",
+        kv_role="kv_both",
+        block_size=block_size,
+    )
+    kv_cache_config = make_kv_cache_config(
+        block_size=block_size,
+        swa_enabled=True,
+    )
+    # FA group claims layer0 + layer2; SWA group claims layer1 + layer3.
+
+    worker = mooncake_store_worker.MooncakeStoreWorker.__new__(
+        mooncake_store_worker.MooncakeStoreWorker,
+    )
+    worker.kv_cache_config = kv_cache_config
+    worker.cache_config = vllm_config.cache_config
+    worker.cache_config.num_gpu_blocks = 4
+    worker.num_blocks = 4
+    worker.block_size = block_size
+    worker.use_mla = False
+    worker.tp_size = 1
+    worker.tp_rank = 0
+    worker.put_step = 1
+    worker.kv_role = "kv_both"
+    worker.metadata = mooncake_store_worker.KeyMetadata(
+        model_name="m",
+        tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+    )
+    worker.token_database = mooncake_store_worker.ChunkedTokenDatabase(
+        worker.metadata,
+        block_size=block_size,
+    )
+    worker.store = MagicMock()
+    worker.store.register_buffer = MagicMock(return_value=0)
+    worker.kv_send_thread = None
+    worker.kv_recv_thread = None
+    worker.enable_kv_events = False
+    worker.disk_offload_buffer_budget_bytes = None
+    worker.replicate_config = None
+    worker.preferred_segment = None
+    worker.store_replicate_config = None
+
+    # MLA-style blocks-first layout: (num_blocks, block_size, head_size).
+    fa_tensor = torch.zeros((4, 16, 64), dtype=torch.float16)
+    sw_tensor = torch.zeros((4, 16, 64), dtype=torch.float16)
+    kv_caches = {
+        "layer0": fa_tensor,
+        "layer2": fa_tensor.clone(),
+        "layer1": sw_tensor,
+        "layer3": sw_tensor.clone(),
+    }
+    with (
+        patch.object(mooncake_store_worker, "KVCacheStoreSendingThread"),
+        patch.object(mooncake_store_worker, "KVCacheStoreRecvingThread"),
+        patch.object(mooncake_store_worker.threading, "Event") as mock_event,
+    ):
+        # Avoid blocking on ready_event_recving.wait().
+        mock_event.return_value.wait = MagicMock()
+        worker.register_kv_caches(kv_caches)
+
+    db = worker.token_database
+    assert len(db.groups) == 2
+    assert len(db.groups[0].base_addrs) == 2  # FA: 2 layers
+    assert len(db.groups[1].base_addrs) == 2  # SWA: 2 layers
+    assert db.layer_to_group == [0, 0, 1, 1]
+
+
+# ---------------------------------------------------------------------------
+# Task: DSV4-shaped per-group hashing (group_block_sizes=[256, 64, 64, 4, 8])
+# ---------------------------------------------------------------------------
+
+
+def _dsv4_db():
+    """Build ChunkedTokenDatabase with DSV4-Flash group block sizes."""
+    metadata = KeyMetadata(
+        model_name="dsv4", tp_rank=0, pcp_rank=0, dcp_rank=0, pp_rank=0
+    )
+    db = ChunkedTokenDatabase(metadata, block_size=256)
+    # 5 groups: FA (256), SWA×2 (64), C4 (4), C8 (8).
+    db.set_groups(
+        [
+            GroupLayout(base_addrs=[0x1000 * (i + 1)], block_lens=[256])
+            for i in range(5)
+        ],
+        layer_to_group=[0, 1, 2, 3, 4],
+    )
+    db.set_blocks_per_sw([0, 3, 3, 3, 17])
+    db.set_group_block_sizes([256, 64, 64, 4, 8], hash_block_size=4)
+    return db
+
+
+@pytest.mark.cpu_test
+def test_dsv4_process_tokens_emits_per_group_native_chunks():
+    """Each group walks its own native block_size; key hash is right-edge."""
+    db = _dsv4_db()
+    token_len = 12_000  # divisible by all group block sizes
+    n_hashes = token_len // 4
+    hashes = [f"h{i:04d}" for i in range(n_hashes)]
+
+    by_group: dict[int, list[tuple[int, int, str]]] = {g: [] for g in range(5)}
+    for start, end, g, key in db.process_tokens(token_len, hashes):
+        by_group[g].append((start, end, key.chunk_hash))
+
+    # cdiv(12000, gbs) per group.
+    assert [len(by_group[g]) for g in range(5)] == [47, 188, 188, 3000, 1500]
+
+    # FA chunk 0 [0, 256) → hash_idx 63 → h0063.
+    assert by_group[0][0] == (0, 256, "h0063")
+    assert by_group[0][1] == (256, 512, "h0127")
+    # FA last chunk [11776, 12000) → hash_idx 2999 → h2999.
+    # Note: token_len=12000, FA ceil(12000/256)=47, last chunk is partial
+    # (12000-11776=224 tokens) but end_idx=12000 is hash-aligned.
+    assert by_group[0][46] == (11776, 12000, "h2999")
+    # SWA group 1 last chunk [11968, 12000) → same hash index.
+    assert by_group[1][187] == (11968, 12000, "h2999")
+    # C4 last chunk [11996, 12000) → same hash index.
+    assert by_group[3][2999] == (11996, 12000, "h2999")
+
+
+@pytest.mark.cpu_test
+def test_dsv4_window_clipping_yields_47_3_3_3_17_in_window_keys():
+    """Save-side window: FA all + SWA tails + compressor tail = 73 keys."""
+    db = _dsv4_db()
+    token_len = 12_000
+    hashes = [f"h{i:04d}" for i in range(token_len // 4)]
+    block_ids = [
+        list(range(47)),
+        list(range(3)),
+        list(range(3)),
+        list(range(3)),
+        list(range(17)),
+    ]
+    g_total = [47, 188, 188, 3000, 1500]
+
+    in_window = []
+    for start, _end, g, _key in db.process_tokens(token_len, hashes):
+        chunk_id = start // db.group_block_sizes[g]
+        if db.is_chunk_in_window_per_request(chunk_id, block_ids, g, g_total[g]):
+            in_window.append(g)
+
+    per_group_count = [in_window.count(k) for k in range(5)]
+    assert per_group_count == [47, 3, 3, 3, 17]
+
+
+@pytest.mark.cpu_test
+def test_dsv4_lookup_window_static_uses_blocks_per_sw():
+    """Lookup-side window check (no block_ids) agrees with save-side."""
+    db = _dsv4_db()
+    g_total = [47, 188, 188, 3000, 1500]
+    in_window = sum(
+        1
+        for g in range(5)
+        for c in range(g_total[g])
+        if db.is_chunk_in_window(c, g_total[g], g)
+    )
+    assert in_window == 73
+
+
+@pytest.mark.cpu_test
+def test_dsv4_scheduler_block_size_lcm_not_min():
+    """scheduler_block_size = LCM (256), not MIN (4)."""
+    db = _dsv4_db()
+    assert db.scheduler_block_size == 256
+    assert db.hash_block_size == 4
+    assert db.group_block_sizes == [256, 64, 64, 4, 8]
+
+
+@pytest.mark.cpu_test
+def test_set_group_block_sizes_explicit_scheduler_block_size():
+    """Explicit scheduler_block_size overrides the LCM default."""
+    db = ChunkedTokenDatabase(KeyMetadata("m", 0, 0, 0, 0), block_size=256)
+    db.set_groups(
+        [GroupLayout([0x1000], [256]), GroupLayout([0x2000], [256])],
+        layer_to_group=[0, 1],
+    )
+    db.set_group_block_sizes([256, 64], hash_block_size=64, scheduler_block_size=512)
+    assert db.scheduler_block_size == 512
+
+
+@pytest.mark.cpu_test
+def test_dsv4_partial_last_chunk_indexes_safely():
+    """Last chunk of every group uses end_idx // hash_bs - 1 in range."""
+    db = _dsv4_db()
+    token_len = 12_000
+    hashes = [f"h{i:04d}" for i in range(token_len // 4)]
+
+    by_group_last: dict[int, tuple[int, int, str]] = {}
+    for start, end, g, key in db.process_tokens(token_len, hashes):
+        by_group_last[g] = (start, end, key.chunk_hash)
+
+    for g, (start, end, h) in by_group_last.items():
+        assert h == f"h{end // 4 - 1:04d}", f"group {g} chunk [{start}, {end}): {h}"

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector_hma.py
@@ -168,15 +168,21 @@ def test_prepare_value_picks_right_group_block_ids():
     sw_block_ids = list(range(100, 109))
     block_ids_per_group = [fa_block_ids, sw_block_ids]
 
-    # Chunk 19 (last): SWA local index = 19 - (20 - 9) = 8 → 108.
-    addr_list, size_list, _ = db.prepare_value(
+    # Chunk 19 (last): FA local index = 19; SWA local index = 19 - (20 - 9) = 8 → 108.
+    fa_addr, _, _ = db.group(0).prepare_value(
         start=19 * block_size,
         end=20 * block_size,
         block_ids=block_ids_per_group,
+        total_chunks=20,
     )
-    assert len(addr_list) == 2
-    assert addr_list[0] == 0x1000 + 19 * 256  # FA: block 19
-    assert addr_list[1] == 0x2000 + 108 * 256  # SWA: block 108
+    sw_addr, _, _ = db.group(1).prepare_value(
+        start=19 * block_size,
+        end=20 * block_size,
+        block_ids=block_ids_per_group,
+        total_chunks=20,
+    )
+    assert fa_addr == [0x1000 + 19 * 256]
+    assert sw_addr == [0x2000 + 108 * 256]
 
 
 @pytest.mark.cpu_test
@@ -196,42 +202,54 @@ def test_prepare_value_single_group_unchanged():
     db.set_groups([layout], layer_to_group=[0, 0])
 
     block_ids_per_group = [[5, 6, 7, 8]]
-    addr_list, _, _ = db.prepare_value(
+    addr_list, _, _ = db.group(0).prepare_value(
         start=2 * block_size,
         end=3 * block_size,
         block_ids=block_ids_per_group,
+        total_chunks=4,
     )
     assert addr_list == [0x1000 + 7 * 256, 0x2000 + 7 * 256]
 
 
 @pytest.mark.cpu_test
-def test_is_chunk_savable_intersection_of_groups():
-    """A chunk is savable iff it lies within every group's window."""
+def test_group_database_accepts_group_local_block_ids():
+    """Each group DB owns its layout and accepts that group's block table."""
     block_size = 16
-    metadata = KeyMetadata(
-        model_name="m",
-        tp_rank=0,
-        pcp_rank=0,
-        dcp_rank=0,
-        pp_rank=0,
-    )
-    db = ChunkedTokenDatabase(metadata, block_size=block_size)
+    db = ChunkedTokenDatabase(KeyMetadata("m", 0, 0, 0, 0), block_size=block_size)
     db.set_groups(
         [
             GroupLayout(base_addrs=[0x1000], block_lens=[256]),
-            GroupLayout(base_addrs=[0x2000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x2000], block_lens=[512]),
         ],
         layer_to_group=[0, 1],
     )
+    db.set_group_block_sizes(
+        [block_size, block_size],
+        hash_block_size=block_size,
+        scheduler_block_size=block_size,
+    )
 
     fa = list(range(20))
-    sw = list(range(100, 109))  # group_start_chunk = 11
+    sw = list(range(100, 109))
     block_ids = [fa, sw]
 
-    assert db.is_chunk_savable(start=5 * block_size, block_ids=block_ids) is False
-    assert db.is_chunk_savable(start=11 * block_size, block_ids=block_ids) is True
-    assert db.is_chunk_savable(start=19 * block_size, block_ids=block_ids) is True
-    assert db.is_chunk_savable(start=20 * block_size, block_ids=block_ids) is False
+    g1 = db.group(1)
+    per_group_addr, per_group_size, per_group_block_id = g1.prepare_value(
+        start=19 * block_size,
+        end=20 * block_size,
+        block_ids=block_ids,
+        total_chunks=20,
+    )
+    local_addr, local_size, local_block_id = g1.prepare_value(
+        start=19 * block_size,
+        end=20 * block_size,
+        block_ids=sw,
+        total_chunks=20,
+    )
+
+    assert per_group_addr == local_addr == [0x2000 + 108 * 512]
+    assert per_group_size == local_size == [512]
+    assert per_group_block_id == local_block_id == 108
 
 
 # ---------------------------------------------------------------------------
@@ -339,76 +357,8 @@ def _dsv4_db():
         ],
         layer_to_group=[0, 1, 2, 3, 4],
     )
-    db.set_blocks_per_sw([0, 3, 3, 3, 17])
     db.set_group_block_sizes([256, 64, 64, 4, 8], hash_block_size=4)
     return db
-
-
-@pytest.mark.cpu_test
-def test_dsv4_process_tokens_emits_per_group_native_chunks():
-    """Each group walks its own native block_size; key hash is right-edge."""
-    db = _dsv4_db()
-    token_len = 12_000  # divisible by all group block sizes
-    n_hashes = token_len // 4
-    hashes = [f"h{i:04d}" for i in range(n_hashes)]
-
-    by_group: dict[int, list[tuple[int, int, str]]] = {g: [] for g in range(5)}
-    for start, end, g, key in db.process_tokens(token_len, hashes):
-        by_group[g].append((start, end, key.chunk_hash))
-
-    # cdiv(12000, gbs) per group.
-    assert [len(by_group[g]) for g in range(5)] == [47, 188, 188, 3000, 1500]
-
-    # FA chunk 0 [0, 256) → hash_idx 63 → h0063.
-    assert by_group[0][0] == (0, 256, "h0063")
-    assert by_group[0][1] == (256, 512, "h0127")
-    # FA last chunk [11776, 12000) → hash_idx 2999 → h2999.
-    # Note: token_len=12000, FA ceil(12000/256)=47, last chunk is partial
-    # (12000-11776=224 tokens) but end_idx=12000 is hash-aligned.
-    assert by_group[0][46] == (11776, 12000, "h2999")
-    # SWA group 1 last chunk [11968, 12000) → same hash index.
-    assert by_group[1][187] == (11968, 12000, "h2999")
-    # C4 last chunk [11996, 12000) → same hash index.
-    assert by_group[3][2999] == (11996, 12000, "h2999")
-
-
-@pytest.mark.cpu_test
-def test_dsv4_window_clipping_yields_47_3_3_3_17_in_window_keys():
-    """Save-side window: FA all + SWA tails + compressor tail = 73 keys."""
-    db = _dsv4_db()
-    token_len = 12_000
-    hashes = [f"h{i:04d}" for i in range(token_len // 4)]
-    block_ids = [
-        list(range(47)),
-        list(range(3)),
-        list(range(3)),
-        list(range(3)),
-        list(range(17)),
-    ]
-    g_total = [47, 188, 188, 3000, 1500]
-
-    in_window = []
-    for start, _end, g, _key in db.process_tokens(token_len, hashes):
-        chunk_id = start // db.group_block_sizes[g]
-        if db.is_chunk_in_window_per_request(chunk_id, block_ids, g, g_total[g]):
-            in_window.append(g)
-
-    per_group_count = [in_window.count(k) for k in range(5)]
-    assert per_group_count == [47, 3, 3, 3, 17]
-
-
-@pytest.mark.cpu_test
-def test_dsv4_lookup_window_static_uses_blocks_per_sw():
-    """Lookup-side window check (no block_ids) agrees with save-side."""
-    db = _dsv4_db()
-    g_total = [47, 188, 188, 3000, 1500]
-    in_window = sum(
-        1
-        for g in range(5)
-        for c in range(g_total[g])
-        if db.is_chunk_in_window(c, g_total[g], g)
-    )
-    assert in_window == 73
 
 
 @pytest.mark.cpu_test
@@ -430,18 +380,3 @@ def test_set_group_block_sizes_explicit_scheduler_block_size():
     )
     db.set_group_block_sizes([256, 64], hash_block_size=64, scheduler_block_size=512)
     assert db.scheduler_block_size == 512
-
-
-@pytest.mark.cpu_test
-def test_dsv4_partial_last_chunk_indexes_safely():
-    """Last chunk of every group uses end_idx // hash_bs - 1 in range."""
-    db = _dsv4_db()
-    token_len = 12_000
-    hashes = [f"h{i:04d}" for i in range(token_len // 4)]
-
-    by_group_last: dict[int, tuple[int, int, str]] = {}
-    for start, end, g, key in db.process_tokens(token_len, hashes):
-        by_group_last[g] = (start, end, key.chunk_hash)
-
-    for g, (start, end, h) in by_group_last.items():
-        assert h == f"h{end // 4 - 1:04d}", f"group {g} chunk [{start}, {end}): {h}"

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -12,6 +12,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     ChunkedTokenDatabase,
+    GroupLayout,
     KeyMetadata,
     LoadSpec,
     ReqMeta,
@@ -20,6 +21,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_metric
     MooncakeStoreConnectorStats,
 )
 
+from .utils import make_kv_cache_config
+
 
 def _make_store_sending_thread(
     store: MagicMock,
@@ -27,8 +30,7 @@ def _make_store_sending_thread(
     token_database = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
     )
-    token_database.set_kv_caches_base_addr([0x1000])
-    token_database.set_block_len([256])
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
     thread = mooncake_store_worker.KVCacheStoreSendingThread(
         store=store,
         token_database=token_database,
@@ -50,8 +52,7 @@ def _make_store_recving_thread(
     token_database = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
     )
-    token_database.set_kv_caches_base_addr([0x1000])
-    token_database.set_block_len([256])
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
     thread = mooncake_store_worker.KVCacheStoreRecvingThread(
         store=store,
         token_database=token_database,
@@ -496,6 +497,93 @@ def test_lookup_records_mooncake_metrics():
     assert stats.data["lookup_exists"][0]["num_keys"] == 2
 
 
+def test_lookup_rounds_first_miss_by_scheduler_block_size_not_min_block_size():
+    """LCM-vs-MIN regression: a C4 miss at token 12000 must round to
+    11776 (LCM=256), not 12000 (MIN=4)."""
+    # DSV4 post-engine-mutation shape: self.block_size=4, scheduler_block_size=256.
+    worker = _make_bare_worker(block_size=4)
+    worker.token_database.set_groups(
+        [
+            GroupLayout(base_addrs=[0x1000 * (i + 1)], block_lens=[256])
+            for i in range(5)
+        ],
+        layer_to_group=[0, 1, 2, 3, 4],
+    )
+    worker.token_database.set_blocks_per_sw([0, 3, 3, 3, 17])
+    worker.token_database.set_group_block_sizes(
+        [256, 64, 64, 4, 8], hash_block_size=4, scheduler_block_size=256
+    )
+    worker.scheduler_block_size = 256
+
+    token_len = 12_004
+    block_hashes = [f"h{i:04d}".encode() for i in range((token_len + 3) // 4)]
+
+    # Build batch_is_exist response: every key hits except C4 chunk 3000
+    # (start=12000). Keys must be in process_tokens order.
+    db = worker.token_database
+    response = []
+    for start, _end, g, _key in db.process_tokens(token_len, block_hashes):
+        gbs = db.group_block_sizes[g]
+        cid = start // gbs
+        if not db.is_chunk_in_window(cid, (token_len + gbs - 1) // gbs, g):
+            continue
+        response.append(0 if (g == 3 and start == 12000) else 1)
+    worker.store.batch_is_exist.return_value = response
+
+    # 12000 is 4-aligned but not 256-aligned. Correct round-down → 11776.
+    assert worker.lookup(token_len, block_hashes) == 11776
+
+    # Control: with scheduler_block_size=4 (the bug), miss returns unrounded.
+    worker.scheduler_block_size = 4
+    assert worker.lookup(token_len, block_hashes) == 12000
+
+
+def test_lookup_does_not_claim_unhashed_partial_tail_as_full_hit():
+    """If token_len is not hash-aligned, skipped tail chunks are not verified.
+
+    process_tokens() intentionally skips chunks whose right edge is not aligned
+    to hash_block_size. lookup() must use the same effective token length for
+    its all-hit shortcut, otherwise all queried keys can hit while the returned
+    prefix includes tail tokens that were never hashed.
+    """
+    worker = _make_bare_worker(block_size=4)
+    worker.token_database.set_groups(
+        [
+            GroupLayout(base_addrs=[0x1000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x2000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x3000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x4000], block_lens=[256]),
+            GroupLayout(base_addrs=[0x5000], block_lens=[256]),
+        ],
+        layer_to_group=[0, 1, 2, 3, 4],
+    )
+    worker.token_database.set_blocks_per_sw([0, 3, 3, 3, 17])
+    worker.token_database.set_group_block_sizes(
+        [256, 64, 64, 4, 8], hash_block_size=4, scheduler_block_size=256
+    )
+    worker.scheduler_block_size = 256
+
+    token_len = 12_005
+    block_hashes = [f"h{i:04d}".encode() for i in range(token_len // 4)]
+
+    db = worker.token_database
+    queried = []
+    for start, end, g, _key in db.process_tokens(token_len, block_hashes):
+        gbs = db.group_block_sizes[g]
+        cid = start // gbs
+        if db.is_chunk_in_window(cid, (token_len + gbs - 1) // gbs, g):
+            queried.append((start, end, g))
+
+    assert queried
+    assert all(end != token_len for _start, end, _g in queried)
+
+    worker.store.batch_is_exist.return_value = [1] * len(queried)
+
+    result = worker.lookup(token_len, block_hashes)
+
+    assert result == 12_004
+
+
 # ---------------------------------------------------------------------------
 # register_kv_caches tests
 # ---------------------------------------------------------------------------
@@ -642,3 +730,28 @@ def test_register_kv_caches_cross_layer_single_segment():
 
     assert worker2.kv_caches_base_addr == worker.kv_caches_base_addr
     assert worker2.block_len == worker.block_len
+
+
+def test_register_cross_layers_kv_caches_allows_synthetic_key_with_config():
+    """Cross-layer registration uses a synthetic key outside kv_cache_groups."""
+    num_blocks = 10
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker.kv_cache_config = make_kv_cache_config(block_size=16, swa_enabled=False)
+    tensor = torch.zeros(num_blocks, 256, dtype=torch.float16)
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreSendingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_worker.KVCacheStoreRecvingThread",
+            side_effect=_auto_set_ready_event,
+        ),
+    ):
+        worker.register_cross_layers_kv_caches(tensor)
+
+    assert len(worker.token_database.groups) == 1
+    assert worker.kv_caches_base_addr == [tensor.untyped_storage().data_ptr()]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -10,6 +10,10 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     mooncake_store_worker,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+    MooncakeChunk,
+    MooncakeLookupCoordinator,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     ChunkedTokenDatabase,
     GroupLayout,
@@ -20,8 +24,32 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data i
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_metrics import (  # noqa: E501
     MooncakeStoreConnectorStats,
 )
+from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
 
 from .utils import make_kv_cache_config
+
+
+def _make_single_group_coordinator(
+    *,
+    block_size: int = 16,
+) -> MooncakeLookupCoordinator:
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer0"], spec)],
+    )
+    return MooncakeLookupCoordinator(config, hash_block_size=block_size)
 
 
 def _make_store_sending_thread(
@@ -39,6 +67,7 @@ def _make_store_sending_thread(
         put_step=1,
         kv_role="kv_producer",
         ready_event=threading.Event(),
+        lookup_coordinator=_make_single_group_coordinator(block_size=16),
     )
     thread.request_queue.task_done = MagicMock()
     return thread
@@ -60,6 +89,7 @@ def _make_store_recving_thread(
         tp_rank=0,
         ready_event=threading.Event(),
         disk_offload_buffer_budget_bytes=disk_offload_buffer_budget_bytes,
+        lookup_coordinator=_make_single_group_coordinator(block_size=16),
     )
     thread.request_queue.task_done = MagicMock()
     return thread
@@ -75,7 +105,7 @@ def _make_load_req(
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=token_len,
-        block_ids=list(range(len(block_hashes))),
+        block_ids=[list(range(len(block_hashes)))],
         block_hashes=block_hashes,
         load_spec=LoadSpec(
             vllm_cached_tokens=vllm_cached_tokens,
@@ -90,7 +120,7 @@ def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
     return ReqMeta(
         req_id=req_id,
         token_len_chunk=32,
-        block_ids=[0, 1],
+        block_ids=[[0, 1]],
         block_hashes=block_hashes,
         can_save=True,
         original_block_size=16,
@@ -183,6 +213,71 @@ def test_store_sending_thread_records_mooncake_metrics():
     assert len(stats.data["save_put"]) == 1
     assert stats.data["save_put"][0]["num_bytes"] == 512
     assert stats.data["save_put"][0]["status"] == "ok"
+
+
+def test_store_sending_thread_uses_coordinator_store_plan():
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0]
+    store.batch_put_from_multi_buffers.return_value = [256]
+    coordinator = MagicMock()
+    coordinator.plan_store_chunks.return_value = [
+        MooncakeChunk(
+            group_id=0,
+            chunk_id=1,
+            start=16,
+            end=32,
+            hash_index=1,
+            block_hash=BlockHash(b"a1"),
+        )
+    ]
+
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
+    thread = mooncake_store_worker.KVCacheStoreSendingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        put_step=1,
+        kv_role="kv_producer",
+        ready_event=threading.Event(),
+        lookup_coordinator=coordinator,
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    coordinator.plan_store_chunks.assert_called_once()
+    assert store.batch_is_exist.call_args.args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131"
+    ]
+
+
+def test_store_sending_thread_drops_save_without_coordinator():
+    store = MagicMock()
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
+    thread = mooncake_store_worker.KVCacheStoreSendingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        put_step=1,
+        kv_role="kv_producer",
+        ready_event=threading.Event(),
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
 
 
 def test_get_disk_offload_buffer_budget_bytes_uses_effective_offload_flag(
@@ -393,6 +488,76 @@ def test_recv_thread_reports_unsplittable_key_larger_than_budget():
     assert store.batch_get_into_multi_buffers.call_count == 0
 
 
+def test_recv_thread_uses_coordinator_load_plan():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256]
+    coordinator = MagicMock()
+    coordinator.plan_load_chunks.return_value = [
+        MooncakeChunk(
+            group_id=0,
+            chunk_id=1,
+            start=16,
+            end=32,
+            hash_index=1,
+            block_hash=BlockHash(b"a1"),
+        )
+    ]
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        ready_event=threading.Event(),
+        disk_offload_buffer_budget_bytes=None,
+        lookup_coordinator=coordinator,
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1"],
+        token_len=32,
+    )
+    thread._handle_request(req)
+
+    coordinator.plan_load_chunks.assert_called_once()
+    assert store.batch_get_into_multi_buffers.call_args.args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131"
+    ]
+
+
+def test_recv_thread_drops_load_without_coordinator():
+    store = MagicMock()
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_groups([GroupLayout(base_addrs=[0x1000], block_lens=[256])], [0])
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        ready_event=threading.Event(),
+        disk_offload_buffer_budget_bytes=None,
+    )
+    thread.request_queue.task_done = MagicMock()
+
+    thread._handle_request(
+        _make_load_req(
+            "req-a",
+            [b"a0", b"a1"],
+            token_len=32,
+        )
+    )
+
+    store.batch_get_into_multi_buffers.assert_not_called()
+    assert "req-a" in thread.get_and_clear_finished_requests()
+
+
 # ---------------------------------------------------------------------------
 # Helpers for register_kv_caches tests
 # ---------------------------------------------------------------------------
@@ -420,7 +585,20 @@ def _make_bare_worker(
     Sets only the attributes that register_kv_caches() reads so we can
     test the stride-based layout detection without a real
     MooncakeDistributedStore.
+
+    Also constructs a minimal :class:`MooncakeLookupCoordinator` so
+    :meth:`lookup` works (lookup is now coordinator-only — see
+    ``docs/design/mooncake_lookup_coordinator.md``).
     """
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+        MooncakeLookupCoordinator,
+    )
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+    )
+
     worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
     worker.cache_config = MagicMock()
     worker.cache_config.num_gpu_blocks = num_gpu_blocks
@@ -443,6 +621,19 @@ def _make_bare_worker(
     worker.tp_size = 1
     worker.num_kv_head = 1
     worker.pp_size = 1
+    # Default single-group FA coordinator so ``lookup`` works.
+    spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=4, head_size=16, dtype=torch.float16
+    )
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer0"], spec)],
+    )
+    worker._lookup_coordinator = MooncakeLookupCoordinator(
+        worker.kv_cache_config, hash_block_size=block_size
+    )
+    worker._coordinator_construction_failed = False
     return worker
 
 
@@ -497,91 +688,130 @@ def test_lookup_records_mooncake_metrics():
     assert stats.data["lookup_exists"][0]["num_keys"] == 2
 
 
-def test_lookup_rounds_first_miss_by_scheduler_block_size_not_min_block_size():
-    """LCM-vs-MIN regression: a C4 miss at token 12000 must round to
-    11776 (LCM=256), not 12000 (MIN=4)."""
-    # DSV4 post-engine-mutation shape: self.block_size=4, scheduler_block_size=256.
-    worker = _make_bare_worker(block_size=4)
-    worker.token_database.set_groups(
-        [
-            GroupLayout(base_addrs=[0x1000 * (i + 1)], block_lens=[256])
-            for i in range(5)
+def _make_bare_worker_fa_swa(*, block_size: int = 16, sliding_window: int = 64):
+    """Bare worker with one FA group and one SWA group, sharing block_size."""
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        SlidingWindowSpec,
+    )
+
+    worker = _make_bare_worker(block_size=block_size)
+    fa_spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=4, head_size=16, dtype=torch.float16
+    )
+    swa_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=sliding_window,
+    )
+    config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["fa0"], fa_spec),
+            KVCacheGroupSpec(["swa0"], swa_spec),
         ],
-        layer_to_group=[0, 1, 2, 3, 4],
     )
-    worker.token_database.set_blocks_per_sw([0, 3, 3, 3, 17])
-    worker.token_database.set_group_block_sizes(
-        [256, 64, 64, 4, 8], hash_block_size=4, scheduler_block_size=256
-    )
-    worker.scheduler_block_size = 256
-
-    token_len = 12_004
-    block_hashes = [f"h{i:04d}".encode() for i in range((token_len + 3) // 4)]
-
-    # Build batch_is_exist response: every key hits except C4 chunk 3000
-    # (start=12000). Keys must be in process_tokens order.
-    db = worker.token_database
-    response = []
-    for start, _end, g, _key in db.process_tokens(token_len, block_hashes):
-        gbs = db.group_block_sizes[g]
-        cid = start // gbs
-        if not db.is_chunk_in_window(cid, (token_len + gbs - 1) // gbs, g):
-            continue
-        response.append(0 if (g == 3 and start == 12000) else 1)
-    worker.store.batch_is_exist.return_value = response
-
-    # 12000 is 4-aligned but not 256-aligned. Correct round-down → 11776.
-    assert worker.lookup(token_len, block_hashes) == 11776
-
-    # Control: with scheduler_block_size=4 (the bug), miss returns unrounded.
-    worker.scheduler_block_size = 4
-    assert worker.lookup(token_len, block_hashes) == 12000
-
-
-def test_lookup_does_not_claim_unhashed_partial_tail_as_full_hit():
-    """If token_len is not hash-aligned, skipped tail chunks are not verified.
-
-    process_tokens() intentionally skips chunks whose right edge is not aligned
-    to hash_block_size. lookup() must use the same effective token length for
-    its all-hit shortcut, otherwise all queried keys can hit while the returned
-    prefix includes tail tokens that were never hashed.
-    """
-    worker = _make_bare_worker(block_size=4)
+    worker.kv_cache_config = config
     worker.token_database.set_groups(
         [
             GroupLayout(base_addrs=[0x1000], block_lens=[256]),
             GroupLayout(base_addrs=[0x2000], block_lens=[256]),
-            GroupLayout(base_addrs=[0x3000], block_lens=[256]),
-            GroupLayout(base_addrs=[0x4000], block_lens=[256]),
-            GroupLayout(base_addrs=[0x5000], block_lens=[256]),
         ],
-        layer_to_group=[0, 1, 2, 3, 4],
+        layer_to_group=[0, 1],
     )
-    worker.token_database.set_blocks_per_sw([0, 3, 3, 3, 17])
     worker.token_database.set_group_block_sizes(
-        [256, 64, 64, 4, 8], hash_block_size=4, scheduler_block_size=256
+        [block_size, block_size],
+        hash_block_size=block_size,
+        scheduler_block_size=block_size,
     )
-    worker.scheduler_block_size = 256
+    worker.scheduler_block_size = block_size
+    return worker
 
-    token_len = 12_005
-    block_hashes = [f"h{i:04d}".encode() for i in range(token_len // 4)]
 
-    db = worker.token_database
-    queried = []
-    for start, end, g, _key in db.process_tokens(token_len, block_hashes):
-        gbs = db.group_block_sizes[g]
-        cid = start // gbs
-        if db.is_chunk_in_window(cid, (token_len + gbs - 1) // gbs, g):
-            queried.append((start, end, g))
+def test_lookup_returns_zero_when_coordinator_construction_failed():
+    """Fail-closed: if coordinator construction failed (unknown spec,
+    misaligned hash block size, ...), lookup returns 0 immediately.
 
-    assert queried
-    assert all(end != token_len for _start, end, _g in queried)
+    There is no alternate single-pass path; that path can't express
+    manager-specific hit semantics for the unknown spec either, so
+    falling back would silently over-report hits.
+    """
+    worker = _make_bare_worker()
+    worker._coordinator_construction_failed = True
+    worker._lookup_coordinator = None
+    # Even a valid lookup query returns 0 — never reaches Mooncake.
+    worker.store.batch_is_exist.return_value = [1, 1, 1]
+    assert worker.lookup(48, [b"a0", b"a1", b"a2"]) == 0
+    # batch_is_exist NOT called.
+    worker.store.batch_is_exist.assert_not_called()
 
-    worker.store.batch_is_exist.return_value = [1] * len(queried)
 
-    result = worker.lookup(token_len, block_hashes)
+def test_lookup_coordinator_path_handles_hex_string_hashes():
+    """Regression: scheduler hex-encodes BlockHashes for the ZMQ wire,
+    so worker.lookup receives ``list[str]``. Coordinator path must
+    decode before entering vllm's manager find_longest_cache_hit
+    (which uses ``b"".join`` on hashes for HMA groups).
 
-    assert result == 12_004
+    Before the fix this raised on every lookup:
+        TypeError: sequence item 0: expected a bytes-like object, str found
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+        MooncakeLookupCoordinator,
+    )
+
+    block_size = 16
+    sliding_window = 32
+    worker = _make_bare_worker_fa_swa(
+        block_size=block_size, sliding_window=sliding_window
+    )
+    coord = MooncakeLookupCoordinator(
+        worker.kv_cache_config, hash_block_size=block_size
+    )
+    worker._lookup_coordinator = coord
+
+    token_len = 8 * block_size
+    # HEX-STRING hashes — same shape the worker actually receives.
+    block_hashes = [f"{i:016x}" for i in range(token_len // block_size)]
+    n_all = len(coord.iter_group_chunks(token_len, block_hashes))
+    worker.store.batch_is_exist.return_value = [1] * n_all
+
+    # Should NOT raise. Returns full hit length.
+    assert worker.lookup(token_len, block_hashes) == token_len
+
+
+def test_lookup_coordinator_path_first_chunk_miss_returns_zero():
+    """FA chunk 0 miss → both paths return 0."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+        MooncakeLookupCoordinator,
+    )
+
+    block_size = 16
+    sliding_window = 32
+
+    worker = _make_bare_worker_fa_swa(
+        block_size=block_size, sliding_window=sliding_window
+    )
+    coord = MooncakeLookupCoordinator(
+        worker.kv_cache_config, hash_block_size=block_size
+    )
+    worker._lookup_coordinator = coord
+
+    token_len = 8 * block_size
+    block_hashes = [f"h{i:04d}".encode() for i in range(token_len // block_size)]
+
+    # Build response in the same coordinator chunk order as worker.lookup.
+    response = []
+    for chunk in coord.iter_group_chunks(token_len, block_hashes):
+        # FA chunk 0 missed; everything else hits.
+        response.append(0 if (chunk.group_id == 0 and chunk.chunk_id == 0) else 1)
+    worker.store.batch_is_exist.return_value = response
+
+    assert worker.lookup(token_len, block_hashes) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_lookup_coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_lookup_coordinator.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cache-hit aggregation for ``MooncakeStoreConnector.lookup`` that
+delegates to vllm's per-manager ``find_longest_cache_hit`` by inheriting
+from :class:`HybridKVCacheCoordinator` and overriding only ``__init__``.
+Reuses upstream's iterative fixed-point loop, EAGLE handling, and
+alignment math instead of reimplementing them.
+"""
+
+from dataclasses import dataclass
+from math import lcm
+from typing import Any, cast
+
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    make_block_hash_with_group_id,
+)
+from vllm.v1.core.single_type_kv_cache_manager import (
+    SingleTypeKVCacheManager,
+    spec_manager_map,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MooncakeChunk:
+    """Logical group chunk that should be addressed in Mooncake.
+
+    ``block_hash`` is the right-edge hash used by Mooncake's persisted key.
+    The lookup coordinator may use a wider concat hash internally when calling
+    vLLM's cache managers, but the transfer path stores/loads by this hash.
+    """
+
+    group_id: int
+    chunk_id: int
+    start: int
+    end: int
+    hash_index: int
+    block_hash: BlockHash
+
+
+@dataclass(slots=True)
+class _LookupBlock:
+    """Stand-in ``KVCacheBlock``: the per-manager ``find_longest_cache_hit``
+    methods only count blocks and check ``is_null``.
+
+    ``chunk`` is present for real Mooncake-backed blocks and absent for
+    manager-produced null/skipped blocks.
+    """
+
+    block_id: int = -1
+    is_null: bool = False
+    chunk: MooncakeChunk | None = None
+
+
+class LookupBlockPool:
+    """Read-only ``BlockPool``-shaped view over Mooncake's exists results.
+
+    Built once per ``lookup`` call from a ``batch_is_exist`` round-trip
+    and assigned to ``self._lookup_coordinator.block_pool`` so the
+    inherited ``find_longest_cache_hit`` probes Mooncake instead of a
+    real GPU-backed pool.
+
+    Hash shape: managers probe with ``make_block_hash_with_group_id(concat_hash,
+    group_id)``, where ``concat_hash`` for HMA groups with ``block_size >
+    hash_block_size`` spans ``scale = block_size / hash_block_size``
+    consecutive entries (matching ``BlockHashListWithBlockSize``).
+    ``MooncakeLookupCoordinator.build_block_pool`` pre-computes those
+    concat hashes so probes here are an O(1) dict lookup.
+    """
+
+    def __init__(self, cached: dict[bytes, _LookupBlock]):
+        self._cached: dict[bytes, _LookupBlock] = cached
+        self.null_block = _LookupBlock(is_null=True)
+
+    def get_cached_block(
+        self,
+        block_hash: BlockHash,
+        kv_cache_group_ids: list[int],
+    ) -> list[Any] | None:
+        cached_blocks: list[Any] = []
+        for group_id in kv_cache_group_ids:
+            key = make_block_hash_with_group_id(block_hash, group_id)
+            cached_block = self._cached.get(bytes(key))
+            if cached_block is None:
+                return None
+            cached_blocks.append(cached_block)
+        return cached_blocks
+
+
+def _unwrap_kv_cache_config(config: KVCacheConfig) -> KVCacheConfig:
+    """Replace ``UniformTypeKVCacheSpecs`` wrappers with their inner spec.
+
+    Worker-side configs wrap groups in ``UniformTypeKVCacheSpecs``,
+    which ``spec_manager_map`` can't dispatch on. ``is_eagle_group``
+    is preserved across the unwrap — without it, EAGLE configs
+    silently over-report hits by one block.
+    """
+    new_groups = []
+    for g in config.kv_cache_groups:
+        spec = g.kv_cache_spec
+        inner_specs = getattr(spec, "kv_cache_specs", None)
+        if inner_specs:
+            inner = next(iter(inner_specs.values()))
+            new_groups.append(
+                KVCacheGroupSpec(g.layer_names, inner, is_eagle_group=g.is_eagle_group)
+            )
+        else:
+            new_groups.append(g)
+    return KVCacheConfig(
+        num_blocks=config.num_blocks,
+        kv_cache_tensors=config.kv_cache_tensors,
+        kv_cache_groups=new_groups,
+    )
+
+
+class UnknownManagerSpecError(ValueError):
+    """A kv_cache_group has a spec type missing from
+    ``spec_manager_map``. Caller disables external hits to avoid
+    over-reporting by skipping the unknown group."""
+
+
+class HashBlockSizeMisalignedError(ValueError):
+    """A kv_cache_group's ``block_size`` is not divisible by
+    ``hash_block_size``."""
+
+
+class MooncakeLookupCoordinator(HybridKVCacheCoordinator):
+    """Inherits ``HybridKVCacheCoordinator.find_longest_cache_hit`` and
+    skips the parent ``__init__`` so we don't pay for a GPU-backed
+    ``BlockPool`` or per-group managers we don't need.
+
+    Attrs ``find_longest_cache_hit`` reads, all populated below:
+    ``kv_cache_config``, ``attention_groups``, ``lcm_block_size``,
+    ``hash_block_size``, ``eagle_attn_group_indices``, ``block_pool``
+    (overwritten per-call by the worker).
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        hash_block_size: int,
+        use_eagle: bool = False,
+    ):
+        # Skip both parent __init__s — they'd build a real GPU BlockPool
+        # and per-group managers we don't need for read-only hit detection.
+        self.kv_cache_config = _unwrap_kv_cache_config(kv_cache_config)
+        self.hash_block_size = hash_block_size
+
+        # Re-assert the parent's invariant since we skipped its __init__:
+        # build_block_pool's scale = block_size // hash_block_size would
+        # silently round otherwise.
+        for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
+            bs = g.kv_cache_spec.block_size
+            if bs % hash_block_size != 0:
+                raise HashBlockSizeMisalignedError(
+                    f"Group {i} block_size={bs} is not divisible by "
+                    f"hash_block_size={hash_block_size}."
+                )
+
+        # Mirror KVCacheCoordinator.__init__'s eagle-group derivation: prefer
+        # explicit per-group is_eagle_group flags; fall back to flagging all
+        # groups when use_eagle=True but nothing is annotated, otherwise an
+        # EAGLE config silently over-reports hits by one block.
+        self.eagle_group_ids: set[int] = {
+            i
+            for i, g in enumerate(self.kv_cache_config.kv_cache_groups)
+            if g.is_eagle_group
+        }
+        if use_eagle and not self.eagle_group_ids:
+            self.eagle_group_ids = set(range(len(self.kv_cache_config.kv_cache_groups)))
+        # Filled by _build_attention_groups once attention_groups exists.
+        self.eagle_attn_group_indices: set[int] = set()
+        # Worker swaps in a fresh LookupBlockPool per lookup call.
+        self.block_pool: LookupBlockPool | None = None  # type: ignore[assignment]
+        self._build_attention_groups()
+
+    def _build_attention_groups(self) -> None:
+        """Group kv_cache_groups by spec type for batch hit-lookup.
+
+        Mirrors ``HybridKVCacheCoordinator.verify_and_split_kv_cache_groups``
+        with two adjustments:
+
+        * Allow single-group configs (no ``len > 1`` assert) so FA-only
+          models work uniformly.
+        * Raise :class:`UnknownManagerSpecError` on unmapped spec types
+          so the worker can fail-closed; silently skipping would
+          over-report hits by ignoring the unknown group.
+        """
+        groups: list[tuple[KVCacheSpec, list[int], type[SingleTypeKVCacheManager]]] = []
+        for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
+            spec = g.kv_cache_spec
+            manager_cls = spec_manager_map.get(type(spec))
+            if manager_cls is None:
+                raise UnknownManagerSpecError(
+                    f"Unknown kv_cache_spec type {type(spec).__name__!r} "
+                    f"at group {i}; coordinator path can't safely "
+                    f"aggregate. Worker will disable external cache "
+                    f"hits for this config."
+                )
+            for existing_spec, group_ids, existing_cls in groups:
+                if existing_spec == spec:
+                    assert manager_cls is existing_cls, (
+                        "Same spec mapped to different manager classes"
+                    )
+                    group_ids.append(i)
+                    break
+            else:
+                groups.append((spec, [i], manager_cls))
+
+        # FA first (tightest initial bound for the iterative loop).
+        groups.sort(key=lambda x: not isinstance(x[0], FullAttentionSpec))
+        self.attention_groups = groups
+        block_sizes = [s.block_size for s, _, _ in groups]
+        self.lcm_block_size: int = lcm(*block_sizes) if block_sizes else 1
+        # Mirror ``HybridKVCacheCoordinator.verify_and_split_kv_cache_groups``:
+        # mark attention_groups containing any eagle group_id.
+        self.eagle_attn_group_indices = {
+            i
+            for i, (_, group_ids, _) in enumerate(self.attention_groups)
+            if any(gid in self.eagle_group_ids for gid in group_ids)
+        }
+
+    def normalize_block_hashes(
+        self,
+        block_hashes: list[BlockHash] | list[bytes] | list[str],
+    ) -> list[BlockHash]:
+        """Return byte-backed block hashes for manager and planner code."""
+        if not block_hashes:
+            return []
+        if isinstance(block_hashes[0], str):
+            return [BlockHash(bytes.fromhex(h)) for h in cast(list[str], block_hashes)]
+        return [BlockHash(bytes(h)) for h in cast(list[bytes], block_hashes)]
+
+    def _chunk_for_group(
+        self,
+        group_id: int,
+        chunk_id: int,
+        block_hashes: list[BlockHash],
+        token_len: int,
+    ) -> MooncakeChunk | None:
+        spec = self.kv_cache_config.kv_cache_groups[group_id].kv_cache_spec
+        start = chunk_id * spec.block_size
+        if start >= token_len:
+            return None
+        end = min(start + spec.block_size, token_len)
+        if end % self.hash_block_size != 0:
+            return None
+        hash_index = end // self.hash_block_size - 1
+        if not (0 <= hash_index < len(block_hashes)):
+            return None
+        return MooncakeChunk(
+            group_id=group_id,
+            chunk_id=chunk_id,
+            start=start,
+            end=end,
+            hash_index=hash_index,
+            block_hash=block_hashes[hash_index],
+        )
+
+    def iter_group_chunks(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash] | list[bytes] | list[str],
+        mask_num: int = 0,
+    ) -> list[MooncakeChunk]:
+        """Return all hash-addressable chunks for every KV cache group."""
+        hashes = self.normalize_block_hashes(block_hashes)
+        chunks: list[MooncakeChunk] = []
+        for group_id, group in enumerate(self.kv_cache_config.kv_cache_groups):
+            total_chunks = cdiv(token_len, group.kv_cache_spec.block_size)
+            for chunk_id in range(total_chunks):
+                chunk = self._chunk_for_group(group_id, chunk_id, hashes, token_len)
+                if chunk is not None and chunk.start >= mask_num:
+                    chunks.append(chunk)
+        return chunks
+
+    def _resident_chunk_ids(
+        self,
+        token_len: int,
+        block_ids: list[list[int]] | list[int],
+    ) -> set[tuple[int, int]]:
+        if block_ids and isinstance(block_ids[0], list):
+            per_group = cast(list[list[int]], block_ids)
+        else:
+            per_group = [cast(list[int], block_ids)]
+
+        resident: set[tuple[int, int]] = set()
+        for group_id, group_block_ids in enumerate(per_group):
+            if group_id >= len(self.kv_cache_config.kv_cache_groups):
+                continue
+            spec = self.kv_cache_config.kv_cache_groups[group_id].kv_cache_spec
+            total_chunks = cdiv(token_len, spec.block_size)
+            offset = total_chunks - len(group_block_ids)
+            for local_i in range(len(group_block_ids)):
+                chunk_id = offset + local_i
+                if 0 <= chunk_id < total_chunks:
+                    resident.add((chunk_id, group_id))
+        return resident
+
+    def plan_store_chunks(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash] | list[bytes] | list[str],
+        block_ids: list[list[int]] | list[int],
+    ) -> list[MooncakeChunk]:
+        """Return chunks that are physically resident and worth storing.
+
+        The scheduler/coordinator path already normalizes block tables by KV
+        spec. The worker consumes this generic plan instead of hard-coding
+        sliding-window clipping.
+        """
+        resident = self._resident_chunk_ids(token_len, block_ids)
+        return [
+            chunk
+            for chunk in self.iter_group_chunks(token_len, block_hashes)
+            if (chunk.chunk_id, chunk.group_id) in resident
+        ]
+
+    def plan_load_chunks(
+        self,
+        token_len: int,
+        block_hashes: list[BlockHash] | list[bytes] | list[str],
+        block_ids: list[list[int]] | list[int],
+        mask_num: int = 0,
+    ) -> list[MooncakeChunk]:
+        """Return resident chunks to load for an externally cached prefix."""
+        resident = self._resident_chunk_ids(token_len, block_ids)
+        return [
+            chunk
+            for chunk in self.iter_group_chunks(token_len, block_hashes, mask_num)
+            if (chunk.chunk_id, chunk.group_id) in resident
+        ]
+
+    def plan_load_chunks_from_hit_blocks(
+        self,
+        hit_blocks: tuple[list[Any], ...],
+        mask_num: int = 0,
+    ) -> list[MooncakeChunk]:
+        """Extract real Mooncake chunks from manager-produced hit blocks."""
+        chunks: list[MooncakeChunk] = []
+        seen: set[tuple[int, int]] = set()
+        for blocks in hit_blocks:
+            for block in blocks:
+                if getattr(block, "is_null", False):
+                    continue
+                chunk = getattr(block, "chunk", None)
+                if chunk is None or chunk.start < mask_num:
+                    continue
+                key = (chunk.group_id, chunk.chunk_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                chunks.append(chunk)
+        return sorted(chunks, key=lambda c: (c.group_id, c.chunk_id))
+
+    def build_block_pool(
+        self,
+        chunk_group_to_exists: dict[tuple[int, int], int],
+        block_hashes: list[BlockHash],
+    ) -> LookupBlockPool:
+        """Build the per-call pool from Mooncake's exists bits.
+
+        Each (chunk, group_id) with ``exists == 1`` is inserted under the
+        same key shape upstream's ``BlockHashListWithBlockSize`` produces:
+        the concat hash spans ``scale = block_size // hash_block_size``
+        consecutive ``block_hashes`` entries (or one when ``scale == 1``).
+        Misses (0 / -1) are simply absent from the dict.
+        """
+        cached: dict[bytes, _LookupBlock] = {}
+        groups = self.kv_cache_config.kv_cache_groups
+        for (chunk_id, group_id), exists in chunk_group_to_exists.items():
+            if exists != 1:
+                continue
+            spec = groups[group_id].kv_cache_spec
+            scale = spec.block_size // self.hash_block_size
+            base = chunk_id * scale
+            end = base + scale
+            if end > len(block_hashes):
+                continue
+            if scale == 1:
+                concat_hash: BlockHash = block_hashes[base]
+            else:
+                concat_hash = BlockHash(b"".join(block_hashes[base:end]))
+            key = make_block_hash_with_group_id(concat_hash, group_id)
+            chunk = self._chunk_for_group(
+                group_id,
+                chunk_id,
+                block_hashes,
+                token_len=len(block_hashes) * self.hash_block_size,
+            )
+            cached[bytes(key)] = _LookupBlock(chunk=chunk)
+        return LookupBlockPool(cached)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -23,6 +23,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorPromMetrics,
@@ -83,7 +84,7 @@ class MooncakeStoreKVEvents(KVConnectorKVEvents):
         return f"<MooncakeStoreKVEvents events={self.get_all_events()}>"
 
 
-class MooncakeStoreConnector(KVConnectorBase_V1):
+class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     """KV connector using MooncakeDistributedStore as shared KV pool."""
 
     @property
@@ -112,9 +113,15 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         self.connector_worker: MooncakeStoreWorker | None = None
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = MooncakeStoreScheduler(vllm_config)
+            self.connector_scheduler = MooncakeStoreScheduler(
+                vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
         else:
-            self.connector_worker = MooncakeStoreWorker(vllm_config)
+            self.connector_worker = MooncakeStoreWorker(
+                vllm_config,
+                kv_cache_config=kv_cache_config,
+            )
             if vllm_config.parallel_config.rank == 0:
                 self.lookup_server = LookupKeyServer(self.connector_worker, vllm_config)
 
@@ -153,7 +160,15 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
     def request_finished(
         self,
         request: Request,
-        block_ids: list[int],
+        block_ids: tuple[list[int], ...] | list[int] | list[list[int]],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    def request_finished_all_groups(
+        self,
+        request: Request,
+        block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
@@ -4,7 +4,9 @@
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional
+from functools import reduce
+from math import lcm
+from typing import Optional, cast
 
 import torch
 
@@ -31,10 +33,15 @@ class KeyMetadata:
 
 @dataclass(order=True)
 class PoolKey:
-    """Key for addressing KV cache blocks in the distributed store."""
+    """Key for addressing KV cache blocks in the distributed store.
+
+    `group_id=None` keeps the pre-HMA wire format. HMA callers pass an
+    id so `to_string()` appends `@grp:{g}`.
+    """
 
     key_metadata: KeyMetadata
     chunk_hash: str
+    group_id: int | None = None
 
     def __hash__(self):
         return hash(
@@ -45,11 +52,12 @@ class PoolKey:
                 self.key_metadata.dcp_rank,
                 self.key_metadata.pp_rank,
                 self.chunk_hash,
+                self.group_id,
             )
         )
 
     def to_string(self) -> str:
-        return (
+        base = (
             f"{self.key_metadata.model_name}"
             f"@tp_rank:{self.key_metadata.tp_rank}"
             f"@pcp{self.key_metadata.pcp_rank}"
@@ -57,6 +65,21 @@ class PoolKey:
             f"@pp_rank:{self.key_metadata.pp_rank}"
             f"@{self.chunk_hash}"
         )
+        if self.group_id is None:
+            return base
+        return f"{base}@grp:{self.group_id}"
+
+
+@dataclass
+class GroupLayout:
+    """Per-KV-cache-group memory layout.
+
+    base_addrs and block_lens are flattened across the group's layers and
+    K/V segments; entry i is one (layer, K|V) pair.
+    """
+
+    base_addrs: list[int]
+    block_lens: list[int]
 
 
 class ChunkedTokenDatabase:
@@ -65,49 +88,227 @@ class ChunkedTokenDatabase:
     def __init__(self, metadata: KeyMetadata, block_size: int):
         self.metadata = metadata
         self.block_size = block_size
+        # Flat views over groups. `kv_caches_base_addr[seg_idx]` and
+        # `block_len[seg_idx]` are what `prepare_value` iterates;
+        # `set_groups` populates them by flattening `groups`.
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
+        self.groups: list[GroupLayout] = []
+        # layer_to_group[seg_idx] -> which group owns segment seg_idx.
+        self.layer_to_group: list[int] = []
+        # Per-group SWA window in blocks; 0 = FA / no clip.
+        self.blocks_per_sw: list[int] = []
+        # Per-group native block_size in tokens (HMA: mixed; else uniform).
+        self.group_block_sizes: list[int] = []
+        # block_hashes granularity = GCD(group_block_sizes). Each chunk's
+        # key uses block_hashes[end_idx // hash_block_size - 1] (right-edge).
+        self.hash_block_size: int = block_size
+        # vllm allocator alignment = LCM(group_block_sizes). Used for
+        # lookup return-value rounding and mask_num. NOT cache_config.block_size:
+        # engine mutates that to MIN(group_block_sizes) for HMA.
+        self.scheduler_block_size: int = block_size
 
-    def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
-        return PoolKey(self.metadata, chunk_hash)
+    def _make_key_by_hash(
+        self,
+        chunk_hash: str,
+        group_id: int | None = None,
+    ) -> PoolKey:
+        return PoolKey(self.metadata, chunk_hash, group_id)
 
-    def set_kv_caches_base_addr(self, kv_caches_base_addr: list[int]):
-        self.kv_caches_base_addr = kv_caches_base_addr
+    def set_groups(
+        self,
+        groups: list[GroupLayout],
+        layer_to_group: list[int],
+    ) -> None:
+        """Group-aware setter — flattens groups into kv_caches_base_addr/block_len."""
+        self.groups = groups
+        self.layer_to_group = layer_to_group
+        flat_addrs: list[int] = []
+        flat_lens: list[int] = []
+        for layout in groups:
+            flat_addrs.extend(layout.base_addrs)
+            flat_lens.extend(layout.block_lens)
+        self.kv_caches_base_addr = flat_addrs
+        self.block_len = flat_lens
+        # Default to "no window" so legacy single-group callers behave like FA.
+        if len(self.blocks_per_sw) != len(groups):
+            self.blocks_per_sw = [0] * len(groups)
 
-    def set_block_len(self, block_len: list[int]):
-        self.block_len = block_len
+    def set_blocks_per_sw(self, blocks_per_sw: list[int]) -> None:
+        """Per-group window in blocks (0 = FA / no clip)."""
+        if self.groups and len(blocks_per_sw) != len(self.groups):
+            raise ValueError(
+                f"blocks_per_sw length {len(blocks_per_sw)} != "
+                f"num_groups {len(self.groups)}"
+            )
+        self.blocks_per_sw = list(blocks_per_sw)
+
+    def set_group_block_sizes(
+        self,
+        group_block_sizes: list[int],
+        hash_block_size: int,
+        scheduler_block_size: int | None = None,
+    ) -> None:
+        """Set per-group native block sizes, hash block size, scheduler block size.
+
+        `scheduler_block_size` defaults to LCM(group_block_sizes).
+        """
+        if self.groups and len(group_block_sizes) != len(self.groups):
+            raise ValueError(
+                f"group_block_sizes length {len(group_block_sizes)} != "
+                f"num_groups {len(self.groups)}"
+            )
+        self.group_block_sizes = list(group_block_sizes)
+        self.hash_block_size = max(1, hash_block_size)
+        if scheduler_block_size is not None and scheduler_block_size > 0:
+            self.scheduler_block_size = scheduler_block_size
+        elif group_block_sizes:
+            self.scheduler_block_size = reduce(lcm, group_block_sizes)
+        else:
+            self.scheduler_block_size = self.block_size
+
+    def _g_block_size(self, group_id: int) -> int:
+        """Return group `group_id`'s native block_size (falls back to global)."""
+        if self.group_block_sizes and group_id < len(self.group_block_sizes):
+            return self.group_block_sizes[group_id]
+        return self.block_size
+
+    @staticmethod
+    def _normalize_per_group(
+        block_ids: list[list[int]] | list[int],
+    ) -> list[list[int]]:
+        """Coerce a flat list[int] to a single-group list[list[int]]."""
+        if block_ids and not isinstance(block_ids[0], list):
+            return [cast(list[int], block_ids)]
+        return cast(list[list[int]], block_ids)
 
     def prepare_value(
-        self, start: int, end: int, block_ids: list[int]
+        self,
+        start: int,
+        end: int,
+        block_ids: list[list[int]] | list[int],
+        group_id: int | None = None,
+        total_chunks: int | None = None,
     ) -> tuple[list[int], list[int], int]:
-        """Compute memory addresses and sizes for a token range.
+        """Memory addrs + sizes for a token range.
 
-        Returns:
-            (addr_list, size_list, block_id)
+        With `group_id` set, emits only that group's segments at its native
+        block_size. Without it, emits all segments scaled by `self.block_size`
+        (single-group / pre-HMA shape). `total_chunks` defaults to
+        `max(len(g))`.
         """
-        addr_list = []
-        size_list = []
-        block_id = block_ids[start // self.block_size]
-        length = len(self.block_len)
-        for index, base_addr in enumerate(self.kv_caches_base_addr):
-            addr = base_addr + block_id * self.block_len[index % length]
-            size = int(self.block_len[index % length] / self.block_size * (end - start))
+        per_group = self._normalize_per_group(block_ids)
+        scoped_block_size = (
+            self._g_block_size(group_id) if group_id is not None else self.block_size
+        )
+        chunk_id = start // scoped_block_size
+        if total_chunks is None:
+            total_chunks = max(len(g) for g in per_group) if per_group else 0
+        # SWA groups have shorter block_ids; offset shifts chunk_id into the
+        # group's local frame.
+        per_group_local: list[int] = []
+        for group in per_group:
+            offset = total_chunks - len(group)
+            local_i = chunk_id - offset
+            per_group_local.append(local_i if 0 <= local_i < len(group) else -1)
+
+        addr_list: list[int] = []
+        size_list: list[int] = []
+        last_block_id = 0
+        for seg_idx, base_addr in enumerate(self.kv_caches_base_addr):
+            g = self.layer_to_group[seg_idx] if self.layer_to_group else 0
+            if group_id is not None and g != group_id:
+                continue
+            local_i = per_group_local[g]
+            if local_i < 0:
+                # Out-of-window; per-group callers filter via
+                # is_chunk_in_window. Emit zeros to preserve list shape.
+                addr_list.append(0)
+                size_list.append(0)
+                continue
+            block_id = per_group[g][local_i]
+            block_len = self.block_len[seg_idx]
+            addr = base_addr + block_id * block_len
+            size = int(block_len / scoped_block_size * (end - start))
             addr_list.append(addr)
             size_list.append(size)
-        return addr_list, size_list, block_id
+            last_block_id = block_id
+        return addr_list, size_list, last_block_id
+
+    def is_chunk_savable(
+        self,
+        start: int,
+        block_ids: list[list[int]] | list[int],
+    ) -> bool:
+        """Legacy all-groups gate. Per-group code uses is_chunk_in_window*."""
+        per_group = self._normalize_per_group(block_ids)
+        if not per_group:
+            return False
+        chunk_id = start // self.block_size
+        total_chunks = max(len(g) for g in per_group)
+        for group in per_group:
+            offset = total_chunks - len(group)
+            local_i = chunk_id - offset
+            if not (0 <= local_i < len(group)):
+                return False
+        return True
+
+    def is_chunk_in_window(
+        self,
+        chunk_id: int,
+        total_chunks: int,
+        group_id: int,
+    ) -> bool:
+        """Lookup-side window check using static `blocks_per_sw` (no block_ids)."""
+        if not self.blocks_per_sw or group_id >= len(self.blocks_per_sw):
+            return True
+        sw_blocks = self.blocks_per_sw[group_id]
+        if sw_blocks == 0:
+            return True
+        return chunk_id >= total_chunks - sw_blocks
+
+    def is_chunk_in_window_per_request(
+        self,
+        chunk_id: int,
+        block_ids: list[list[int]] | list[int],
+        group_id: int,
+        total_chunks: int | None = None,
+    ) -> bool:
+        """Save/load-side window check using observed `block_ids` shape.
+
+        `total_chunks` must match the lookup path (= `cdiv(token_len,
+        block_size)`); without it SWA offsets disagree by ±1 when vllm
+        allocates a scratch block beyond the live prefix. Defaults to
+        `max(len(g))`.
+        """
+        per_group = self._normalize_per_group(block_ids)
+        if not per_group or group_id >= len(per_group):
+            return True
+        if total_chunks is None:
+            total_chunks = max(len(g) for g in per_group)
+        group_blocks = per_group[group_id]
+        local_i = chunk_id - (total_chunks - len(group_blocks))
+        return 0 <= local_i < len(group_blocks)
 
     def process_tokens(
         self,
         token_len: int,
         block_hashes: list[BlockHash] | list[str],
         mask_num: int = 0,
-    ) -> Iterable[tuple[int, int, PoolKey]]:
-        """Process tokens and yield (start_idx, end_idx, pool_key) tuples.
+    ) -> Iterable[tuple[int, int, int, PoolKey]]:
+        """Yield (start, end, group_id, pool_key) per (chunk, group).
 
-        Args:
-            token_len: Total number of tokens.
-            block_hashes: Block hashes for each block.
-            mask_num: Number of tokens to skip from the beginning.
+        Each group iterates at its OWN native block_size; callers
+        window-clip via `is_chunk_in_window*`.
+
+        Each key's hash is `block_hashes[end_idx // hash_block_size - 1]`
+        (right-edge), so groups with `g_block_size > hash_block_size`
+        fingerprint the full chunk content instead of only the first
+        `hash_block_size` tokens.
+
+        Single-group keys use `group_id=None` so the wire format matches
+        the pre-HMA shape; existing master state stays valid. Callers
+        must filter out-of-window (chunk, group) tuples themselves.
         """
         if not block_hashes:
             return
@@ -116,15 +317,33 @@ class ChunkedTokenDatabase:
                 h.hex()  # type: ignore[union-attr]
                 for h in block_hashes
             ]
-        for chunk_id, hash_val in enumerate(block_hashes):
-            start_idx = chunk_id * self.block_size
-            if start_idx >= token_len:
-                break
-            end_idx = min(start_idx + self.block_size, token_len)
-            if start_idx < mask_num:
-                continue
-            else:
-                yield start_idx, end_idx, self._make_key_by_hash(hash_val)
+        num_groups = max(1, len(self.groups))
+        emit_group_id = num_groups > 1
+        n_hashes = len(block_hashes)
+        hash_bs = max(1, self.hash_block_size)
+        for g in range(num_groups):
+            g_block_size = self._g_block_size(g)
+            chunk_id = 0
+            while True:
+                start_idx = chunk_id * g_block_size
+                if start_idx >= token_len:
+                    break
+                end_idx = min(start_idx + g_block_size, token_len)
+                if start_idx >= mask_num:
+                    # Skip non-hash-aligned partial tail: block_hashes
+                    # only fingerprints up to the last full hash_bs
+                    # boundary, so emitting a key here would leave the
+                    # trailing 1..hash_bs-1 tokens unfingerprinted.
+                    if end_idx % hash_bs != 0:
+                        chunk_id += 1
+                        continue
+                    hash_idx = end_idx // hash_bs - 1
+                    if 0 <= hash_idx < n_hashes:
+                        key = self._make_key_by_hash(
+                            block_hashes[hash_idx], g if emit_group_id else None
+                        )
+                        yield start_idx, end_idx, g, key
+                chunk_id += 1
 
 
 @dataclass
@@ -143,23 +362,40 @@ class RequestTracker:
 
     req_id: str
     token_len: int
-    allocated_block_ids: list[int]
+    # One list of block ids per KV cache group. Single-group models use [[...]]
+    allocated_block_ids: list[list[int]]
     num_saved_tokens: int = 0
     token_ids: list[int] | None = None
 
     def update(
         self,
-        new_block_ids: tuple[list[int], ...] | list[int],
+        new_block_ids: tuple[list[int], ...] | list[list[int]] | list[int],
     ) -> None:
+        """Append new blocks to each group.
+
+        Accepts:
+          - tuple/list of per-group block lists (HMA shape)
+          - flat list[int] for legacy single-group callers
+        """
         if len(new_block_ids) == 0:
-            new_block_ids = []
-        elif isinstance(new_block_ids, tuple):
-            new_block_ids = new_block_ids[0]
+            return
+
+        if isinstance(new_block_ids, tuple):
+            per_group = list(new_block_ids)
+        elif isinstance(new_block_ids, list) and isinstance(new_block_ids[0], list):
+            per_group = cast(list[list[int]], new_block_ids)
         elif isinstance(new_block_ids, list):
-            pass
+            self.allocated_block_ids[0].extend(cast(list[int], new_block_ids))
+            return
         else:
             raise ValueError(f"Unsupported new_block_ids type {type(new_block_ids)}")
-        self.allocated_block_ids.extend(new_block_ids)
+
+        assert len(per_group) == len(self.allocated_block_ids), (
+            f"KV group count mismatch on update: got {len(per_group)} "
+            f"groups, tracker has {len(self.allocated_block_ids)}"
+        )
+        for g, group_blocks in enumerate(per_group):
+            self.allocated_block_ids[g].extend(group_blocks)
 
 
 @dataclass
@@ -168,7 +404,7 @@ class ReqMeta:
 
     req_id: str
     token_len_chunk: int
-    block_ids: list[int]
+    block_ids: list[list[int]]
     block_hashes: list[BlockHash]
 
     can_save: bool | None = None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_data.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Data classes for MooncakeStoreConnector."""
 
-from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import reduce
 from math import lcm
@@ -82,6 +81,84 @@ class GroupLayout:
     block_lens: list[int]
 
 
+@dataclass
+class GroupDatabase:
+    """Token/address database for one KV cache group.
+
+    This owns the group's memory layout and block sizing. The parent
+    ``ChunkedTokenDatabase`` holds the group list and flat layout views, while
+    group-specific callers use this object directly.
+    """
+
+    metadata: KeyMetadata
+    group_id: int
+    layout: GroupLayout
+    block_size: int
+    hash_block_size: int
+    emit_group_id: bool = False
+
+    def _make_key_by_hash(self, chunk_hash: str) -> PoolKey:
+        return PoolKey(
+            self.metadata,
+            chunk_hash,
+            self.group_id if self.emit_group_id else None,
+        )
+
+    def make_key(self, chunk_hash: BlockHash | bytes | str) -> PoolKey:
+        """Build this group's Mooncake key from a right-edge chunk hash."""
+        if isinstance(chunk_hash, str):
+            hash_str = chunk_hash
+        else:
+            hash_str = bytes(chunk_hash).hex()
+        return self._make_key_by_hash(hash_str)
+
+    def _select_block_ids(
+        self,
+        block_ids: list[list[int]] | list[int],
+    ) -> list[int]:
+        """Accept either full per-group block_ids or this group's local list."""
+        if block_ids and isinstance(block_ids[0], list):
+            per_group = cast(list[list[int]], block_ids)
+            if self.group_id >= len(per_group):
+                return []
+            return per_group[self.group_id]
+        return cast(list[int], block_ids)
+
+    def prepare_value(
+        self,
+        start: int,
+        end: int,
+        block_ids: list[list[int]] | list[int],
+        total_chunks: int,
+    ) -> tuple[list[int], list[int], int]:
+        """Memory addrs + sizes for ``[start, end)`` in this group."""
+        group_block_ids = self._select_block_ids(block_ids)
+        chunk_id = start // self.block_size
+        local_i = chunk_id - (total_chunks - len(group_block_ids))
+
+        addr_list: list[int] = []
+        size_list: list[int] = []
+        last_block_id = 0
+        for base_addr, block_len in zip(
+            self.layout.base_addrs,
+            self.layout.block_lens,
+            strict=True,
+        ):
+            if not (0 <= local_i < len(group_block_ids)):
+                # No resident block for this logical chunk. Coordinated
+                # transfer plans avoid this; preserve list shape defensively.
+                addr_list.append(0)
+                size_list.append(0)
+                continue
+            block_id = group_block_ids[local_i]
+            addr = base_addr + block_id * block_len
+            size = int(block_len / self.block_size * (end - start))
+            addr_list.append(addr)
+            size_list.append(size)
+            last_block_id = block_id
+        return addr_list, size_list, last_block_id
+
+
 class ChunkedTokenDatabase:
     """Maps token positions to store keys and GPU memory addresses."""
 
@@ -96,8 +173,6 @@ class ChunkedTokenDatabase:
         self.groups: list[GroupLayout] = []
         # layer_to_group[seg_idx] -> which group owns segment seg_idx.
         self.layer_to_group: list[int] = []
-        # Per-group SWA window in blocks; 0 = FA / no clip.
-        self.blocks_per_sw: list[int] = []
         # Per-group native block_size in tokens (HMA: mixed; else uniform).
         self.group_block_sizes: list[int] = []
         # block_hashes granularity = GCD(group_block_sizes). Each chunk's
@@ -107,13 +182,7 @@ class ChunkedTokenDatabase:
         # lookup return-value rounding and mask_num. NOT cache_config.block_size:
         # engine mutates that to MIN(group_block_sizes) for HMA.
         self.scheduler_block_size: int = block_size
-
-    def _make_key_by_hash(
-        self,
-        chunk_hash: str,
-        group_id: int | None = None,
-    ) -> PoolKey:
-        return PoolKey(self.metadata, chunk_hash, group_id)
+        self.group_dbs: list[GroupDatabase] = []
 
     def set_groups(
         self,
@@ -130,18 +199,7 @@ class ChunkedTokenDatabase:
             flat_lens.extend(layout.block_lens)
         self.kv_caches_base_addr = flat_addrs
         self.block_len = flat_lens
-        # Default to "no window" so legacy single-group callers behave like FA.
-        if len(self.blocks_per_sw) != len(groups):
-            self.blocks_per_sw = [0] * len(groups)
-
-    def set_blocks_per_sw(self, blocks_per_sw: list[int]) -> None:
-        """Per-group window in blocks (0 = FA / no clip)."""
-        if self.groups and len(blocks_per_sw) != len(self.groups):
-            raise ValueError(
-                f"blocks_per_sw length {len(blocks_per_sw)} != "
-                f"num_groups {len(self.groups)}"
-            )
-        self.blocks_per_sw = list(blocks_per_sw)
+        self._rebuild_group_dbs()
 
     def set_group_block_sizes(
         self,
@@ -166,6 +224,7 @@ class ChunkedTokenDatabase:
             self.scheduler_block_size = reduce(lcm, group_block_sizes)
         else:
             self.scheduler_block_size = self.block_size
+        self._rebuild_group_dbs()
 
     def _g_block_size(self, group_id: int) -> int:
         """Return group `group_id`'s native block_size (falls back to global)."""
@@ -173,177 +232,36 @@ class ChunkedTokenDatabase:
             return self.group_block_sizes[group_id]
         return self.block_size
 
-    @staticmethod
-    def _normalize_per_group(
-        block_ids: list[list[int]] | list[int],
-    ) -> list[list[int]]:
-        """Coerce a flat list[int] to a single-group list[list[int]]."""
-        if block_ids and not isinstance(block_ids[0], list):
-            return [cast(list[int], block_ids)]
-        return cast(list[list[int]], block_ids)
+    def _rebuild_group_dbs(self) -> None:
+        """Rebuild per-group databases from the current group geometry."""
+        emit_group_id = len(self.groups) > 1
+        self.group_dbs = [
+            GroupDatabase(
+                metadata=self.metadata,
+                group_id=group_id,
+                layout=layout,
+                block_size=self._g_block_size(group_id),
+                hash_block_size=self.hash_block_size,
+                emit_group_id=emit_group_id,
+            )
+            for group_id, layout in enumerate(self.groups)
+        ]
 
-    def prepare_value(
-        self,
-        start: int,
-        end: int,
-        block_ids: list[list[int]] | list[int],
-        group_id: int | None = None,
-        total_chunks: int | None = None,
-    ) -> tuple[list[int], list[int], int]:
-        """Memory addrs + sizes for a token range.
-
-        With `group_id` set, emits only that group's segments at its native
-        block_size. Without it, emits all segments scaled by `self.block_size`
-        (single-group / pre-HMA shape). `total_chunks` defaults to
-        `max(len(g))`.
-        """
-        per_group = self._normalize_per_group(block_ids)
-        scoped_block_size = (
-            self._g_block_size(group_id) if group_id is not None else self.block_size
-        )
-        chunk_id = start // scoped_block_size
-        if total_chunks is None:
-            total_chunks = max(len(g) for g in per_group) if per_group else 0
-        # SWA groups have shorter block_ids; offset shifts chunk_id into the
-        # group's local frame.
-        per_group_local: list[int] = []
-        for group in per_group:
-            offset = total_chunks - len(group)
-            local_i = chunk_id - offset
-            per_group_local.append(local_i if 0 <= local_i < len(group) else -1)
-
-        addr_list: list[int] = []
-        size_list: list[int] = []
-        last_block_id = 0
-        for seg_idx, base_addr in enumerate(self.kv_caches_base_addr):
-            g = self.layer_to_group[seg_idx] if self.layer_to_group else 0
-            if group_id is not None and g != group_id:
-                continue
-            local_i = per_group_local[g]
-            if local_i < 0:
-                # Out-of-window; per-group callers filter via
-                # is_chunk_in_window. Emit zeros to preserve list shape.
-                addr_list.append(0)
-                size_list.append(0)
-                continue
-            block_id = per_group[g][local_i]
-            block_len = self.block_len[seg_idx]
-            addr = base_addr + block_id * block_len
-            size = int(block_len / scoped_block_size * (end - start))
-            addr_list.append(addr)
-            size_list.append(size)
-            last_block_id = block_id
-        return addr_list, size_list, last_block_id
-
-    def is_chunk_savable(
-        self,
-        start: int,
-        block_ids: list[list[int]] | list[int],
-    ) -> bool:
-        """Legacy all-groups gate. Per-group code uses is_chunk_in_window*."""
-        per_group = self._normalize_per_group(block_ids)
-        if not per_group:
-            return False
-        chunk_id = start // self.block_size
-        total_chunks = max(len(g) for g in per_group)
-        for group in per_group:
-            offset = total_chunks - len(group)
-            local_i = chunk_id - offset
-            if not (0 <= local_i < len(group)):
-                return False
-        return True
-
-    def is_chunk_in_window(
-        self,
-        chunk_id: int,
-        total_chunks: int,
-        group_id: int,
-    ) -> bool:
-        """Lookup-side window check using static `blocks_per_sw` (no block_ids)."""
-        if not self.blocks_per_sw or group_id >= len(self.blocks_per_sw):
-            return True
-        sw_blocks = self.blocks_per_sw[group_id]
-        if sw_blocks == 0:
-            return True
-        return chunk_id >= total_chunks - sw_blocks
-
-    def is_chunk_in_window_per_request(
-        self,
-        chunk_id: int,
-        block_ids: list[list[int]] | list[int],
-        group_id: int,
-        total_chunks: int | None = None,
-    ) -> bool:
-        """Save/load-side window check using observed `block_ids` shape.
-
-        `total_chunks` must match the lookup path (= `cdiv(token_len,
-        block_size)`); without it SWA offsets disagree by ±1 when vllm
-        allocates a scratch block beyond the live prefix. Defaults to
-        `max(len(g))`.
-        """
-        per_group = self._normalize_per_group(block_ids)
-        if not per_group or group_id >= len(per_group):
-            return True
-        if total_chunks is None:
-            total_chunks = max(len(g) for g in per_group)
-        group_blocks = per_group[group_id]
-        local_i = chunk_id - (total_chunks - len(group_blocks))
-        return 0 <= local_i < len(group_blocks)
-
-    def process_tokens(
-        self,
-        token_len: int,
-        block_hashes: list[BlockHash] | list[str],
-        mask_num: int = 0,
-    ) -> Iterable[tuple[int, int, int, PoolKey]]:
-        """Yield (start, end, group_id, pool_key) per (chunk, group).
-
-        Each group iterates at its OWN native block_size; callers
-        window-clip via `is_chunk_in_window*`.
-
-        Each key's hash is `block_hashes[end_idx // hash_block_size - 1]`
-        (right-edge), so groups with `g_block_size > hash_block_size`
-        fingerprint the full chunk content instead of only the first
-        `hash_block_size` tokens.
-
-        Single-group keys use `group_id=None` so the wire format matches
-        the pre-HMA shape; existing master state stays valid. Callers
-        must filter out-of-window (chunk, group) tuples themselves.
-        """
-        if not block_hashes:
-            return
-        if not isinstance(block_hashes[0], str):
-            block_hashes = [
-                h.hex()  # type: ignore[union-attr]
-                for h in block_hashes
-            ]
-        num_groups = max(1, len(self.groups))
-        emit_group_id = num_groups > 1
-        n_hashes = len(block_hashes)
-        hash_bs = max(1, self.hash_block_size)
-        for g in range(num_groups):
-            g_block_size = self._g_block_size(g)
-            chunk_id = 0
-            while True:
-                start_idx = chunk_id * g_block_size
-                if start_idx >= token_len:
-                    break
-                end_idx = min(start_idx + g_block_size, token_len)
-                if start_idx >= mask_num:
-                    # Skip non-hash-aligned partial tail: block_hashes
-                    # only fingerprints up to the last full hash_bs
-                    # boundary, so emitting a key here would leave the
-                    # trailing 1..hash_bs-1 tokens unfingerprinted.
-                    if end_idx % hash_bs != 0:
-                        chunk_id += 1
-                        continue
-                    hash_idx = end_idx // hash_bs - 1
-                    if 0 <= hash_idx < n_hashes:
-                        key = self._make_key_by_hash(
-                            block_hashes[hash_idx], g if emit_group_id else None
-                        )
-                        yield start_idx, end_idx, g, key
-                chunk_id += 1
+    def group(self, group_id: int) -> GroupDatabase:
+        """Return the independent token database for one KV cache group."""
+        if not self.group_dbs and group_id == 0:
+            return GroupDatabase(
+                metadata=self.metadata,
+                group_id=0,
+                layout=GroupLayout(
+                    base_addrs=self.kv_caches_base_addr,
+                    block_lens=self.block_len,
+                ),
+                block_size=self.block_size,
+                hash_block_size=self.hash_block_size,
+                emit_group_id=False,
+            )
+        return self.group_dbs[group_id]
 
 
 @dataclass
@@ -375,7 +293,7 @@ class RequestTracker:
 
         Accepts:
           - tuple/list of per-group block lists (HMA shape)
-          - flat list[int] for legacy single-group callers
+          - flat list[int] for single-group callers
         """
         if len(new_block_ids) == 0:
             return

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_metrics.py
@@ -54,9 +54,7 @@ class MooncakeStoreConnectorStats(KVConnectorStats):
         for operation, records in sorted(self.data.items()):
             if not records:
                 continue
-            durations = [
-                float(record["duration_seconds"]) for record in records
-            ]
+            durations = [float(record["duration_seconds"]) for record in records]
             reduced[f"{operation}_count"] = len(records)
             reduced[f"{operation}_avg_ms"] = round(fmean(durations) * 1e3, 3)
             reduced[f"{operation}_p90_ms"] = round(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -3,7 +3,9 @@
 """Scheduler-side logic for MooncakeStoreConnector."""
 
 import os
-from typing import Any
+from functools import reduce
+from math import lcm
+from typing import Any, cast
 
 import zmq
 
@@ -22,10 +24,16 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import
     get_mooncake_dp_engine_index,
 )
 from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    SlidingWindowSpec,
+)
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackEncoder
 
@@ -35,7 +43,11 @@ logger = init_logger(__name__)
 class MooncakeStoreScheduler:
     """Scheduler-side component for MooncakeStoreConnector."""
 
-    def __init__(self, vllm_config: VllmConfig):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig | None = None,
+    ):
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         self.load_async = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
             "load_async", False
@@ -45,8 +57,17 @@ class MooncakeStoreScheduler:
         self.load_specs: dict[str, LoadSpec] = {}
         self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
         self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        # Scheduler alignment = LCM(group_block_sizes); engine mutates
+        # cache_config.block_size to MIN for HMA. Fall back to
+        # cache_config.block_size for non-HMA / pre-spec callers.
         self.original_block_size = vllm_config.cache_config.block_size
-        self._block_size = vllm_config.cache_config.block_size
+        if kv_cache_config is not None and kv_cache_config.kv_cache_groups:
+            self._block_size = reduce(
+                lcm,
+                (g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups),
+            )
+        else:
+            self._block_size = vllm_config.cache_config.block_size
         if self.pcp_size > 1:
             self._block_size *= self.pcp_size
         if self.dcp_size > 1:
@@ -59,8 +80,60 @@ class MooncakeStoreScheduler:
                 "discard_partial_chunks", True
             )
         )
-        self._unfinished_requests: dict[str, tuple[Request, list[int]]] = {}
+        self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._unfinished_request_ids: set[str] = set()
+
+        # HMA detection. blocks_per_sw[g] is non-zero only for SlidingWindowSpec
+        # groups; FullAttentionSpec groups stay 0 and are never clipped.
+        self._is_hma_required = False
+        self.blocks_per_sw: list[int] = [0]
+        if kv_cache_config is not None:
+            self._is_hma_required = (
+                not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+                and any(
+                    not isinstance(g.kv_cache_spec, FullAttentionSpec)
+                    for g in kv_cache_config.kv_cache_groups
+                )
+            )
+            sw_sizes_tokens: list[tuple[int, int]] = [
+                (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
+                if isinstance(g.kv_cache_spec, SlidingWindowSpec)
+                else (0, self._block_size)
+                for g in kv_cache_config.kv_cache_groups
+            ]
+            self.blocks_per_sw = [
+                cdiv(n_tokens, block_size) + 1 if n_tokens else 0
+                for n_tokens, block_size in sw_sizes_tokens
+            ]
+
+    def get_sw_clipped_blocks(
+        self,
+        block_ids: tuple[list[int], ...] | list[list[int]],
+    ) -> list[list[int]]:
+        """Clip per-group block IDs to the SWA window. No-op for non-HMA."""
+        if len(block_ids) == 0 or not self._is_hma_required:
+            return list(block_ids)
+        return [
+            blocks[-self.blocks_per_sw[i] :] if self.blocks_per_sw[i] > 0 else blocks
+            for i, blocks in enumerate(block_ids)
+        ]
+
+    def _normalize_block_ids(
+        self,
+        block_ids: tuple[list[int], ...] | list[int] | list[list[int]],
+    ) -> list[list[int]]:
+        """Return a per-group list[list[int]] regardless of input shape."""
+        if isinstance(block_ids, tuple):
+            return self.get_sw_clipped_blocks(block_ids)
+        if (
+            isinstance(block_ids, list)
+            and len(block_ids) > 0
+            and isinstance(block_ids[0], list)
+        ):
+            return self.get_sw_clipped_blocks(cast(list[list[int]], block_ids))
+        # Flat list[int] → wrap as single group, no clipping.
+        flat = cast(list[int], block_ids)
+        return [list(flat)] if flat else [[]]
 
     def get_num_new_matched_tokens(
         self,
@@ -114,9 +187,13 @@ class MooncakeStoreScheduler:
         num_external_tokens: int,
     ):
         """Update state after block allocation."""
-        local_block_ids: list[int] = []
         if num_external_tokens > 0:
-            local_block_ids = blocks.get_block_ids()[0]
+            # Always per-group (tuple) → list[list[int]]; clip SWA groups.
+            local_block_ids = self.get_sw_clipped_blocks(blocks.get_block_ids())
+        else:
+            # One empty group per detected KV cache group, so subsequent
+            # .update() calls have correct shape.
+            local_block_ids = [[] for _ in range(len(self.blocks_per_sw))]
 
         self._unfinished_requests[request.request_id] = (request, local_block_ids)
         self._unfinished_request_ids.add(request.request_id)
@@ -174,10 +251,7 @@ class MooncakeStoreScheduler:
             request_tuple = self._unfinished_requests.get(request.req_id)
             request_real = request_tuple[0]  # type: ignore[index]
 
-            if not isinstance(request.block_ids[0], list):
-                unfolded_block_ids = request.block_ids.copy()
-            else:
-                unfolded_block_ids = request.block_ids[0].copy()
+            unfolded_block_ids = self._normalize_block_ids(request.block_ids)
 
             request_tracker = RequestTracker(
                 req_id=request.req_id,
@@ -218,10 +292,7 @@ class MooncakeStoreScheduler:
                 req_meta = None
                 if req_id in self._preempted_req_ids:
                     # Resumed after preemption
-                    if isinstance(new_block_ids, tuple):
-                        new_block_ids = new_block_ids[0].copy()
-                    else:
-                        new_block_ids = new_block_ids.copy()
+                    new_block_ids = self._normalize_block_ids(new_block_ids)
                     self._preempted_req_ids.discard(req_id)
                     load_spec = self.load_specs.pop(req_id, None)
                     request_tuple = self._unfinished_requests.get(req_id)
@@ -346,7 +417,7 @@ class MooncakeStoreScheduler:
     def request_finished(
         self,
         request: Request,
-        block_ids: list[int],
+        block_ids: tuple[list[int], ...] | list[int] | list[list[int]],
     ) -> tuple[bool, dict[str, Any] | None]:
         """Determine whether to delay freeing blocks for async save."""
         if self.kv_role == "kv_consumer":
@@ -354,11 +425,12 @@ class MooncakeStoreScheduler:
         tracker = self._request_trackers.get(request.request_id)
         if tracker is not None and tracker.num_saved_tokens <= 0:
             return False, None
-        delay_free_blocks = len(block_ids) > 0
+        normalized = self._normalize_block_ids(block_ids)
+        delay_free_blocks = any(len(group) > 0 for group in normalized)
         if delay_free_blocks:
             logger.debug(
-                "Delaying free of %d blocks for request %s",
-                len(block_ids),
+                "Delaying free of %s blocks for request %s",
+                [len(g) for g in normalized],
                 request.request_id,
             )
         return delay_free_blocks, None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -14,6 +14,8 @@ import time
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import reduce
+from math import gcd, lcm
 from typing import Any
 
 import regex as re
@@ -30,6 +32,7 @@ from vllm.distributed import (
 from vllm.distributed.kv_events import BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     ChunkedTokenDatabase,
+    GroupLayout,
     KeyMetadata,
     MooncakeStoreConnectorMetadata,
     ReqMeta,
@@ -41,8 +44,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import
     get_mooncake_dp_engine_index,
 )
 from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import get_ip, make_zmq_socket
 from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.serial_utils import MsgpackDecoder
 
 from .mooncake_store_metrics import MooncakeStoreConnectorStats
@@ -386,21 +391,73 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.request_queue.task_done()
             return
 
-        starts = []
-        ends = []
-        keys = []
+        # HMA: assert per-group block_ids matches the registered group count.
+        num_groups = len(self.token_database.groups) or 1
+        if isinstance(block_ids, list) and block_ids and isinstance(block_ids[0], list):
+            req_groups = len(block_ids)
+        else:
+            # Legacy flat list — treat as single group.
+            req_groups = 1
+        if req_groups != num_groups:
+            logger.error(
+                "req %s: KV group count mismatch on save: got %d, expected %d. "
+                "Dropping save.",
+                req_id,
+                req_groups,
+                num_groups,
+            )
+            self.dec_stored_request(req_id)
+            self.request_queue.task_done()
+            return
+
+        starts: list[int] = []
+        ends: list[int] = []
+        groups_per_key: list[int] = []
+        keys: list[str] = []
         block_hashes: list[BlockHash] = []
-        for index, (start, end, key) in enumerate(
-            self.token_database.process_tokens(token_len, req_meta.block_hashes)
+        # Per-group chunk counts (= cdiv(token_len, g_block_size)).
+        # `len(req_meta.block_hashes)` is at hash_block_size granularity,
+        # not per-group, so it can't be used here.
+        group_block_sizes = self.token_database.group_block_sizes or [
+            self.block_size
+        ] * max(1, num_groups)
+        g_total_chunks = [cdiv(token_len, gbs) for gbs in group_block_sizes]
+        hash_bs = max(1, self.token_database.hash_block_size)
+        per_group_savable = [0] * max(1, num_groups)
+        for start, end, group_id, key in self.token_database.process_tokens(
+            token_len, req_meta.block_hashes
         ):
+            g_block_size = group_block_sizes[group_id]
+            chunk_id = start // g_block_size
+            if not self.token_database.is_chunk_in_window_per_request(
+                chunk_id, block_ids, group_id, g_total_chunks[group_id]
+            ):
+                continue
             starts.append(start)
             ends.append(end)
+            groups_per_key.append(group_id)
             keys.append(key.to_string())
-            block_hashes.append(req_meta.block_hashes[index])
+            # Right-edge hash; same index `process_tokens` used for the key.
+            block_hashes.append(req_meta.block_hashes[end // hash_bs - 1])
+            per_group_savable[group_id] += 1
+
+        self._save_debug_counter = getattr(self, "_save_debug_counter", 0) + 1
+        if self._save_debug_counter % 50 == 1:
+            logger.info(
+                "[mooncake-save] call=%d savable=%d per_group=%s "
+                "blocks_per_sw=%s g_total_chunks=%s g_block_sizes=%s",
+                self._save_debug_counter,
+                len(keys),
+                per_group_savable,
+                self.token_database.blocks_per_sw,
+                g_total_chunks,
+                group_block_sizes,
+            )
 
         # Apply put_step striding for TP
         starts = starts[self.tp_rank % self.put_step :: self.put_step]
         ends = ends[self.tp_rank % self.put_step :: self.put_step]
+        groups_per_key = groups_per_key[self.tp_rank % self.put_step :: self.put_step]
         keys = keys[self.tp_rank % self.put_step :: self.put_step]
         block_hashes = block_hashes[self.tp_rank % self.put_step :: self.put_step]
 
@@ -434,6 +491,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         starts = [starts[i] for i in missing_indices]
         ends = [ends[i] for i in missing_indices]
+        groups_per_key = [groups_per_key[i] for i in missing_indices]
         keys = [keys[i] for i in missing_indices]
         block_hashes = [block_hashes[i] for i in missing_indices]
 
@@ -453,8 +511,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
         new_block_hashes = [maybe_convert_block_hash(bh) for bh in block_hashes]
 
         for index, start in enumerate(starts):
+            gid = groups_per_key[index]
             addr, size, _ = self.token_database.prepare_value(
-                start, ends[index], block_ids
+                start,
+                ends[index],
+                block_ids,
+                gid,
+                g_total_chunks[gid],
             )
             addrs.append(addr)
             sizes.append(size)
@@ -495,16 +558,35 @@ class KVCacheStoreSendingThread(KVTransferThread):
             )
             if failed:
                 failed_codes = set(res[i] for i in failed)
+                # Log a sample (first failed key's first segment addr+size).
+                # Cross-correlating addr against the registered ranges in the
+                # startup "Registering KV_Caches" log is the fastest way to
+                # spot the "RDMA address out of registered range" failure
+                # mode (e.g., heterogeneous strides bug from DP=2 EP).
+                fi = failed[0]
+                first_addr = "N/A"
+                first_size = "N/A"
+                if fi < len(addrs):
+                    a = addrs[fi]
+                    s = sizes[fi]
+                    if isinstance(a, list) and a:
+                        first_addr = f"0x{a[0]:x}+{s[0] if isinstance(s, list) else s}"
+                        first_size = f"n_segs={len(a)}"
+                    elif isinstance(a, int):
+                        first_addr = f"0x{a:x}"
+                        first_size = str(s)
                 logger.warning(
                     "batch_put failed: %d/%d keys failed "
                     "(codes=%s, batch_bytes=%d, num_keys=%d), "
-                    "first_key=%s",
+                    "first_key=%s, first_failed_addr=%s, %s",
                     len(failed),
                     len(keys),
                     failed_codes,
                     batch_bytes,
                     len(keys),
                     keys[0] if keys else "N/A",
+                    first_addr,
+                    first_size,
                 )
                 if (
                     MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
@@ -574,24 +656,65 @@ class KVCacheStoreRecvingThread(KVTransferThread):
     def _handle_request(self, req_meta: ReqMeta):
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
+        # Mask aligns to scheduler frame (LCM); self.block_size is MIN
+        # on HMA and would skip at hash-block granularity.
+        sched_bs = getattr(self.token_database, "scheduler_block_size", self.block_size)
         mask_num = (
             req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size
-            * self.block_size
+            // sched_bs
+            * sched_bs
         )
 
+        # HMA: assert per-group block_ids matches the registered group count.
+        num_groups = len(self.token_database.groups) or 1
+        block_ids = req_meta.block_ids
+        if isinstance(block_ids, list) and block_ids and isinstance(block_ids[0], list):
+            req_groups = len(block_ids)
+        else:
+            req_groups = 1
+        if req_groups != num_groups:
+            logger.error(
+                "req %s: KV group count mismatch on load: got %d, expected %d. "
+                "Dropping load.",
+                req_id,
+                req_groups,
+                num_groups,
+            )
+            return
+
+        # Per-group load: skip (chunk, group) pairs outside the group's window.
         addr_list = []
         size_list = []
         key_list = []
-        for start, end, key in self.token_database.process_tokens(
+        # Per-group native chunk counts; symmetric with the save path.
+        load_group_block_sizes = self.token_database.group_block_sizes or [
+            self.block_size
+        ] * max(1, num_groups)
+        load_g_total_chunks = [cdiv(token_len, gbs) for gbs in load_group_block_sizes]
+        for start, end, group_id, key in self.token_database.process_tokens(
             token_len, req_meta.block_hashes, mask_num
         ):
+            g_block_size = load_group_block_sizes[group_id]
+            chunk_id = start // g_block_size
+            if not self.token_database.is_chunk_in_window_per_request(
+                chunk_id, block_ids, group_id, load_g_total_chunks[group_id]
+            ):
+                continue
             addr, size, _ = self.token_database.prepare_value(
-                start, end, req_meta.block_ids
+                start,
+                end,
+                block_ids,
+                group_id,
+                load_g_total_chunks[group_id],
             )
             key_list.append(key.to_string())
             addr_list.append(addr)
             size_list.append(size)
+
+        if not key_list:
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
 
         # Rotate lists by tp_rank for load balancing
         key_list_c = (
@@ -705,7 +828,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 class MooncakeStoreWorker:
     """Worker-side component for MooncakeStoreConnector."""
 
-    def __init__(self, vllm_config: VllmConfig):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: "KVCacheConfig | None" = None,
+    ):
         try:
             from mooncake.store import MooncakeDistributedStore  # type: ignore
         except ImportError as e:
@@ -715,6 +842,7 @@ class MooncakeStoreWorker:
                 "en/build.md to run vLLM with MooncakeStoreConnector."
             ) from e
 
+        self.kv_cache_config = kv_cache_config
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
 
@@ -818,8 +946,12 @@ class MooncakeStoreWorker:
         self.register_kv_caches({"__cross_layer__": kv_cache})
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        """Register KV cache tensors and start transfer threads."""
-        # TODO(yifan): we haven't supported HMA yet.
+        """Register KV cache tensors and start transfer threads.
+
+        Buckets layers by kv_cache_config.kv_cache_groups so HMA models
+        (mixed FullAttention + SlidingWindow) get one GroupLayout per
+        group and prepare_value can resolve per-group block ids.
+        """
         first_kv_cache = next(iter(kv_caches.values()))
 
         # num_blocks from cache_config is authoritative (set after
@@ -828,75 +960,205 @@ class MooncakeStoreWorker:
         self.num_blocks = self.cache_config.num_gpu_blocks
 
         # Detect the KV cache memory layout using the stride-based
-        # approach from simple_kv_offload/worker.py.
+        # approach from simple_kv_offload/worker.py. Same logic as
+        # before, but now applied per group.
         #
         # The physical layout varies across attention backends:
         #   FlashAttn/ROCm : (2, num_blocks, ...) → K/V outermost
         #   FlashInfer/MLA : (num_blocks, ...)    → blocks outermost
-        #
-        # We derive page_size_bytes = storage.nbytes() // num_blocks,
-        # then classify dims: any dim whose byte-stride exceeds
-        # page_size_bytes must be an outer segment dim (e.g. the K/V
-        # dim of size 2).  For those backends we register each segment
-        # (K, V) as a separate base-address so that the per-block
-        # offset arithmetic in prepare_value() stays correct.
-        storage = first_kv_cache.untyped_storage()
-        el = first_kv_cache.element_size()
-        page_size_bytes = storage.nbytes() // self.num_blocks
-        outer_dims = [
-            d
-            for d in range(first_kv_cache.ndim)
-            if first_kv_cache.stride(d) * el > page_size_bytes
-        ]
+        # Layout detection now happens per-tensor inside the group loop
+        # below (cache_outer_dims). The early `outer_dims` was dead code.
 
-        # Register buffers with the store (deduplicate shared storages)
-        # and record per-segment base addresses for every layer.
-        seen_ptrs: set[int] = set()
-        self.kv_caches_base_addr: list[int] = []
-        self.block_len: list[int] = []
-
-        for cache in kv_caches.values():
-            cache_storage = cache.untyped_storage()
-            base_addr = cache_storage.data_ptr()
-            region_len = cache_storage.nbytes()
-
-            if base_addr not in seen_ptrs:
-                seen_ptrs.add(base_addr)
-                ret = self.store.register_buffer(base_addr, region_len)
-                if ret != 0:
-                    logger.error(
-                        "register_buffer failed for addr %#x len %d: %d",
-                        base_addr,
-                        region_len,
-                        ret,
+        # Bucket layers by KV cache group. If kv_cache_config is missing
+        # (legacy / tests / no-arg construction), fall back to a single
+        # group containing everything — preserves N=1 behavior for
+        # DeepSeek/MLA.
+        kv_cache_config = getattr(self, "kv_cache_config", None)
+        is_cross_layer_registration = set(kv_caches) == {"__cross_layer__"}
+        if kv_cache_config is not None:
+            if is_cross_layer_registration:
+                if len(kv_cache_config.kv_cache_groups) != 1:
+                    raise ValueError(
+                        "Cross-layer KV cache registration is only supported for "
+                        "single-group KV cache configs."
                     )
-
-            if not outer_dims:
-                # Blocks-first layout (FlashInfer / MLA): one segment.
-                self.kv_caches_base_addr.append(base_addr)
-                self.block_len.append(page_size_bytes)
+                layer_to_group_idx: dict[str, int] = {"__cross_layer__": 0}
+                num_groups = 1
             else:
-                # K/V-first layout (FlashAttn / ROCm): split segments.
-                seg_stride = cache.stride(outer_dims[0]) * el
-                for idx in range(cache.shape[outer_dims[0]]):
-                    self.kv_caches_base_addr.append(base_addr + idx * seg_stride)
-                    self.block_len.append(seg_stride // self.num_blocks)
+                layer_to_group_idx = {}
+                for g_idx, group in enumerate(kv_cache_config.kv_cache_groups):
+                    for layer_name in group.layer_names:
+                        layer_to_group_idx[layer_name] = g_idx
+                num_groups = len(kv_cache_config.kv_cache_groups)
+        else:
+            layer_to_group_idx = {name: 0 for name in kv_caches}
+            num_groups = 1
+
+        # Bucket layers by group. Fail closed on unknown layer names when
+        # `kv_cache_config` is present: silently defaulting to group 0
+        # would misattribute window/block_size/block_ids on HMA.
+        grouped_caches: list[list[tuple[str, torch.Tensor]]] = [
+            [] for _ in range(num_groups)
+        ]
+        for name, cache in kv_caches.items():
+            if kv_cache_config is not None and name not in layer_to_group_idx:
+                raise ValueError(
+                    f"KV cache layer '{name}' not in any kv_cache_group. "
+                    f"Known groups: "
+                    f"{[g.layer_names for g in kv_cache_config.kv_cache_groups]}"
+                )
+            g_idx = layer_to_group_idx.get(name, 0)
+            grouped_caches[g_idx].append((name, cache))
+
+        seen_ptrs: set[int] = set()
+        groups: list[GroupLayout] = []
+        flat_layer_to_group: list[int] = []
+
+        for g_idx, layers in enumerate(grouped_caches):
+            group_base_addrs: list[int] = []
+            group_block_lens: list[int] = []
+            for _, cache in layers:
+                cache_storage = cache.untyped_storage()
+                base_addr = cache_storage.data_ptr()
+                region_len = cache_storage.nbytes()
+
+                if base_addr not in seen_ptrs:
+                    seen_ptrs.add(base_addr)
+                    ret = self.store.register_buffer(base_addr, region_len)
+                    if ret != 0:
+                        logger.error(
+                            "register_buffer failed for addr %#x len %d: %d",
+                            base_addr,
+                            region_len,
+                            ret,
+                        )
+
+                # Compute outer_dims and page_size_bytes PER TENSOR. HMA mixes
+                # layer types (FA, SWA, indexer, compressor, ...) with
+                # different shapes/strides; using globals from first_kv_cache
+                # produces RDMA put addresses outside the registered range
+                # for any tensor whose per-block stride differs from the
+                # first one.
+                cache_el = cache.element_size()
+                cache_page_size_bytes = region_len // self.num_blocks
+                cache_outer_dims = [
+                    d
+                    for d in range(cache.ndim)
+                    if cache.stride(d) * cache_el > cache_page_size_bytes
+                ]
+
+                if not cache_outer_dims:
+                    # Blocks-first layout (FlashInfer / MLA): one segment.
+                    group_base_addrs.append(base_addr)
+                    group_block_lens.append(cache_page_size_bytes)
+                    flat_layer_to_group.append(g_idx)
+                else:
+                    # K/V-first layout (FlashAttn / ROCm): split segments.
+                    seg_stride = cache.stride(cache_outer_dims[0]) * cache_el
+                    for seg in range(cache.shape[cache_outer_dims[0]]):
+                        group_base_addrs.append(base_addr + seg * seg_stride)
+                        group_block_lens.append(seg_stride // self.num_blocks)
+                        flat_layer_to_group.append(g_idx)
+            groups.append(
+                GroupLayout(
+                    base_addrs=group_base_addrs,
+                    block_lens=group_block_lens,
+                )
+            )
+
+        self.token_database.set_groups(groups, flat_layer_to_group)
+        self.kv_caches_base_addr = self.token_database.kv_caches_base_addr
+        self.block_len = self.token_database.block_len
+
+        # Per-group SWA window in blocks (0 = FA / no clip) and per-group
+        # native block_size. HMA wraps per-layer specs in
+        # `UniformTypeKVCacheSpecs` which hides `sliding_window` /
+        # `attention_chunk_size` at the top level; drill into
+        # `spec.kv_cache_specs` to recover it.
+        if kv_cache_config is not None:
+            blocks_per_sw: list[int] = []
+            group_block_sizes: list[int] = []
+            for group in kv_cache_config.kv_cache_groups:
+                spec = group.kv_cache_spec
+                inner_specs = getattr(spec, "kv_cache_specs", None)
+                probe_spec = next(iter(inner_specs.values())) if inner_specs else spec
+                g_block_size = getattr(spec, "block_size", None) or self.block_size
+                group_block_sizes.append(g_block_size)
+                window_tokens = getattr(probe_spec, "sliding_window", None) or getattr(
+                    probe_spec, "attention_chunk_size", None
+                )
+                if window_tokens:
+                    blocks_per_sw.append(cdiv(window_tokens, g_block_size) + 1)
+                else:
+                    blocks_per_sw.append(0)
+        else:
+            blocks_per_sw = [0] * num_groups
+            group_block_sizes = [self.block_size] * num_groups
+        self.token_database.set_blocks_per_sw(blocks_per_sw)
+        # block_hashes granularity. Honor cache_config.hash_block_size if
+        # set (mirroring vllm's resolver), else GCD(group_block_sizes).
+        hash_block_size_attr = getattr(self.cache_config, "hash_block_size", None)
+        if isinstance(hash_block_size_attr, int) and hash_block_size_attr > 0:
+            hash_block_size = hash_block_size_attr
+        elif group_block_sizes:
+            hash_block_size = reduce(gcd, group_block_sizes)
+        else:
+            hash_block_size = self.block_size
+        # Scheduler-frame alignment = LCM(group_block_sizes), then scale
+        # by pcp/dcp. cache_config.block_size is mutated to MIN for HMA,
+        # so don't read from it.
+        if group_block_sizes:
+            self.scheduler_block_size = reduce(lcm, group_block_sizes)
+        else:
+            self.scheduler_block_size = self.block_size
+        pcp = getattr(self, "pcp_size", 1)
+        dcp = getattr(self, "dcp_size", 1)
+        if pcp > 1:
+            self.scheduler_block_size *= pcp
+        if dcp > 1:
+            self.scheduler_block_size *= dcp
+        self.token_database.set_group_block_sizes(
+            group_block_sizes, hash_block_size, self.scheduler_block_size
+        )
+        self._blocks_per_sw = blocks_per_sw
+        logger.info(
+            "Per-group blocks_per_sw=%s group_block_sizes=%s "
+            "hash_block_size=%d scheduler_block_size=%d "
+            "(self.block_size=%d)",
+            blocks_per_sw,
+            group_block_sizes,
+            hash_block_size,
+            self.scheduler_block_size,
+            self.block_size,
+        )
+
+        # Heterogeneous per-tensor block_lens are now handled correctly,
+        # but logging them up front catches future regressions of the
+        # DP=2 EP "first-tensor page_size for all" failure.
+        unique_block_lens = sorted(set(self.block_len))
+        if len(unique_block_lens) > 1:
+            from collections import Counter
+
+            dist = Counter(self.block_len)
+            logger.info(
+                "Mooncake KV layout has heterogeneous per-tensor block_lens %s "
+                "(distribution=%s); per-tensor stride accounting is in effect.",
+                unique_block_lens,
+                dict(dist),
+            )
 
         logger.info(
-            "Registering KV_Caches. use_mla: %s, shape %s, "
-            "num_blocks: %d, block_len: %s, "
-            "per_key_bytes: %d, "
-            "num_segments: %d",
+            "Registering KV_Caches. use_mla: %s, num_groups: %d, "
+            "shape %s, num_blocks: %d, block_len: %s, "
+            "per_key_bytes: %d, num_segments: %d",
             self.use_mla,
+            num_groups,
             first_kv_cache.shape,
             self.num_blocks,
             list(set(self.block_len)),
             sum(self.block_len),
             len(self.kv_caches_base_addr),
         )
-
-        self.token_database.set_kv_caches_base_addr(self.kv_caches_base_addr)
-        self.token_database.set_block_len(self.block_len)
 
         # Start transfer threads
         if self.kv_role in ["kv_producer", "kv_both"]:
@@ -1072,21 +1334,45 @@ class MooncakeStoreWorker:
         token_len: int,
         block_hashes: list[BlockHash],
     ) -> int:
-        """Check how many prefix tokens exist in the store.
+        """Largest contiguous prefix (in tokens) that all groups + ranks supply.
 
-        Checks across all TP ranks and PP ranks.
+        Per-(chunk, group) keys; a chunk hits iff every queried group
+        returned 1. Single batch_is_exist round-trip.
         """
-        end = 0
         keys: list[str] = []
         multi_tp_keys: list[str] = []
         lookup_start = time.perf_counter()
         try:
-            starts: list[int] = []
-            for start, end, key in self.token_database.process_tokens(
-                token_len, block_hashes
+            hash_bs = max(1, self.token_database.hash_block_size)
+            lookup_token_len = token_len // hash_bs * hash_bs
+            if lookup_token_len <= 0:
+                return 0
+
+            # Per-group chunk counts. Each group's chunk_id indexes a
+            # different token frame, so we keep (chunk_id, group_id) per
+            # key and convert misses back to token positions before
+            # aggregating.
+            group_block_sizes = self.token_database.group_block_sizes or [
+                self.block_size
+            ] * max(1, len(self.token_database.groups) or 1)
+            g_total_chunks_lk = [
+                cdiv(lookup_token_len, gbs) for gbs in group_block_sizes
+            ]
+            chunk_groups: list[tuple[int, int]] = []
+            for start, _end, group_id, key in self.token_database.process_tokens(
+                lookup_token_len, block_hashes
             ):
+                g_block = group_block_sizes[group_id]
+                chunk_id = start // g_block
+                if not self.token_database.is_chunk_in_window(
+                    chunk_id, g_total_chunks_lk[group_id], group_id
+                ):
+                    continue
                 keys.append(key.to_string())
-                starts.append(start)
+                chunk_groups.append((chunk_id, group_id))
+
+            if not keys:
+                return 0
 
             # Expand keys for all TP ranks
             multi_tp_keys = keys[:]
@@ -1109,14 +1395,44 @@ class MooncakeStoreWorker:
                 len(multi_tp_keys),
             )
 
-            num_block = len(keys)
-            multi_tp_values = [
-                res[i * num_block : (i + 1) * num_block]
-                for i in range(min(self.tp_size, self.num_kv_head) * self.pp_size)
-            ]
-            index = self._find_min_first_non_one_index(multi_tp_values)
-            if index != -1:
-                return starts[index]
+            n = len(keys)
+            num_rows = min(self.tp_size, self.num_kv_head) * self.pp_size
+            multi_tp_values = [res[i * n : (i + 1) * n] for i in range(num_rows)]
+
+            # First-miss in token space: each missed (chunk_id, group)
+            # maps to `cid * g_block_size`; the min across rows caps the
+            # available prefix.
+            def first_miss_token(row: list[int]) -> int:
+                miss = lookup_token_len
+                for (cid, gid), v in zip(chunk_groups, row):
+                    if v != 1:
+                        miss = min(miss, cid * group_block_sizes[gid])
+                return miss
+
+            per_row_first_miss = [first_miss_token(r) for r in multi_tp_values]
+            min_token = min(per_row_first_miss) if per_row_first_miss else 0
+
+            self._lookup_debug_counter = getattr(self, "_lookup_debug_counter", 0) + 1
+            if self._lookup_debug_counter % 50 == 1:
+                ones_per_row = [
+                    sum(1 for v in row if v == 1) for row in multi_tp_values
+                ]
+                logger.info(
+                    "[mooncake-lookup] call=%d num_keys=%d ones=%s "
+                    "first_miss_token=%s min_first_miss_token=%d",
+                    self._lookup_debug_counter,
+                    len(multi_tp_keys),
+                    ones_per_row,
+                    per_row_first_miss,
+                    min_token,
+                )
+
+            # Round to scheduler block boundary (LCM); self.block_size
+            # is MIN on HMA, see `register_kv_caches`.
+            sched_bs = getattr(self, "scheduler_block_size", self.block_size)
+            if min_token >= lookup_token_len:
+                return lookup_token_len
+            return (min_token // sched_bs) * sched_bs
         except Exception as e:
             self._record_kv_connector_operation(
                 "lookup_exists",
@@ -1127,16 +1443,6 @@ class MooncakeStoreWorker:
             )
             logger.error("Remote connection failed in lookup: %s", e)
             return 0
-        return end
-
-    @staticmethod
-    def _find_min_first_non_one_index(
-        arr: list[list[int]],
-    ) -> int:
-        try:
-            return min(idx for row in arr for idx, val in enumerate(row) if val != 1)
-        except ValueError:
-            return -1
 
     def get_kv_events(self) -> list[BlockStored]:
         if self.enable_kv_events and self.kv_send_thread is not None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -30,6 +30,9 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_lookup_coordinator import (  # noqa: E501
+    MooncakeLookupCoordinator,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     ChunkedTokenDatabase,
     GroupLayout,
@@ -230,6 +233,7 @@ class KVTransferThread(threading.Thread):
         ready_event: threading.Event,
         name: str,
         record_operation: Callable[..., None] | None = None,
+        lookup_coordinator: MooncakeLookupCoordinator | None = None,
     ):
         super().__init__(daemon=True, name=name)
         self.store = store
@@ -237,6 +241,7 @@ class KVTransferThread(threading.Thread):
         self.block_size = block_size
         self.tp_rank = tp_rank
         self.token_database = token_database
+        self.lookup_coordinator = lookup_coordinator
         self._record_operation_cb = record_operation
         self.done_task_lock = threading.Lock()
         self.request_queue: queue.Queue[Any] = queue.Queue()
@@ -319,6 +324,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         ready_event: threading.Event,
         enable_kv_event: bool = False,
         record_operation: Callable[..., None] | None = None,
+        lookup_coordinator: MooncakeLookupCoordinator | None = None,
     ):
         super().__init__(
             store,
@@ -328,6 +334,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             ready_event,
             name="KVCacheStoreSendingThread",
             record_operation=record_operation,
+            lookup_coordinator=lookup_coordinator,
         )
         self.put_step = put_step
         self.kv_role = kv_role
@@ -410,48 +417,50 @@ class KVCacheStoreSendingThread(KVTransferThread):
             self.request_queue.task_done()
             return
 
+        if self.lookup_coordinator is None:
+            logger.error(
+                "req %s: Mooncake coordinator unavailable on save. Dropping save.",
+                req_id,
+            )
+            self.dec_stored_request(req_id)
+            self.request_queue.task_done()
+            return
+
+        group_dbs = [self.token_database.group(g) for g in range(num_groups)]
+        g_total_chunks = [
+            cdiv(token_len, group_db.block_size) for group_db in group_dbs
+        ]
+        chunks = self.lookup_coordinator.plan_store_chunks(
+            token_len,
+            req_meta.block_hashes,
+            block_ids,
+        )
         starts: list[int] = []
         ends: list[int] = []
         groups_per_key: list[int] = []
         keys: list[str] = []
         block_hashes: list[BlockHash] = []
-        # Per-group chunk counts (= cdiv(token_len, g_block_size)).
-        # `len(req_meta.block_hashes)` is at hash_block_size granularity,
-        # not per-group, so it can't be used here.
-        group_block_sizes = self.token_database.group_block_sizes or [
-            self.block_size
-        ] * max(1, num_groups)
-        g_total_chunks = [cdiv(token_len, gbs) for gbs in group_block_sizes]
-        hash_bs = max(1, self.token_database.hash_block_size)
         per_group_savable = [0] * max(1, num_groups)
-        for start, end, group_id, key in self.token_database.process_tokens(
-            token_len, req_meta.block_hashes
-        ):
-            g_block_size = group_block_sizes[group_id]
-            chunk_id = start // g_block_size
-            if not self.token_database.is_chunk_in_window_per_request(
-                chunk_id, block_ids, group_id, g_total_chunks[group_id]
-            ):
-                continue
-            starts.append(start)
-            ends.append(end)
+        for chunk in chunks:
+            group_id = chunk.group_id
+            group_db = group_dbs[group_id]
+            starts.append(chunk.start)
+            ends.append(chunk.end)
             groups_per_key.append(group_id)
-            keys.append(key.to_string())
-            # Right-edge hash; same index `process_tokens` used for the key.
-            block_hashes.append(req_meta.block_hashes[end // hash_bs - 1])
+            keys.append(group_db.make_key(chunk.block_hash).to_string())
+            block_hashes.append(chunk.block_hash)
             per_group_savable[group_id] += 1
 
         self._save_debug_counter = getattr(self, "_save_debug_counter", 0) + 1
         if self._save_debug_counter % 50 == 1:
             logger.info(
                 "[mooncake-save] call=%d savable=%d per_group=%s "
-                "blocks_per_sw=%s g_total_chunks=%s g_block_sizes=%s",
+                "g_total_chunks=%s g_block_sizes=%s",
                 self._save_debug_counter,
                 len(keys),
                 per_group_savable,
-                self.token_database.blocks_per_sw,
                 g_total_chunks,
-                group_block_sizes,
+                [group_db.block_size for group_db in group_dbs],
             )
 
         # Apply put_step striding for TP
@@ -512,11 +521,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
         for index, start in enumerate(starts):
             gid = groups_per_key[index]
-            addr, size, _ = self.token_database.prepare_value(
+            addr, size, _ = group_dbs[gid].prepare_value(
                 start,
                 ends[index],
                 block_ids,
-                gid,
                 g_total_chunks[gid],
             )
             addrs.append(addr)
@@ -634,6 +642,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         ready_event: threading.Event,
         disk_offload_buffer_budget_bytes: int | None = None,
         record_operation: Callable[..., None] | None = None,
+        lookup_coordinator: MooncakeLookupCoordinator | None = None,
     ):
         super().__init__(
             store,
@@ -643,6 +652,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             ready_event,
             name="KVCacheStoreRecvingThread",
             record_operation=record_operation,
+            lookup_coordinator=lookup_coordinator,
         )
         self.disk_offload_buffer_budget_bytes = disk_offload_buffer_budget_bytes
         self.usable_disk_offload_buffer_budget_bytes = (
@@ -682,32 +692,38 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             )
             return
 
-        # Per-group load: skip (chunk, group) pairs outside the group's window.
+        if self.lookup_coordinator is None:
+            logger.error(
+                "req %s: Mooncake coordinator unavailable on load. Dropping load.",
+                req_id,
+            )
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
+
         addr_list = []
         size_list = []
         key_list = []
-        # Per-group native chunk counts; symmetric with the save path.
-        load_group_block_sizes = self.token_database.group_block_sizes or [
-            self.block_size
-        ] * max(1, num_groups)
-        load_g_total_chunks = [cdiv(token_len, gbs) for gbs in load_group_block_sizes]
-        for start, end, group_id, key in self.token_database.process_tokens(
-            token_len, req_meta.block_hashes, mask_num
-        ):
-            g_block_size = load_group_block_sizes[group_id]
-            chunk_id = start // g_block_size
-            if not self.token_database.is_chunk_in_window_per_request(
-                chunk_id, block_ids, group_id, load_g_total_chunks[group_id]
-            ):
-                continue
-            addr, size, _ = self.token_database.prepare_value(
-                start,
-                end,
+        load_group_dbs = [self.token_database.group(g) for g in range(num_groups)]
+        load_g_total_chunks = [
+            cdiv(token_len, group_db.block_size) for group_db in load_group_dbs
+        ]
+        chunks = self.lookup_coordinator.plan_load_chunks(
+            token_len,
+            req_meta.block_hashes,
+            block_ids,
+            mask_num,
+        )
+        for chunk in chunks:
+            group_id = chunk.group_id
+            group_db = load_group_dbs[group_id]
+            addr, size, _ = group_db.prepare_value(
+                chunk.start,
+                chunk.end,
                 block_ids,
-                group_id,
                 load_g_total_chunks[group_id],
             )
-            key_list.append(key.to_string())
+            key_list.append(group_db.make_key(chunk.block_hash).to_string())
             addr_list.append(addr)
             size_list.append(size)
 
@@ -860,6 +876,22 @@ class MooncakeStoreWorker:
         self.kv_role = vllm_config.kv_transfer_config.kv_role
         # NOTE(yifan): enforce load_async for now for better compute-I/O overlap.
         self.load_async = True
+        # Mirror Scheduler.__init__'s use_eagle derivation; the coordinator
+        # uses it to apply the upstream "flag all groups when none are
+        # annotated" fallback for EAGLE configs.
+        self._use_eagle = False
+        spec_cfg = getattr(vllm_config, "speculative_config", None)
+        if spec_cfg is not None:
+            use_eagle_fn = getattr(spec_cfg, "use_eagle", None)
+            if callable(use_eagle_fn):
+                try:
+                    self._use_eagle = bool(use_eagle_fn())
+                except Exception:
+                    self._use_eagle = False
+        # Set in register_kv_caches; None → construction failed →
+        # lookup returns 0 (fail-closed).
+        self._lookup_coordinator: MooncakeLookupCoordinator | None = None
+        self._coordinator_construction_failed: bool = False
         self.cache_config = vllm_config.cache_config
         self.original_block_size = self.cache_config.block_size
         self.block_size = self.cache_config.block_size
@@ -970,9 +1002,8 @@ class MooncakeStoreWorker:
         # below (cache_outer_dims). The early `outer_dims` was dead code.
 
         # Bucket layers by KV cache group. If kv_cache_config is missing
-        # (legacy / tests / no-arg construction), fall back to a single
-        # group containing everything — preserves N=1 behavior for
-        # DeepSeek/MLA.
+        # (tests / no-arg construction), use a single group containing
+        # everything to preserve N=1 behavior for DeepSeek/MLA.
         kv_cache_config = getattr(self, "kv_cache_config", None)
         is_cross_layer_registration = set(kv_caches) == {"__cross_layer__"}
         if kv_cache_config is not None:
@@ -1070,31 +1101,20 @@ class MooncakeStoreWorker:
         self.kv_caches_base_addr = self.token_database.kv_caches_base_addr
         self.block_len = self.token_database.block_len
 
-        # Per-group SWA window in blocks (0 = FA / no clip) and per-group
-        # native block_size. HMA wraps per-layer specs in
-        # `UniformTypeKVCacheSpecs` which hides `sliding_window` /
-        # `attention_chunk_size` at the top level; drill into
-        # `spec.kv_cache_specs` to recover it.
+        # Per-group native block_size. HMA wraps per-layer specs in
+        # `UniformTypeKVCacheSpecs`; drill into `spec.kv_cache_specs` when
+        # needed so hash/scheduler alignment uses the concrete inner spec.
         if kv_cache_config is not None:
-            blocks_per_sw: list[int] = []
             group_block_sizes: list[int] = []
             for group in kv_cache_config.kv_cache_groups:
                 spec = group.kv_cache_spec
                 inner_specs = getattr(spec, "kv_cache_specs", None)
-                probe_spec = next(iter(inner_specs.values())) if inner_specs else spec
+                if inner_specs:
+                    spec = next(iter(inner_specs.values()))
                 g_block_size = getattr(spec, "block_size", None) or self.block_size
                 group_block_sizes.append(g_block_size)
-                window_tokens = getattr(probe_spec, "sliding_window", None) or getattr(
-                    probe_spec, "attention_chunk_size", None
-                )
-                if window_tokens:
-                    blocks_per_sw.append(cdiv(window_tokens, g_block_size) + 1)
-                else:
-                    blocks_per_sw.append(0)
         else:
-            blocks_per_sw = [0] * num_groups
             group_block_sizes = [self.block_size] * num_groups
-        self.token_database.set_blocks_per_sw(blocks_per_sw)
         # block_hashes granularity. Honor cache_config.hash_block_size if
         # set (mirroring vllm's resolver), else GCD(group_block_sizes).
         hash_block_size_attr = getattr(self.cache_config, "hash_block_size", None)
@@ -1120,16 +1140,37 @@ class MooncakeStoreWorker:
         self.token_database.set_group_block_sizes(
             group_block_sizes, hash_block_size, self.scheduler_block_size
         )
-        self._blocks_per_sw = blocks_per_sw
+        # Build the lookup coordinator once for the worker's lifetime.
+        # On construction failure (unknown spec, misaligned hash block
+        # size, ...), fail closed so lookup returns 0 instead of risking
+        # over-reported hits. Tests use ``__new__`` and skip __init__,
+        # so kv_cache_config may be None.
+        self._coordinator_construction_failed = False
+        if kv_cache_config is not None:
+            try:
+                self._lookup_coordinator = MooncakeLookupCoordinator(
+                    kv_cache_config=kv_cache_config,
+                    hash_block_size=hash_block_size,
+                    use_eagle=getattr(self, "_use_eagle", False),
+                )
+            except Exception as e:
+                logger.error(
+                    "MooncakeLookupCoordinator construction failed (%s); "
+                    "external cache hits DISABLED for this worker "
+                    "(lookup will return 0).",
+                    e,
+                )
+                self._lookup_coordinator = None
+                self._coordinator_construction_failed = True
         logger.info(
-            "Per-group blocks_per_sw=%s group_block_sizes=%s "
-            "hash_block_size=%d scheduler_block_size=%d "
-            "(self.block_size=%d)",
-            blocks_per_sw,
+            "Per-group group_block_sizes=%s hash_block_size=%d "
+            "scheduler_block_size=%d "
+            "(self.block_size=%d) coordinator=%s",
             group_block_sizes,
             hash_block_size,
             self.scheduler_block_size,
             self.block_size,
+            "active" if self._lookup_coordinator is not None else "disabled",
         )
 
         # Heterogeneous per-tensor block_lens are now handled correctly,
@@ -1173,6 +1214,7 @@ class MooncakeStoreWorker:
                 ready_event_sending,
                 self.enable_kv_events,
                 self._record_kv_connector_operation,
+                self._lookup_coordinator,
             )
             self.kv_send_thread.start()
 
@@ -1185,6 +1227,7 @@ class MooncakeStoreWorker:
             ready_event_recving,
             disk_offload_buffer_budget_bytes=self.disk_offload_buffer_budget_bytes,
             record_operation=self._record_kv_connector_operation,
+            lookup_coordinator=self._lookup_coordinator,
         )
         self.kv_recv_thread.start()
         ready_event_recving.wait()
@@ -1336,40 +1379,43 @@ class MooncakeStoreWorker:
     ) -> int:
         """Largest contiguous prefix (in tokens) that all groups + ranks supply.
 
-        Per-(chunk, group) keys; a chunk hits iff every queried group
-        returned 1. Single batch_is_exist round-trip.
+        Per-(chunk, group) keys → ``batch_is_exist`` → vllm's per-manager
+        ``find_longest_cache_hit`` (via :class:`MooncakeLookupCoordinator`).
+        Single round-trip to Mooncake; a chunk hits iff every queried group
+        for that chunk returned 1.
         """
+        # Fail-closed when the coordinator wasn't built.
+        if (
+            getattr(self, "_coordinator_construction_failed", False)
+            or getattr(self, "_lookup_coordinator", None) is None
+        ):
+            return 0
+
         keys: list[str] = []
         multi_tp_keys: list[str] = []
         lookup_start = time.perf_counter()
+        # Local alias to narrow Optional type past the guard above.
+        coord = self._lookup_coordinator
+        assert coord is not None
         try:
             hash_bs = max(1, self.token_database.hash_block_size)
             lookup_token_len = token_len // hash_bs * hash_bs
             if lookup_token_len <= 0:
                 return 0
 
-            # Per-group chunk counts. Each group's chunk_id indexes a
-            # different token frame, so we keep (chunk_id, group_id) per
-            # key and convert misses back to token positions before
-            # aggregating.
-            group_block_sizes = self.token_database.group_block_sizes or [
-                self.block_size
-            ] * max(1, len(self.token_database.groups) or 1)
-            g_total_chunks_lk = [
-                cdiv(lookup_token_len, gbs) for gbs in group_block_sizes
+            group_dbs = [
+                self.token_database.group(g)
+                for g in range(max(1, len(self.token_database.groups) or 1))
             ]
             chunk_groups: list[tuple[int, int]] = []
-            for start, _end, group_id, key in self.token_database.process_tokens(
-                lookup_token_len, block_hashes
-            ):
-                g_block = group_block_sizes[group_id]
-                chunk_id = start // g_block
-                if not self.token_database.is_chunk_in_window(
-                    chunk_id, g_total_chunks_lk[group_id], group_id
-                ):
-                    continue
-                keys.append(key.to_string())
-                chunk_groups.append((chunk_id, group_id))
+            bh_bytes = coord.normalize_block_hashes(block_hashes)
+            # Query every (chunk, group) — no window filter. The
+            # per-manager find_longest_cache_hit needs the full set to
+            # shrink max_length correctly across iterations.
+            for chunk in coord.iter_group_chunks(lookup_token_len, bh_bytes):
+                group_db = group_dbs[chunk.group_id]
+                keys.append(group_db.make_key(chunk.block_hash).to_string())
+                chunk_groups.append((chunk.chunk_id, chunk.group_id))
 
             if not keys:
                 return 0
@@ -1399,18 +1445,20 @@ class MooncakeStoreWorker:
             num_rows = min(self.tp_size, self.num_kv_head) * self.pp_size
             multi_tp_values = [res[i * n : (i + 1) * n] for i in range(num_rows)]
 
-            # First-miss in token space: each missed (chunk_id, group)
-            # maps to `cid * g_block_size`; the min across rows caps the
-            # available prefix.
-            def first_miss_token(row: list[int]) -> int:
-                miss = lookup_token_len
-                for (cid, gid), v in zip(chunk_groups, row):
-                    if v != 1:
-                        miss = min(miss, cid * group_block_sizes[gid])
-                return miss
+            sched_bs = getattr(self, "scheduler_block_size", self.block_size)
 
-            per_row_first_miss = [first_miss_token(r) for r in multi_tp_values]
-            min_token = min(per_row_first_miss) if per_row_first_miss else 0
+            per_row_hits: list[int] = []
+            for row in multi_tp_values:
+                exists_map = {chunk_groups[i]: row[i] for i in range(len(chunk_groups))}
+                # Swap in this row's pool, then let the inherited
+                # find_longest_cache_hit probe through it.
+                coord.block_pool = coord.build_block_pool(exists_map, bh_bytes)
+                _hit_blocks, hit_length = coord.find_longest_cache_hit(
+                    bh_bytes,
+                    max_cache_hit_length=lookup_token_len,
+                )
+                per_row_hits.append(hit_length)
+            min_token = min(per_row_hits) if per_row_hits else 0
 
             self._lookup_debug_counter = getattr(self, "_lookup_debug_counter", 0) + 1
             if self._lookup_debug_counter % 50 == 1:
@@ -1419,17 +1467,14 @@ class MooncakeStoreWorker:
                 ]
                 logger.info(
                     "[mooncake-lookup] call=%d num_keys=%d ones=%s "
-                    "first_miss_token=%s min_first_miss_token=%d",
+                    "per_row_hit_tokens=%s min_hit_tokens=%d",
                     self._lookup_debug_counter,
                     len(multi_tp_keys),
                     ones_per_row,
-                    per_row_first_miss,
+                    per_row_hits,
                     min_token,
                 )
 
-            # Round to scheduler block boundary (LCM); self.block_size
-            # is MIN on HMA, see `register_kv_caches`.
-            sched_bs = getattr(self, "scheduler_block_size", self.block_size)
             if min_token >= lookup_token_len:
                 return lookup_token_len
             return (min_token // sched_bs) * sched_bs
@@ -1441,7 +1486,7 @@ class MooncakeStoreWorker:
                 status="error",
                 num_failed_keys=len(multi_tp_keys),
             )
-            logger.error("Remote connection failed in lookup: %s", e)
+            logger.error("Mooncake lookup failed: %s", e)
             return 0
 
     def get_kv_events(self) -> list[BlockStored]:


### PR DESCRIPTION
## Summary

Both `docker/Dockerfile` and `docker/Dockerfile.mooncake-layer` install `libyaml-cpp-dev` in the build stage (for the source compile), but the **runtime stage `apt-get install --no-install-recommends`** carries only:

```
libgoogle-glog0v5 libjsoncpp25 liburing2 libgflags2.2
libjemalloc2 libhiredis0.14 libcurl4
```

`libyaml-cpp0.7` is missing. The Python workers don't hit this — they use the `mooncake_transfer_engine` wheel which bundles its own deps. But the standalone C++ `mooncake_master` binary that gets compiled to `/usr/local/bin/mooncake_master` is linked against `libyaml-cpp.so.0.7`, so any deployment running the master in this image fails immediately:

```
mooncake_master: error while loading shared libraries:
  libyaml-cpp.so.0.7: cannot open shared object file: No such file or directory
```

## Verification

Ran the built image (`inferactinc/public:hma-mk-20260506`, built from this PR) as a one-shot pod on a Mellanox B300 / RoCE k8s cluster and inspected `ldd /usr/local/bin/mooncake_master`:

```
libibverbs.so.1     -> resolved
libxxhash.so.0      -> resolved
libzstd.so.1        -> resolved
libasio.so          -> resolved (/usr/local/lib/)
libgflags.so.2.2    -> resolved
libglog.so.0        -> resolved
libunwind.so.8      -> resolved
libjsoncpp.so.25    -> resolved
libnuma.so.1        -> resolved
libyaml-cpp.so.0.7  -> not found    <-- only unresolved lib
libstdc++.so.6      -> resolved
... (rest resolved)
```

After `apt-get install -qq -y libyaml-cpp0.7` (~150 KiB, ~3 s):

```
ldd /usr/local/bin/mooncake_master | grep "not found"
(empty — all libs resolve)
mooncake_master --help     -> runs
```

## Fix

Add `libyaml-cpp0.7` to the runtime install line in both Dockerfiles. One-token change in each, no other modifications.

## Test plan

- [ ] Rebuild the image with this change.
- [ ] `docker run --rm <image> ldd /usr/local/bin/mooncake_master | grep "not found"` should be empty.
- [ ] `docker run --rm <image> mooncake_master --help` should print the gflags help instead of erroring.
- [ ] Existing Python-side worker behavior unchanged.

## Workaround for users on the current image

For deployments stuck on the current image, an idempotent runtime guard works (used in [Inferact/k8s-config#22](https://github.com/Inferact/k8s-config/pull/22)):

```yaml
command: ["bash", "-lc"]
args:
  - |
    if ! ldconfig -p | grep -q libyaml-cpp.so.0.7; then
      apt-get update -qq && apt-get install -qq -y libyaml-cpp0.7
    fi
    exec mooncake_master ...
```

Once this PR ships in a new image tag, that guard becomes a no-op (the `ldconfig -p` check passes) — no manifest change required on the consumer side.