### PR TITLE
chore(mooncake): remove HTTP metadata startup flags

### DIFF
--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -57,10 +57,9 @@ This starts the master in the background. Logs go to `scripts/mooncake/mooncake_
 Default ports:
 
 - RPC: 50051
-- HTTP metadata: 8080
 - Prometheus metrics: 9003
 
-See the script header for environment variables (`MC_RPC_PORT`, `MC_HTTP_PORT`, etc.) to customize ports and eviction settings. Mooncake master is launched cluster-wise, so we may get port conflict if someone else has already launched it. Typically we don't need to change this, and multiple users should be able to share the same master. One can freely change ports here, but also remember to update the `mooncake_config.json` for the client (vLLM) below.
+See the script header for environment variables (`MC_RPC_PORT`, `MC_METRICS_PORT`, etc.) to customize ports and eviction settings. Mooncake master is launched cluster-wise, so we may get port conflict if someone else has already launched it. Typically we don't need to change this, and multiple users should be able to share the same master. One can freely change ports here, but also remember to update the `mooncake_config.json` for the client (vLLM) below.
 
 ### 2. Configure Mooncake
 
@@ -68,7 +67,7 @@ Edit `scripts/mooncake/mooncake_config.json`:
 
 ```json
 {
-  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "metadata_server": "P2PHANDSHAKE",
   "master_server_address": "127.0.0.1:50051",
   "global_segment_size": "600GB",
   "local_buffer_size": "4GB",
@@ -78,12 +77,15 @@ Edit `scripts/mooncake/mooncake_config.json`:
 ```
 
 - `protocol`: Use `"rdma"` for best performance. `"tcp"` works as a fallback but performs poorly.
+- `metadata_server`: Use `"P2PHANDSHAKE"` so Transfer Engine peer discovery does not require a separate metadata service.
 - Adjust `global_segment_size` and `local_buffer_size` based on available memory.
     - global_segment_size: Memory contributed to the distributed pool
     - local_buffer_size: Private buffer for this node's own operations
     - For now we use a single node so they don't differ much
     - **These sizes are per GPU (per rank), not for the entire node.** For example, with 4 GPUs and `global_segment_size` set to `80GB`, each rank allocates 80 GB of CPU memory, totaling 320 GB across the node.
 - Note: the benchmark script automatically updates `global_segment_size` and `local_buffer_size` to match `CPU_OFFLOAD_GIB`. The `CPU_OFFLOAD_GIB` and `DISK_OFFLOAD_GIB` env vars in the benchmark scripts are also per GPU (per rank).
+
+The local master helper does not start an embedded HTTP metadata server. Keep the default config and smoke-test example on `"P2PHANDSHAKE"` unless you intentionally run a separate metadata service and update the client config to match it.
 
 ### 3. Environment Setup (setup_vllm_env.sh)
 

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -1,5 +1,5 @@
 {
-  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "metadata_server": "P2PHANDSHAKE",
   "master_server_address": "127.0.0.1:50051",
   "global_segment_size": "600GB",
   "local_buffer_size": "4GB",

--- a/scripts/mooncake/mooncake_config_gb200_rack1_01.json
+++ b/scripts/mooncake/mooncake_config_gb200_rack1_01.json
@@ -1,8 +1,0 @@
-{
-  "metadata_server": "http://192.168.0.101:8080/metadata",
-  "master_server_address": "192.168.0.101:50051",
-  "global_segment_size": "100GB",
-  "local_buffer_size": "4GB",
-  "protocol": "rdma",
-  "device_name": ""
-}

--- a/scripts/mooncake/mooncake_example.py
+++ b/scripts/mooncake/mooncake_example.py
@@ -8,7 +8,7 @@ store = MooncakeDistributedStore()
 # 2. Setup with all required parameters
 store.setup(
     "localhost",  # Your node's address
-    "http://localhost:8080/metadata",  # HTTP metadata server
+    "P2PHANDSHAKE",  # Transfer Engine peer discovery
     512 * 1024 * 1024,  # 512MB segment size
     128 * 1024 * 1024,  # 128MB local buffer
     "tcp",  # Use TCP (RDMA for high performance)

--- a/scripts/mooncake/start_mooncake_master.sh
+++ b/scripts/mooncake/start_mooncake_master.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Start a local Mooncake master server for benchmarking.
 #
-# The master provides two services:
+# The master provides the Mooncake Store RPC service:
 #   - RPC (port 50051): object metadata, allocation, eviction
-#   - HTTP metadata (port 8080): transfer engine peer discovery
 #
 # Usage:
 #   bash start_mooncake_master.sh                          # foreground
@@ -15,7 +14,6 @@
 #
 # Environment variables (all optional):
 #   MC_RPC_PORT       - Master RPC port           (default: 50051)
-#   MC_HTTP_PORT      - HTTP metadata port         (default: 8080)
 #   MC_METRICS_PORT   - Prometheus metrics port    (default: 9003)
 #   MC_RPC_THREADS    - RPC worker threads         (default: 4)
 #   MC_LEASE_TTL      - KV lease TTL in ms         (default: 30000)
@@ -49,7 +47,6 @@ done
 
 # --- Master settings -------------------------------------------------------
 MC_RPC_PORT="${MC_RPC_PORT:-50051}"
-MC_HTTP_PORT="${MC_HTTP_PORT:-8080}"
 MC_METRICS_PORT="${MC_METRICS_PORT:-9003}"
 MC_RPC_THREADS="${MC_RPC_THREADS:-4}"
 MC_LEASE_TTL="${MC_LEASE_TTL:-30000}"
@@ -96,9 +93,6 @@ CMD=(
     -rpc_thread_num="$MC_RPC_THREADS"
     -rpc_address=0.0.0.0
     -rpc_enable_tcp_no_delay=true
-    -enable_http_metadata_server=true
-    -http_metadata_server_host=0.0.0.0
-    -http_metadata_server_port="$MC_HTTP_PORT"
     -enable_metric_reporting=true
     -metrics_port="$MC_METRICS_PORT"
     -default_kv_lease_ttl="$MC_LEASE_TTL"
@@ -118,7 +112,6 @@ fi
 # --- Start ------------------------------------------------------------------
 echo "Starting mooncake_master"
 echo "  RPC:      0.0.0.0:${MC_RPC_PORT}"
-echo "  HTTP:     0.0.0.0:${MC_HTTP_PORT}/metadata"
 echo "  Metrics:  0.0.0.0:${MC_METRICS_PORT}"
 if $OPT_OFFLOAD; then
     echo "  Offload:  ON"


### PR DESCRIPTION
## Summary
- Remove embedded HTTP metadata server flags from `scripts/mooncake/start_mooncake_master.sh`.
- Remove matching `MC_HTTP_PORT` docs/output and the HTTP metadata default port from the Mooncake script README.
- Switch the default local Mooncake config and smoke-test example to `P2PHANDSHAKE` metadata discovery so they remain consistent with the master startup script.
- Delete the rack-specific `scripts/mooncake/mooncake_config_gb200_rack1_01.json` config from this helper setup.
- Document why the local master helper does not start an embedded HTTP metadata server and why the local config uses `P2PHANDSHAKE`.

## Duplicate-work check
- Searched open vLLM PRs for `mooncake metadata server`, `mooncake store metadata`, and `http metadata mooncake`; no existing PR was found for this scripts/config cleanup.
- Searched open ivanium/vLLM PRs for `HTTP metadata startup flags` and `mooncake P2PHANDSHAKE`; no duplicate PR was found.

## Tests
- `bash -n scripts/mooncake/start_mooncake_master.sh` - passed.
- `/home/aoshen/setup_new_cluster/vllm/.venv/bin/python -m py_compile scripts/mooncake/mooncake_example.py` - passed.
- Started `scripts/mooncake/start_mooncake_master.sh --bg` locally with the Mooncake wheel library path on `LD_LIBRARY_PATH`; metrics reported `role=leader, state=serving, service_ready=true`, `scripts/mooncake/mooncake_example.py` printed `Hello, Mooncake Store!`, and `scripts/mooncake/start_mooncake_master.sh --stop` stopped the server successfully.

## AI assistance
- AI assistance was used to prepare this change. The human submitter should review every changed line and validate the behavior before merging.