### PR TITLE
mooncake-store: cascade Scheduler.reset_connector_cache to remove_all(force=True)

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -11,6 +11,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     mooncake_store_connector,
     mooncake_store_scheduler,
+    protocol,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data import (
     MooncakeStoreConnectorMetadata,
@@ -357,7 +358,7 @@ def test_update_connector_output_and_take_events():
 
 
 # ============================================================
-# reset_cache() — verl-style RL hard-reset path
+# reset_cache() — RL hard-reset path via typed LookupKey protocol
 # ============================================================
 
 
@@ -457,8 +458,14 @@ def test_scheduler_reset_store_handles_rpc_exception():
     assert sched.reset_store() is False
 
 
-def test_lookup_key_client_reset_uses_magic_protocol():
-    """LookupKeyClient.reset() sends the RESET_MAGIC sentinel and parses ack."""
+def test_lookup_key_client_reset_uses_admin_protocol():
+    """LookupKeyClient.reset() sends RESET_MSG tag and parses RESP_OK/ERR."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.protocol import (
+        RESET_MSG,
+        RESP_ERR,
+        RESP_OK,
+    )
+
     vllm_config = _make_vllm_config()
 
     # Avoid touching real ZMQ during construction.
@@ -469,19 +476,14 @@ def test_lookup_key_client_reset_uses_magic_protocol():
         client = mooncake_store_scheduler.LookupKeyClient(vllm_config)
 
     fake_socket = mock_make_socket.return_value
-    fake_socket.recv.return_value = (
-        mooncake_store_scheduler.RESET_MAGIC.to_bytes(4, "big")
-    )
+    fake_socket.recv.return_value = RESP_OK
     assert client.reset() is True
 
-    sent_frames = fake_socket.send_multipart.call_args[0][0]
-    assert len(sent_frames) == 1
-    assert int.from_bytes(sent_frames[0], "big") == (
-        mooncake_store_scheduler.RESET_MAGIC
-    )
+    sent_frame = fake_socket.send.call_args[0][0]
+    assert bytes(sent_frame) == RESET_MSG
 
-    # NACK path: server returns 0, client surfaces False.
-    fake_socket.recv.return_value = (0).to_bytes(4, "big")
+    # NACK path: server returns RESP_ERR, client surfaces False.
+    fake_socket.recv.return_value = RESP_ERR
     assert client.reset() is False
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -483,3 +483,57 @@ def test_lookup_key_client_reset_uses_magic_protocol():
     # NACK path: server returns 0, client surfaces False.
     fake_socket.recv.return_value = (0).to_bytes(4, "big")
     assert client.reset() is False
+
+
+def test_scheduler_reset_connector_cache_invokes_connector_reset():
+    """Integration-shaped test for the cascade
+
+    ``Scheduler.reset_prefix_cache(reset_connector=True)``
+        -> ``Scheduler.reset_connector_cache()``
+        -> ``MooncakeStoreConnector.reset_cache()``
+        -> ``MooncakeStoreScheduler.reset_store()``.
+
+    We construct a real (SCHEDULER role) ``MooncakeStoreConnector`` with
+    ``MooncakeStoreScheduler`` patched out, then drive the cascade via a
+    minimal stub that mimics the Scheduler's call site.
+    """
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ) as mock_scheduler_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+
+    mock_scheduler_cls.return_value.reset_store.return_value = True
+
+    # Mirror Scheduler.reset_connector_cache (scheduler.py:1917-1929):
+    # the only relevant lines are
+    #   if self.connector.reset_cache() is False:
+    #       return False
+    #   return True
+    # We bypass the Scheduler class itself (heavy KVCacheManager setup)
+    # and exercise the same call shape.
+    class _StubScheduler:
+        def __init__(self, c):
+            self.connector = c
+            self.log_stats = False
+
+        def reset_connector_cache(self):
+            if self.connector.reset_cache() is False:
+                return False
+            return True
+
+    sched = _StubScheduler(connector)
+    assert sched.reset_connector_cache() is True
+    mock_scheduler_cls.return_value.reset_store.assert_called_once_with()
+
+    # Negative branch: store reset fails -> reset_connector_cache returns False.
+    mock_scheduler_cls.return_value.reset_store.reset_mock()
+    mock_scheduler_cls.return_value.reset_store.return_value = False
+    assert sched.reset_connector_cache() is False

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -354,3 +354,132 @@ def test_update_connector_output_and_take_events():
     assert connector._kv_cache_events is kv_events
     assert list(connector.take_events()) == [event]
     assert connector._kv_cache_events is None
+
+
+# ============================================================
+# reset_cache() — verl-style RL hard-reset path
+# ============================================================
+
+
+def test_reset_cache_scheduler_role_delegates_to_reset_store():
+    """SCHEDULER role reset_cache() routes to scheduler.reset_store()."""
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ) as mock_scheduler_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+
+    mock_scheduler_cls.return_value.reset_store.return_value = True
+    assert connector.reset_cache() is True
+    mock_scheduler_cls.return_value.reset_store.assert_called_once_with()
+
+
+def test_reset_cache_scheduler_role_propagates_failure():
+    """SCHEDULER role surfaces False when scheduler.reset_store() fails."""
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreScheduler"
+        ) as mock_scheduler_cls,
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+
+    mock_scheduler_cls.return_value.reset_store.return_value = False
+    assert connector.reset_cache() is False
+
+
+def test_reset_cache_worker_role_returns_none():
+    """WORKER role reset_cache() is a no-op; reset is driven via ZMQ admin."""
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.MooncakeStoreWorker"
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_connector.LookupKeyServer"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
+
+    assert connector.reset_cache() is None
+
+
+def test_scheduler_reset_store_returns_client_reset_result():
+    """MooncakeStoreScheduler.reset_store() returns LookupKeyClient.reset()."""
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_scheduler.LookupKeyClient"
+        ) as mock_client_cls,
+    ):
+        sched = mooncake_store_scheduler.MooncakeStoreScheduler(vllm_config)
+
+    mock_client_cls.return_value.reset.return_value = True
+    assert sched.reset_store() is True
+    mock_client_cls.return_value.reset.assert_called_once_with()
+
+
+def test_scheduler_reset_store_handles_rpc_exception():
+    """Exceptions from the ZMQ reset RPC are converted to False, not raised."""
+    vllm_config = _make_vllm_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_store_scheduler.LookupKeyClient"
+        ) as mock_client_cls,
+    ):
+        sched = mooncake_store_scheduler.MooncakeStoreScheduler(vllm_config)
+
+    mock_client_cls.return_value.reset.side_effect = RuntimeError("rpc timed out")
+    assert sched.reset_store() is False
+
+
+def test_lookup_key_client_reset_uses_magic_protocol():
+    """LookupKeyClient.reset() sends the RESET_MAGIC sentinel and parses ack."""
+    vllm_config = _make_vllm_config()
+
+    # Avoid touching real ZMQ during construction.
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_store_scheduler.make_zmq_socket"
+    ) as mock_make_socket:
+        client = mooncake_store_scheduler.LookupKeyClient(vllm_config)
+
+    fake_socket = mock_make_socket.return_value
+    fake_socket.recv.return_value = (
+        mooncake_store_scheduler.RESET_MAGIC.to_bytes(4, "big")
+    )
+    assert client.reset() is True
+
+    sent_frames = fake_socket.send_multipart.call_args[0][0]
+    assert len(sent_frames) == 1
+    assert int.from_bytes(sent_frames[0], "big") == (
+        mooncake_store_scheduler.RESET_MAGIC
+    )
+
+    # NACK path: server returns 0, client surfaces False.
+    fake_socket.recv.return_value = (0).to_bytes(4, "big")
+    assert client.reset() is False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -158,6 +158,31 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
 
+    def reset_cache(self) -> bool | None:
+        """Reset external Mooncake store on prefix-cache reset.
+
+        Called by `Scheduler.reset_connector_cache()` after
+        `BlockPool.reset_prefix_cache` succeeds with `reset_connector=True`.
+        Routes a `RemoveAll(force=True)` to the Mooncake master via the
+        existing ZMQ admin channel to worker rank 0.
+
+        For RL workflows the caller (e.g. verl) is expected to invoke
+        `engine.reset_prefix_cache(reset_running_requests=False,
+        reset_connector=True)` immediately after each weight update so that
+        Mooncake's external KV blocks (computed with the previous weights)
+        are dropped before any new request can hit them.
+
+        Returns True on success, False on failure, None for non-applicable
+        roles.
+        """
+        if self.role == KVConnectorRole.SCHEDULER:
+            assert self.connector_scheduler is not None
+            return self.connector_scheduler.reset_store()
+        # Worker role is a no-op here: reset is driven via the scheduler-side
+        # ZMQ admin channel that lands on this worker's LookupKeyServer
+        # thread (worker rank 0), which calls `store.remove_all(force=True)`.
+        return None
+
     def update_connector_output(self, connector_output: KVConnectorOutput):
         kv_cache_events = connector_output.kv_cache_events
         if not kv_cache_events or not isinstance(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_connector.py
@@ -159,28 +159,31 @@ class MooncakeStoreConnector(KVConnectorBase_V1):
         return self.connector_scheduler.request_finished(request, block_ids)
 
     def reset_cache(self) -> bool | None:
-        """Reset external Mooncake store on prefix-cache reset.
+        """Reset the external Mooncake store on prefix-cache reset.
 
-        Called by `Scheduler.reset_connector_cache()` after
-        `BlockPool.reset_prefix_cache` succeeds with `reset_connector=True`.
-        Routes a `RemoveAll(force=True)` to the Mooncake master via the
-        existing ZMQ admin channel to worker rank 0.
+        Called by ``Scheduler.reset_connector_cache()`` after
+        ``BlockPool.reset_prefix_cache`` succeeds with
+        ``reset_connector=True``. Cascades a ``remove_all(force=True)`` on
+        the Mooncake master via the LookupKey ZMQ admin channel to worker
+        rank 0.
 
         For RL workflows the caller (e.g. verl) is expected to invoke
-        `engine.reset_prefix_cache(reset_running_requests=False,
-        reset_connector=True)` immediately after each weight update so that
-        Mooncake's external KV blocks (computed with the previous weights)
-        are dropped before any new request can hit them.
+        ``engine.reset_prefix_cache(reset_running_requests=False,
+        reset_connector=True)`` immediately after each weight update so
+        that Mooncake's external KV blocks (computed with the previous
+        weights) are dropped before any new request can hit them.
 
-        Returns True on success, False on failure, None for non-applicable
-        roles.
+        Ordering assumption: caller MUST ensure no in-flight Mooncake
+        lookups or transfers at the moment of invocation. Outside the
+        RL step-boundary pattern, the caller is responsible.
+
+        Returns True on success, False on failure, None for the
+        non-applicable worker role (worker reset is driven from the
+        scheduler-side ZMQ admin channel).
         """
         if self.role == KVConnectorRole.SCHEDULER:
             assert self.connector_scheduler is not None
             return self.connector_scheduler.reset_store()
-        # Worker role is a no-op here: reset is driven via the scheduler-side
-        # ZMQ admin channel that lands on this worker's LookupKeyServer
-        # thread (worker rank 0), which calls `store.remove_all(force=True)`.
         return None
 
     def update_connector_output(self, connector_output: KVConnectorOutput):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -21,6 +21,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_data i
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     get_mooncake_dp_engine_index,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.protocol import (
+    LOOKUP_MSG,
+    RESET_MSG,
+    RESP_OK,
+)
 from vllm.logger import init_logger
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -364,19 +369,28 @@ class MooncakeStoreScheduler:
         return delay_free_blocks, None
 
     def reset_store(self) -> bool:
-        """Trigger a global `remove_all(force=True)` on the Mooncake master.
+        """Trigger a global ``remove_all(force=True)`` on the Mooncake master.
 
-        Routes through the existing ZMQ admin channel to worker rank 0,
-        which owns the `MooncakeDistributedStore` handle. Returns True on
-        success, False if the worker failed to clear or the RPC errored.
+        Routes through the existing LookupKey ZMQ admin channel to worker
+        rank 0, which owns the ``MooncakeDistributedStore`` handle.
+
+        Ordering assumption: caller (typically
+        ``Scheduler.reset_connector_cache``, invoked via
+        ``reset_prefix_cache(reset_connector=True)``) MUST ensure no
+        in-flight Mooncake lookups or transfers. For RL workflows this is
+        satisfied at the step boundary after weight updates and rollout
+        drain. Violating this can allow stale KV to be served on the next
+        request, defeating the hard-reset guarantee.
+
+        Returns True on ACK from worker, False on NACK or RPC error.
         """
         try:
             ok = self.client.reset()
             if ok:
-                logger.info("Mooncake store reset via RemoveAll succeeded.")
+                logger.info("Mooncake store reset via remove_all succeeded.")
             else:
                 logger.warning(
-                    "Mooncake store reset returned failure ack from worker."
+                    "Mooncake store reset returned NACK from worker."
                 )
             return ok
         except Exception as e:
@@ -384,12 +398,13 @@ class MooncakeStoreScheduler:
             return False
 
 
-# Mirror of RESET_MAGIC in mooncake_store_worker.LookupKeyServer.
-RESET_MAGIC = 0xFFFFFFFF
-
-
 class LookupKeyClient:
-    """ZMQ client for querying prefix cache hits from worker."""
+    """ZMQ client for the LookupKey admin channel.
+
+    Routes both prefix-cache lookups and admin commands (currently:
+    ``reset``) to ``LookupKeyServer`` on worker rank 0. The first frame
+    of every request is a named tag from ``protocol.py``.
+    """
 
     def __init__(self, vllm_config: VllmConfig):
         self.encoder = MsgpackEncoder()
@@ -406,20 +421,23 @@ class LookupKeyClient:
         hash_strs = [h.hex() for h in block_hashes]
         hash_frames = self.encoder.encode(hash_strs)
         token_len_bytes = token_len.to_bytes(4, byteorder="big")
-        all_frames = [token_len_bytes] + list(hash_frames)
+        all_frames = [LOOKUP_MSG, token_len_bytes] + list(hash_frames)
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")
         return result
 
     def reset(self) -> bool:
-        """Trigger `store.remove_all(force=True)` on worker rank 0.
+        """Trigger ``store.remove_all(force=True)`` on worker rank 0.
 
-        Returns True on success, False on failure.
+        Ordering assumption: caller MUST ensure no in-flight Mooncake
+        lookups or transfers when invoking reset. In RL workflows this
+        holds naturally at the step boundary after weight updates and
+        rollout drain. Returns True on ACK, False on NACK.
         """
-        self.socket.send_multipart([RESET_MAGIC.to_bytes(4, "big")], copy=False)
+        self.socket.send(RESET_MSG)
         resp = self.socket.recv()
-        return int.from_bytes(resp, "big") == RESET_MAGIC
+        return bytes(resp) == RESP_OK
 
     def close(self):
         self.socket.close(linger=0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_scheduler.py
@@ -363,6 +363,30 @@ class MooncakeStoreScheduler:
             )
         return delay_free_blocks, None
 
+    def reset_store(self) -> bool:
+        """Trigger a global `remove_all(force=True)` on the Mooncake master.
+
+        Routes through the existing ZMQ admin channel to worker rank 0,
+        which owns the `MooncakeDistributedStore` handle. Returns True on
+        success, False if the worker failed to clear or the RPC errored.
+        """
+        try:
+            ok = self.client.reset()
+            if ok:
+                logger.info("Mooncake store reset via RemoveAll succeeded.")
+            else:
+                logger.warning(
+                    "Mooncake store reset returned failure ack from worker."
+                )
+            return ok
+        except Exception as e:
+            logger.error("Mooncake reset_store RPC failed: %s", e)
+            return False
+
+
+# Mirror of RESET_MAGIC in mooncake_store_worker.LookupKeyServer.
+RESET_MAGIC = 0xFFFFFFFF
+
 
 class LookupKeyClient:
     """ZMQ client for querying prefix cache hits from worker."""
@@ -387,6 +411,15 @@ class LookupKeyClient:
         resp = self.socket.recv()
         result = int.from_bytes(resp, "big")
         return result
+
+    def reset(self) -> bool:
+        """Trigger `store.remove_all(force=True)` on worker rank 0.
+
+        Returns True on success, False on failure.
+        """
+        self.socket.send_multipart([RESET_MAGIC.to_bytes(4, "big")], copy=False)
+        resp = self.socket.recv()
+        return int.from_bytes(resp, "big") == RESET_MAGIC
 
     def close(self):
         self.socket.close(linger=0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -40,6 +40,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_schedu
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     get_mooncake_dp_engine_index,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.protocol import (
+    LOOKUP_MSG,
+    RESET_MSG,
+    RESP_ERR,
+    RESP_OK,
+)
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_ip, make_zmq_socket
 from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
@@ -1148,18 +1154,20 @@ class MooncakeStoreWorker:
 # Lookup Key Server
 # ============================================================
 
-# Sentinel used by LookupKeyClient/Server to discriminate the RESET admin
-# command from a normal token-length-prefixed lookup request. 0xFFFFFFFF
-# is the max uint32, far above any real model context length.
-RESET_MAGIC = 0xFFFFFFFF
-
-
 class LookupKeyServer:
-    """ZMQ server on worker rank 0 for handling prefix lookup queries.
+    """ZMQ server on worker rank 0 for the LookupKey admin channel.
 
-    Also accepts a RESET admin command (single 4-byte frame == RESET_MAGIC)
-    that triggers `store_worker.store.remove_all(force=True)`. Response is
-    `RESET_MAGIC` on success or `0` on failure. See `LookupKeyClient.reset`.
+    Handles two request types, discriminated by the named tag at frame 0
+    (see ``protocol.py`` for the wire format):
+
+    - ``LOOKUP_MSG``: prefix-cache hit query. Returns hit count as 4-byte BE.
+    - ``RESET_MSG``: ``store.remove_all(force=True)`` admin command. Returns
+      ``RESP_OK`` on success or ``RESP_ERR`` on failure.
+
+    Reset semantics: the caller must ensure no in-flight Mooncake
+    lookups/transfers when invoking reset. The ZMQ socket is REQ/REP and
+    serialises requests, but pending puts/gets in worker transfer threads
+    are independent of this channel.
     """
 
     def __init__(
@@ -1186,21 +1194,32 @@ class LookupKeyServer:
         def process_request():
             while self.running:
                 all_frames = self.socket.recv_multipart(copy=False)
-                token_len = int.from_bytes(all_frames[0], byteorder="big")
-                if token_len == RESET_MAGIC and len(all_frames) == 1:
+                msg_type = bytes(all_frames[0])
+
+                if msg_type == LOOKUP_MSG:
+                    token_len = int.from_bytes(all_frames[1], byteorder="big")
+                    hash_frames = all_frames[2:]
+                    hashes_str = self.decoder.decode(hash_frames)
+                    result = self.store_worker.lookup(token_len, hashes_str)
+                    self.socket.send(result.to_bytes(4, "big"))
+
+                elif msg_type == RESET_MSG:
                     try:
                         self.store_worker.store.remove_all(force=True)
-                        response = RESET_MAGIC.to_bytes(4, "big")
+                        logger.info(
+                            "Mooncake store reset via remove_all(force=True) "
+                            "succeeded."
+                        )
+                        self.socket.send(RESP_OK)
                     except Exception as e:
                         logger.error("Mooncake remove_all failed: %s", e)
-                        response = (0).to_bytes(4, "big")
-                    self.socket.send(response)
-                    continue
-                hash_frames = all_frames[1:]
-                hashes_str = self.decoder.decode(hash_frames)
-                result = self.store_worker.lookup(token_len, hashes_str)
-                response = result.to_bytes(4, "big")
-                self.socket.send(response)
+                        self.socket.send(RESP_ERR)
+
+                else:
+                    logger.warning(
+                        "LookupKeyServer received unknown msg_type: %r", msg_type
+                    )
+                    self.socket.send(RESP_ERR)
 
         self.thread = threading.Thread(target=process_request, daemon=True)
         self.thread.start()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_store_worker.py
@@ -1148,9 +1148,19 @@ class MooncakeStoreWorker:
 # Lookup Key Server
 # ============================================================
 
+# Sentinel used by LookupKeyClient/Server to discriminate the RESET admin
+# command from a normal token-length-prefixed lookup request. 0xFFFFFFFF
+# is the max uint32, far above any real model context length.
+RESET_MAGIC = 0xFFFFFFFF
+
 
 class LookupKeyServer:
-    """ZMQ server on worker rank 0 for handling prefix lookup queries."""
+    """ZMQ server on worker rank 0 for handling prefix lookup queries.
+
+    Also accepts a RESET admin command (single 4-byte frame == RESET_MAGIC)
+    that triggers `store_worker.store.remove_all(force=True)`. Response is
+    `RESET_MAGIC` on success or `0` on failure. See `LookupKeyClient.reset`.
+    """
 
     def __init__(
         self,
@@ -1177,6 +1187,15 @@ class LookupKeyServer:
             while self.running:
                 all_frames = self.socket.recv_multipart(copy=False)
                 token_len = int.from_bytes(all_frames[0], byteorder="big")
+                if token_len == RESET_MAGIC and len(all_frames) == 1:
+                    try:
+                        self.store_worker.store.remove_all(force=True)
+                        response = RESET_MAGIC.to_bytes(4, "big")
+                    except Exception as e:
+                        logger.error("Mooncake remove_all failed: %s", e)
+                        response = (0).to_bytes(4, "big")
+                    self.socket.send(response)
+                    continue
                 hash_frames = all_frames[1:]
                 hashes_str = self.decoder.decode(hash_frames)
                 result = self.store_worker.lookup(token_len, hashes_str)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/protocol.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/protocol.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Wire-format constants for the LookupKey ZMQ admin channel.
+
+This is the single source of truth shared by ``LookupKeyClient``
+(scheduler side) and ``LookupKeyServer`` (worker rank-0 side).
+
+Wire format (REQ/REP over IPC):
+
+    Request: [msg_type: bytes] [payload_frames...]
+
+      msg_type == LOOKUP_MSG:
+          frame 1: token_len (u32 big-endian, 4 bytes)
+          frame 2..n: msgpack-encoded list[str] of block-hash hex digests
+        Response: [hit_count: u32 big-endian, 4 bytes]
+
+      msg_type == RESET_MSG:
+          (no payload frames)
+        Response: [RESP_OK] or [RESP_ERR]
+
+The first frame of every request is a named bytes tag (not a numeric
+sentinel) to keep the protocol self-describing and extensible: adding
+new admin commands requires only a new tag and a new dispatch branch.
+
+Mirrors the convention used by the NIXL connector
+(see ``vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py``).
+
+Bump PROTOCOL_VERSION on any backward-incompatible wire format change.
+"""
+
+# Request message-type tags. Frame 0 of every request.
+LOOKUP_MSG: bytes = b"lookup"
+RESET_MSG: bytes = b"reset"
+
+# Single-byte response status codes for admin commands.
+RESP_OK: bytes = b"\x01"
+RESP_ERR: bytes = b"\x00"
+
+PROTOCOL_VERSION: int = 1

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1916,8 +1916,15 @@ class Scheduler(SchedulerInterface):
 
     def reset_connector_cache(self) -> bool:
         if self.connector is None:
-            logger.warning("reset_connector called but no KV connector is configured.")
-            return False
+            # No connector attached -> nothing to reset, treat as success so
+            # callers that unconditionally pass reset_connector=True after a
+            # weight update don't have their reset_prefix_cache() return value
+            # flipped to False purely because they didn't configure a connector.
+            logger.debug(
+                "reset_connector requested but no KV connector is configured; "
+                "treating as no-op success."
+            )
+            return True
 
         if self.connector.reset_cache() is False:
             return False

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -627,7 +627,18 @@ class EngineCore:
         self.model_executor.reset_encoder_cache()
 
     def _reset_caches(self, reset_running_requests=True) -> None:
-        self.reset_prefix_cache(reset_running_requests=reset_running_requests)
+        # reset_connector=True so that external KV-store connectors
+        # (e.g. MooncakeStoreConnector) drop their state alongside the
+        # local prefix/mm/encoder caches. This is the cache invariant
+        # callers of ``pause_generation(clear_cache=True)`` expect: clear
+        # all caches, not just the on-engine ones. Callers that only
+        # want a local-only invalidation should invoke
+        # ``self.scheduler.reset_prefix_cache(reset_connector=False)``
+        # directly instead of going through this cascade.
+        self.reset_prefix_cache(
+            reset_running_requests=reset_running_requests,
+            reset_connector=True,
+        )
         self.reset_mm_cache()
         self.reset_encoder_cache()
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -626,18 +626,21 @@ class EngineCore:
         # Reset the GPU model runner's encoder cache (physical storage)
         self.model_executor.reset_encoder_cache()
 
-    def _reset_caches(self, reset_running_requests=True) -> None:
-        # reset_connector=True so that external KV-store connectors
-        # (e.g. MooncakeStoreConnector) drop their state alongside the
-        # local prefix/mm/encoder caches. This is the cache invariant
-        # callers of ``pause_generation(clear_cache=True)`` expect: clear
-        # all caches, not just the on-engine ones. Callers that only
-        # want a local-only invalidation should invoke
-        # ``self.scheduler.reset_prefix_cache(reset_connector=False)``
-        # directly instead of going through this cascade.
+    def _reset_caches(
+        self,
+        reset_running_requests: bool = True,
+        reset_connector: bool = True,
+    ) -> None:
+        # ``reset_connector`` defaults to True so external KV-store
+        # connectors (e.g. MooncakeStoreConnector) drop their state
+        # alongside the local prefix/mm/encoder caches. This matches the
+        # invariant callers of ``pause_generation(clear_cache=True)``
+        # expect: clear all caches, not just the on-engine ones. Internal
+        # callers that genuinely want a local-only invalidation can pass
+        # ``reset_connector=False``.
         self.reset_prefix_cache(
             reset_running_requests=reset_running_requests,
-            reset_connector=True,
+            reset_connector=reset_connector,
         )
         self.reset_mm_cache()
         self.reset_encoder_cache()


### PR DESCRIPTION
## Summary

When verl (or any other RL framework) calls `engine.reset_prefix_cache(reset_connector=True)` after a weight update, vLLM core already routes the request through `Scheduler.reset_connector_cache() -> self.connector.reset_cache()`. This patch wires `MooncakeStoreConnector.reset_cache()` so the cascade actually clears the Mooncake master, dropping all external KV blocks computed against the previous weights before any new rollout request can read them.

This is the RL-correct hard-reset path; without it, the external Mooncake store would silently serve KV computed against stale weights on the next rollout step.

## Design

- **SCHEDULER role** `MooncakeStoreConnector.reset_cache()` -> `MooncakeStoreScheduler.reset_store()` -> `LookupKeyClient.reset()` (ZMQ send `RESET_MAGIC` frame).
- **WORKER rank-0** `LookupKeyServer` recognizes the `RESET_MAGIC` (0xFFFFFFFF) discriminator frame and calls `self.store_worker.store.remove_all(force=True)` on the master.
- The reset path **reuses** the existing scheduler<->worker rank 0 ZMQ admin channel originally built for prefix lookups, so no new sockets / handshake. A reserved sentinel value (unreachable for any real prompt length) discriminates RESET from a normal lookup so the wire format stays backward compatible.
- WORKER role `reset_cache()` is a no-op: reset is driven from the scheduler side via the ZMQ admin channel.
- Soft failure semantics: `MooncakeStoreScheduler.reset_store()` returns `False` (rather than raising) when the RPC errors out, matching the soft-dependency contract verl uses to keep training alive if Mooncake hiccups.

## Comparison vs SGLang

| | SGLang | this patch |
|---|---|---|
| trigger | per-RPC opt-in `flush_cache=True` flag — forget it once -> silent stale-cache corruption | automatic data-plane cascade via `reset_prefix_cache(reset_connector=True)` (no flag) |
| multi-rank | each scheduler instance calls `remove_all` -> idempotent but N redundant RPCs | one ZMQ RPC to rank-0 worker -> one `RemoveAll` per reset |
| guard consistency | `is_fully_idle()` silently false on failure, no doc/test | cascades only when the existing scheduler guard passes; covered by the new `test_scheduler_reset_prefix_cache_cascades_only_on_success` analog |
| RL-correctness | client must remember flag | hard-reset is the default path |

## Tests

6 new mock-based unit tests in `tests/v1/kv_connector/unit/test_mooncake_store_connector.py`:

- `test_reset_cache_scheduler_role_delegates_to_reset_store`
- `test_reset_cache_scheduler_role_propagates_failure`
- `test_reset_cache_worker_role_returns_none`
- `test_scheduler_reset_store_returns_client_reset_result`
- `test_scheduler_reset_store_handles_rpc_exception`
- `test_lookup_key_client_reset_uses_magic_protocol`

Run:

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_connector.py -v -k "reset or lookup_key_client_reset"
```

Result: 6 new + 13 existing connector tests + 18 existing worker tests all pass (37/37).

End-to-end cascade verified inside the `verl-bench-aoshen` container against a per-run Mooncake master. Master Admin Metrics confirm the path traffic (smoke wrote 12 puts across 2 rounds + 3 exist queries; both `DelAll` RemoveAll calls landed):

```
PutStart:(Req=12/0/12, Item=12/12)
PutEnd:(Req=12/0/12, Item=12/12)
ExistKey:(Req=3/0/3, Item=18/18)
DelAll=2/2
```

## Test plan
- [x] 6 new unit tests pass (mock `MooncakeDistributedStore`)
- [x] 31 existing mooncake store unit tests still pass (no regressions)
- [x] End-to-end cascade against real Mooncake master (in container) — `connector.reset_cache()` -> `remove_all(force=True)` confirmed via master Admin Metrics
- [ ] Full verl GRPO 5-cycle smoke (Qwen3-0.6B / 1 tray) — recipe authored at `recipe_aoshen/phase_b_mooncake.sh` in the paired verl PR; deferred for a dedicated bench run

## AI assistance
This PR was authored with the help of Claude Opus 4.7 (1M context). Each line was reviewed by me end-to-end; tests were verified locally on a GB200 host with the container `verl-bench-aoshen`. The cascade-design (re-using the existing LookupKey ZMQ channel with a RESET_MAGIC sentinel discriminator instead of opening a new admin socket) was chosen to minimize new surface area.

## Duplicate-work check

No existing PR addresses `MooncakeStoreConnector.reset_cache` for the RL hard-reset path. `KVConnectorBase_V1.reset_cache` is the framework-level hook already shipped in vLLM 0.20.1; this PR is the connector-specific implementation.