### PR TITLE
[Mooncake] Forward-port owner-client topology + disk-offload + tier-log + perf fixes (squashed, rebased)

### DIFF
--- a/docs/features/mooncake_store_connector_usage.md
+++ b/docs/features/mooncake_store_connector_usage.md
@@ -2,7 +2,7 @@
 
 MooncakeStoreConnector is a KV cache connector that uses [MooncakeDistributedStore](https://github.com/kvcache-ai/Mooncake) as a shared KV cache pool. Unlike `MooncakeConnector` which does direct point-to-point KV transfer between prefiller and decoder, MooncakeStoreConnector enables KV cache offloading to an external distributed store, supporting:
 
-- **CPU offloading**: Extend effective KV cache capacity by offloading to CPU memory via Mooncake's transfer engine.
+- **CPU/disk offloading**: Extend effective KV cache capacity by offloading to CPU memory or disk via Mooncake's transfer engine.
 - **Prefix caching across instances**: Hash-based deduplication allows multiple vLLM instances to share cached KV blocks through the store.
 - **Single-node and multi-node deployment**: Works both as a standalone KV cache extension and in disaggregated prefill-decode setups.
 
@@ -126,12 +126,30 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct \
 
 A disaggregation proxy is required to route requests between prefiller and decoder nodes. The proxy assigns `do_remote_prefill=True` / `do_remote_decode=True` to coordinate P2P transfer via `MooncakeConnector`. Refer to the [MooncakeConnector usage guide](mooncake_connector_usage.md) for proxy setup details.
 
+### Disk Offloading
+
+To enable disk offloading for even larger cache capacity, set the following environment variables:
+
+```bash
+export MOONCAKE_ENABLE_OFFLOAD=1
+export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=/path/to/offload/dir
+```
+
+You can also control the local staging buffer size:
+
+```bash
+export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES=1280mb
+```
+
 ## Environment Variables
 
 | Variable | Description | Default |
-| --- | --- | --- |
+|---|---|---|
 | `MOONCAKE_CONFIG_PATH` | Path to Mooncake JSON config file | (required) |
 | `VLLM_MOONCAKE_BOOTSTRAP_PORT` | Bootstrap port for MooncakeConnector P2P transfer (disagg mode only) | 8998 |
+| `MOONCAKE_ENABLE_OFFLOAD` | Enable disk offloading (`1` or `true`) | disabled |
+| `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | Directory for disk offload files | — |
+| `MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES` | Local staging buffer size for disk offload | 1280MB |
 
 ## KV Transfer Config
 

--- a/scripts/mooncake/README.md
+++ b/scripts/mooncake/README.md
@@ -1,0 +1,55 @@
+# Mooncake KV Store for vLLM
+
+## Two launch paths
+
+| Path | Where | When to use |
+|---|---|---|
+| **`verify/`** (recommended) | `scripts/mooncake/verify/mndp_noscripts.yaml` | Production / new setups. Inlines `mooncake_master` + `mooncake_client` directly in the vigil yaml, RDMA NIC assignment done in Python via `vllm/.../mooncake/rdma_utils.py`. |
+| **`legacy/`** | `scripts/mooncake/legacy/mndp.yaml` | Pre-existing wrapper-script flow. Useful for comparison / debugging — uses `start_mooncake_master.sh`, `run_vllm_with_mooncake_owner.sh`, etc. |
+
+## Quickstart
+
+```bash
+cd ~/repos/vllm-mooncake
+
+# Verify (no-scripts) path — recommended:
+~/repos/model-ci/.venv/bin/vigil -c scripts/mooncake/verify/mndp_noscripts.yaml
+
+# Legacy (wrapper-script) path — equivalent but with bash wrappers:
+~/repos/model-ci/.venv/bin/vigil -c scripts/mooncake/legacy/mndp.yaml
+```
+
+See `verify/RUNBOOK.md` for the full step-by-step launch guide,
+prerequisites, troubleshooting, and tuning knobs.
+
+## Files at this directory
+
+- `README.md` — this file
+- `mooncake_config.json` — connection config consumed by `MOONCAKE_CONFIG_PATH`; referenced by both `verify/` and `legacy/`. `legacy/mooncake_config.json` is a symlink back here so the wrapper script's `${SCRIPT_DIR}/mooncake_config.json` default still resolves.
+
+  Ships with **`"mode": "owner-client"`** + `"global_segment_size": 0` because both pipelines in this repo spawn a separate `mooncake_client` owner. To run the legacy PR-40900 baseline (every rank contributes a CPU segment, no separate owner), switch to `"mode": "real-client"` + `"global_segment_size": "4GB"`. See `~/repos/disk/design/dual-mode-design.md` for the full mode contract and `~/repos/disk/design/toggle-runbook.md` for the switch procedure.
+
+## Install Mooncake
+
+Both paths assume `mooncake_master` and `mooncake_client` are on PATH (i.e.
+`mooncake-transfer-engine` wheel installed into the vllm-mooncake venv).
+Build from source:
+
+```shell
+git clone https://github.com/ivanium/Mooncake
+cd Mooncake
+git checkout yifan/dev
+./scripts/dev_compile.sh
+./scripts/dev_install.sh
+```
+
+Build flags (set in `dev_compile.sh`):
+- `-DUSE_CUDA=ON`
+- `-DWITH_NVIDIA_PEERMEM=OFF` (required on GB200 — peermem kernel module won't load)
+- `-DUSE_MNNVL=ON`
+
+## See also
+
+- `~/repos/disk/deploy/RUNBOOK.md` — the launch runbook (also copied into `verify/`)
+- `~/repos/disk/deploy/P2P_VS_HTTP_METADATA.md` — peer-discovery mode trade-off
+- `~/repos/disk/deploy/RDMA_UTILS.md` — why per-rank NIC pinning is necessary and how it's done

--- a/scripts/mooncake/legacy/benchmark_cpu_offloading.sh
+++ b/scripts/mooncake/legacy/benchmark_cpu_offloading.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Benchmark CPU KV cache offloading overhead.
+# Launches a vllm server, runs `vllm-bench` against it, then
+# repeats with offloading enabled. Uses random (unique) prompts so
+# no offloaded prefix is ever hit — isolating the pure store overhead.
+#
+# Usage:
+#   bash benchmark_cpu_offloading.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+#
+# Supported backends (comma-separated in BACKENDS):
+#   baseline        - No offloading
+#   native          - Built-in vLLM KV offloading (--kv-offloading-backend native)
+#   simple          - Simple native offload (VLLM_USE_SIMPLE_KV_OFFLOAD=1 + native backend)
+#   mooncake        - MooncakeStoreConnector via --kv-transfer-config
+#
+# Environment variables:
+#   CPU_OFFLOAD_GIB       - CPU offload buffer in GiB   (default: 80)
+#   DISK_OFFLOAD_GIB      - Disk offload quota in GiB   (default: unset = disabled)
+#   REQUEST_RATE          - Requests/s to the server     (default: 1)
+#   PORT                  - Server port                  (default: 8192)
+#   RESULT_DIR            - Output directory             (default: ./bench_results)
+#   BACKENDS              - Comma-separated backends     (default: baseline,native,simple,mooncake)
+#   MOONCAKE_CONFIG_PATH  - Path to mooncake config JSON (required for mooncake, auto-skipped if unset)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODEL="${1:-meta-llama/Llama-3.1-8B-Instruct}"
+# MODEL="${1:-nvidia/Qwen3.5-397B-A17B-NVFP4}"
+INPUT_LEN="${2:-8192}"
+OUTPUT_LEN="${3:-1024}"
+NUM_PROMPTS="${4:-200}"
+CPU_OFFLOAD_GIB="${CPU_OFFLOAD_GIB:-80}"
+DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-400}"
+REQUEST_RATE="${REQUEST_RATE:-1}"
+PORT="${PORT:-8192}"
+RESULT_DIR="${RESULT_DIR:-./bench_results}"
+BACKENDS="${BACKENDS:-baseline,mooncake}"
+
+mkdir -p "$RESULT_DIR"
+
+SERVER_COMMON=(
+    --model "$MODEL"
+    --disable-hybrid-kv-cache-manager
+    --port "$PORT"
+    --no-enable-log-requests
+    --attention-backend FLASHINFER
+)
+if [[ "$MODEL" == *"Qwen3.5"* ]]; then
+    SERVER_COMMON+=(
+        --mamba-cache-mode align
+        --enable-prefix-caching
+    )
+fi
+
+if [[ "$MODEL" == "nvidia/Qwen3.5-397B-A17B-NVFP4" ]]; then
+    SERVER_COMMON+=(
+        -dp 4
+        --enable-expert-parallel
+        --language-model-only
+        --reasoning-parser qwen3
+    )
+fi
+
+BENCH_COMMON=(
+    --model "$MODEL"
+    --base-url "http://127.0.0.1:${PORT}"
+    --dataset-name random
+    --random-input-len "$INPUT_LEN"
+    --random-output-len "$OUTPUT_LEN"
+    --num-prompts "$NUM_PROMPTS"
+    --request-rate "$REQUEST_RATE"
+    --seed 42
+    --save-result
+    --result-dir "$RESULT_DIR"
+)
+
+wait_for_server() {
+    echo "  Waiting for server on port $PORT..."
+    for _ in $(seq 1 180); do
+        if curl -sf "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+            echo "  Server ready."
+            return 0
+        fi
+        sleep 1
+    done
+    echo "  ERROR: server did not start within 180s" >&2
+    return 1
+}
+
+kill_server() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        unset SERVER_PID
+    fi
+}
+trap kill_server EXIT
+
+run_one() {
+    local label="$1"
+    local result_file="$2"
+    shift 2
+    local server_extra=("$@")
+
+    echo ""
+    echo ">>> Starting server: $label"
+    echo "Command: vllm serve ${SERVER_COMMON[@]} ${server_extra[@]}"
+    vllm serve \
+        "${SERVER_COMMON[@]}" "${server_extra[@]}" &
+    SERVER_PID=$!
+
+    wait_for_server
+
+    echo ">>> Running benchmark: $label"
+    vllm-bench \
+        "${BENCH_COMMON[@]}" \
+        --result-filename "$result_file"
+
+    echo ">>> Stopping server"
+    sleep 2
+    kill_server
+}
+
+echo "============================================"
+echo "  CPU Offloading Overhead Benchmark"
+echo "============================================"
+echo "  Model:         $MODEL"
+echo "  Input len:     $INPUT_LEN"
+echo "  Output len:    $OUTPUT_LEN"
+echo "  Num prompts:   $NUM_PROMPTS"
+echo "  Request rate:  $REQUEST_RATE req/s"
+echo "  Backends:      $BACKENDS"
+echo "  CPU offload:   ${CPU_OFFLOAD_GIB} GiB"
+if [[ -n "$DISK_OFFLOAD_GIB" ]]; then
+echo "  Disk offload:  ${DISK_OFFLOAD_GIB} GiB"
+fi
+echo "============================================"
+
+# ── Run each requested backend ──────────────────────────────────
+IFS=',' read -ra BACKEND_LIST <<< "$BACKENDS"
+
+for backend in "${BACKEND_LIST[@]}"; do
+    case "$backend" in
+        baseline)
+            run_one "Baseline (no offloading)" "baseline.json"
+            ;;
+        native)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            run_one "With CPU offloading (native)" "native.json" \
+                --kv-offloading-size "$CPU_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        simple)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=1
+            run_one "With CPU offloading (simple)" "simple.json" \
+                --kv-offloading-size "$CPU_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        mooncake)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            SETUP_ARGS=(--cpu-mem-size "$CPU_OFFLOAD_GIB")
+            if [[ -n "$DISK_OFFLOAD_GIB" ]]; then
+                SETUP_ARGS+=(--disk-size "$DISK_OFFLOAD_GIB")
+            fi
+            source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
+            run_one "With CPU offloading (mooncake)" "mooncake.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;
+        *)
+            echo ""
+            echo ">>> Skipping unknown backend: $backend"
+            ;;
+    esac
+done
+
+# ── Compare all available results ───────────────────────────────
+python3 "${SCRIPT_DIR}/compare_results.py" "$RESULT_DIR"

--- a/scripts/mooncake/legacy/benchmark_multi_turn.sh
+++ b/scripts/mooncake/legacy/benchmark_multi_turn.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Benchmark multi-turn chat with/without CPU KV cache offloading.
+# Launches a vllm server, runs `vllm-bench` with multi-turn options,
+# then repeats with offloading enabled.
+#
+# Usage:
+#   bash benchmark_multi_turn.sh [MODEL] [INPUT_LEN] [OUTPUT_LEN] [NUM_PROMPTS]
+#
+# Supported backends (comma-separated in BACKENDS):
+#   baseline        - No offloading
+#   native          - Built-in vLLM KV offloading (--kv-offloading-backend native)
+#   simple          - Simple native offload (VLLM_USE_SIMPLE_KV_OFFLOAD=1 + native backend)
+#   mooncake-mem    - MooncakeStoreConnector with CPU memory only (no disk)
+#   mooncake        - MooncakeStoreConnector via --kv-transfer-config
+#
+# Environment variables:
+#   CPU_OFFLOAD_GIB       - CPU offload buffer in GiB   (default: 80)
+#   DISK_OFFLOAD_GIB      - Disk offload quota in GiB   (default: 400)
+#   PORT                  - Server port                  (default: 8192)
+#   RESULT_DIR            - Output directory             (default: ./bench_results)
+#   BACKENDS              - Comma-separated backends     (default: baseline,mooncake)
+#   MOONCAKE_CONFIG_PATH  - Path to mooncake config JSON (required for mooncake, auto-skipped if unset)
+#   MULTI_TURN_NUM_TURNS  - Number of turns per conversation  (default: 4)
+#   MULTI_TURN_CONCURRENCY - Concurrent conversations         (default: 8)
+#   MULTI_TURN_DELAY_MS   - Delay between turns in ms         (default: 500)
+#   GLOBAL_PREFIX_RATIO   - Fraction of input as global prefix  (default: 0.1)
+#   CONV_PREFIX_RATIO     - Fraction of input as conversation prefix (default: 0.8)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODEL="${1:-meta-llama/Llama-3.1-8B-Instruct}"
+INPUT_LEN="${2:-70000}"
+OUTPUT_LEN="${3:-200}"
+NUM_PROMPTS="${4:-200}"
+CPU_OFFLOAD_GIB="${CPU_OFFLOAD_GIB:-600}"
+DISK_OFFLOAD_GIB="${DISK_OFFLOAD_GIB:-2000}"
+PORT="${PORT:-8192}"
+RESULT_DIR="${RESULT_DIR:-./bench_results}"
+BACKENDS="${BACKENDS:-baseline,mooncake}"
+
+MULTI_TURN_NUM_TURNS="${MULTI_TURN_NUM_TURNS:-3}"
+MULTI_TURN_CONCURRENCY="${MULTI_TURN_CONCURRENCY:-16}"
+MULTI_TURN_DELAY_MS="${MULTI_TURN_DELAY_MS:-500}"
+GLOBAL_PREFIX_RATIO="${GLOBAL_PREFIX_RATIO:-0.1}"
+CONV_PREFIX_RATIO="${CONV_PREFIX_RATIO:-0.8}"
+
+mkdir -p "$RESULT_DIR"
+
+SERVER_COMMON=(
+    --model "$MODEL"
+    --disable-hybrid-kv-cache-manager
+    --port "$PORT"
+    --no-enable-log-requests
+    --attention-backend FLASHINFER
+)
+if [[ "$MODEL" == *"Qwen3.5"* ]]; then
+    SERVER_COMMON+=(
+        --mamba-cache-mode align
+        --enable-prefix-caching
+    )
+fi
+
+if [[ "$MODEL" == "nvidia/Qwen3.5-397B-A17B-NVFP4" ]]; then
+    SERVER_COMMON+=(
+        -dp 4
+        --enable-expert-parallel
+        --language-model-only
+        --reasoning-parser qwen3
+    )
+fi
+
+BENCH_COMMON=(
+    --backend openai-chat
+    --model "$MODEL"
+    --base-url "http://127.0.0.1:${PORT}"
+    --dataset-name random
+    --random-input-len "$INPUT_LEN"
+    --random-output-len "$OUTPUT_LEN"
+    --num-prompts "$NUM_PROMPTS"
+    --multi-turn
+    --multi-turn-num-turns "$MULTI_TURN_NUM_TURNS"
+    --multi-turn-concurrency "$MULTI_TURN_CONCURRENCY"
+    --multi-turn-delay-ms "$MULTI_TURN_DELAY_MS"
+    --multi-turn-prefix-global-ratio "$GLOBAL_PREFIX_RATIO"
+    --multi-turn-prefix-conversation-ratio "$CONV_PREFIX_RATIO"
+    --percentile-metrics "ttft,tpot,itl,e2el"
+    --save-result
+    --result-dir "$RESULT_DIR"
+)
+
+wait_for_server() {
+    echo "  Waiting for server on port $PORT..."
+    for _ in $(seq 1 180); do
+        if curl -sf "http://127.0.0.1:${PORT}/health" > /dev/null 2>&1; then
+            echo "  Server ready."
+            return 0
+        fi
+        sleep 1
+    done
+    echo "  ERROR: server did not start within 180s" >&2
+    return 1
+}
+
+kill_server() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        unset SERVER_PID
+    fi
+}
+trap kill_server EXIT
+
+run_one() {
+    local label="$1"
+    local result_file="$2"
+    shift 2
+    local server_extra=("$@")
+
+    echo ""
+    echo ">>> Starting server: $label"
+    echo "Command: vllm serve ${SERVER_COMMON[@]} ${server_extra[@]}"
+    vllm serve \
+        "${SERVER_COMMON[@]}" "${server_extra[@]}" &
+    SERVER_PID=$!
+
+    wait_for_server
+
+    echo ">>> Running benchmark: $label"
+    vllm-bench \
+        "${BENCH_COMMON[@]}" \
+        --result-filename "$result_file"
+
+    echo ">>> Stopping server"
+    sleep 2
+    kill_server
+}
+
+echo "============================================"
+echo "  Multi-Turn Offloading Benchmark"
+echo "============================================"
+echo "  Model:         $MODEL"
+echo "  Input len:     $INPUT_LEN"
+echo "  Output len:    $OUTPUT_LEN"
+echo "  Num prompts:   $NUM_PROMPTS"
+echo "  Turns:         $MULTI_TURN_NUM_TURNS"
+echo "  Concurrency:   $MULTI_TURN_CONCURRENCY"
+echo "  Turn delay:    ${MULTI_TURN_DELAY_MS} ms"
+echo "  Global prefix: $GLOBAL_PREFIX_RATIO"
+echo "  Conv prefix:   $CONV_PREFIX_RATIO"
+echo "  Backends:      $BACKENDS"
+echo "  CPU offload:   ${CPU_OFFLOAD_GIB} GiB"
+if [[ -n "$DISK_OFFLOAD_GIB" ]]; then
+echo "  Disk offload:  ${DISK_OFFLOAD_GIB} GiB"
+fi
+echo "============================================"
+
+# ── Run each requested backend ──────────────────────────────────
+IFS=',' read -ra BACKEND_LIST <<< "$BACKENDS"
+
+for backend in "${BACKEND_LIST[@]}"; do
+    case "$backend" in
+        baseline)
+            run_one "Baseline (no offloading)" "mt_baseline.json"
+            ;;
+        native)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            run_one "With CPU offloading (native)" "mt_native.json" \
+                --kv-offloading-size "$CPU_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        simple)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=1
+            run_one "With CPU offloading (simple)" "mt_simple.json" \
+                --kv-offloading-size "$CPU_OFFLOAD_GIB" \
+                --kv-offloading-backend "native"
+            ;;
+        mooncake)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            SETUP_ARGS=(--cpu-mem-size "$CPU_OFFLOAD_GIB")
+            if [[ -n "$DISK_OFFLOAD_GIB" ]]; then
+                SETUP_ARGS+=(--disk-size "$DISK_OFFLOAD_GIB")
+            fi
+            source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
+            run_one "With CPU offloading (mooncake)" "mt_mooncake.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;
+        mooncake-mem)
+            export VLLM_USE_SIMPLE_KV_OFFLOAD=0
+            SETUP_ARGS=(--cpu-mem-size "$CPU_OFFLOAD_GIB")
+            source "${SCRIPT_DIR}/setup_vllm_env.sh" "${SETUP_ARGS[@]}"
+            run_one "With CPU offloading (mooncake-mem)" "mt_mooncake_mem.json" \
+                --kv-transfer-config "{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"load_async\":true}}"
+            ;;
+        *)
+            echo ""
+            echo ">>> Skipping unknown backend: $backend"
+            ;;
+    esac
+done
+
+# ── Compare all available results ───────────────────────────────
+python3 "${SCRIPT_DIR}/compare_results.py" "$RESULT_DIR" --prefix mt_

--- a/scripts/mooncake/legacy/compare_results.py
+++ b/scripts/mooncake/legacy/compare_results.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare benchmark results across offloading backends.
+
+Usage:
+    python compare_results.py <result_dir> [--prefix PREFIX]
+
+Examples:
+    # Compare multi-turn results (mt_baseline.json, mt_mooncake.json, ...)
+    python compare_results.py ./bench_results --prefix mt_
+
+    # Compare single-turn results (baseline.json, mooncake.json, ...)
+    python compare_results.py ./bench_results
+"""
+
+import argparse
+import json
+import os
+
+ALL_BACKENDS = ["baseline", "native", "simple", "mooncake_mem", "mooncake"]
+
+METRICS = [
+    ("Output throughput (tok/s)", "output_throughput", ".1f"),
+    ("Request throughput (req/s)", "request_throughput", ".3f"),
+    ("Mean TTFT (ms)", "mean_ttft_ms", ".2f"),
+    ("Median TTFT (ms)", "median_ttft_ms", ".2f"),
+    ("P99 TTFT (ms)", "p99_ttft_ms", ".2f"),
+    ("Mean TPOT (ms)", "mean_tpot_ms", ".2f"),
+    ("Mean ITL (ms)", "mean_itl_ms", ".2f"),
+    ("Mean E2EL (ms)", "mean_e2el_ms", ".2f"),
+]
+
+COL_W = 20
+
+
+def pct(old, new):
+    return (new - old) / old * 100 if old else 0.0
+
+
+def load_results(result_dir, prefix):
+    results = {}
+    for label in ALL_BACKENDS:
+        path = os.path.join(result_dir, f"{prefix}{label}.json")
+        if os.path.isfile(path):
+            with open(path) as f:
+                results[label] = json.load(f)
+    return results
+
+
+def print_comparison(results, title):
+    if not results:
+        print("\nNo result files found — nothing to compare.\n")
+        return
+
+    labels = list(results.keys())
+
+    print()
+    print("=" * (32 + COL_W * len(labels)))
+    print(f"  {title}  (delta vs baseline: + = regression, - = improvement)")
+    print("=" * (32 + COL_W * len(labels)))
+
+    header = f"  {'Metric':<30}"
+    for lb in labels:
+        header += f"  {lb:>{COL_W - 2}}"
+    print(header)
+
+    sep = f"  {'-' * 30}"
+    for _ in labels:
+        sep += f"  {'-' * (COL_W - 2)}"
+    print(sep)
+
+    baseline = results.get("baseline")
+
+    for metric_label, key, fmt in METRICS:
+        # Skip metrics not present in any result
+        if all(results[lb].get(key) is None for lb in labels):
+            continue
+        row = f"  {metric_label:<30}"
+        for lb in labels:
+            val = results[lb].get(key)
+            if val is None:
+                row += f"  {'N/A':>{COL_W - 2}}"
+                continue
+            cell = f"{val:{fmt}}"
+            if baseline and lb != "baseline":
+                bval = baseline.get(key, 0)
+                delta = pct(bval, val)
+                cell += f" ({delta:+.1f}%)"
+            row += f"  {cell:>{COL_W - 2}}"
+        print(row)
+
+    print("=" * (32 + COL_W * len(labels)))
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare benchmark results across offloading backends."
+    )
+    parser.add_argument("result_dir", help="Directory containing result JSONs")
+    parser.add_argument(
+        "--prefix",
+        default="",
+        help="Filename prefix (e.g. 'mt_' for multi-turn results)",
+    )
+    args = parser.parse_args()
+
+    results = load_results(args.result_dir, args.prefix)
+    title = "MULTI-TURN COMPARISON" if args.prefix == "mt_" else "COMPARISON"
+    print_comparison(results, title)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mooncake/legacy/mndp.yaml
+++ b/scripts/mooncake/legacy/mndp.yaml
@@ -1,0 +1,140 @@
+# Kimi-K2.5-NVFP4 Multi-Node DP with MooncakeStore — 2 nodes × 4 GPUs each
+#
+# This config bootstraps the Mooncake master in pre_serve, then lets
+# run_vllm_with_mooncake_owner.sh default the GID/fabric choice and inject the
+# final Mooncake --kv-transfer-config for each worker node.
+
+model: Qwen/Qwen3-8B
+mode: local
+precheck: true
+collect_env: true
+router_port: auto
+prometheus_port: auto
+
+pre_serve:
+  - cmd: >-
+      bash scripts/mooncake/legacy/start_mooncake_master.sh
+      --bg
+      --enable-offload
+    repo_path: /home/${USER}/repos/vllm-mooncake
+    env:
+      # Short lease TTL so memory replicas become evictable shortly after
+      # NotifyOffloadSuccess; otherwise BatchEvict skips every candidate
+      # (default 1800000 ms = 30 min) and the CPU pool plateaus at 95%.
+      MC_LEASE_TTL: "30000"
+
+serving:
+  roles:
+    - role: worker
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      base_port: 8100
+      vllm_engine:
+        repo_path: /home/${USER}/repos/vllm-mooncake
+        cmd: >-
+          bash /home/${USER}/repos/vllm-mooncake/scripts/mooncake/legacy/run_vllm_with_mooncake_owner.sh
+          vllm serve {model}
+          --port {port}
+          --trust-remote-code
+          --load-format dummy
+          --enforce-eager
+          -dp 4
+          --gpu-memory-utilization 0.4
+          --num-gpu-blocks-override 1024
+          --max-model-len 16384
+          --max-num-seqs 32
+          --max-num-batched-tokens 8192
+          --enable-prefix-caching
+          --enable-chunked-prefill
+          --disable-uvicorn-access-log
+        env:
+          GLOG_v: "1"
+          VLLM_MOONCAKE_STORE_TIER_LOG: "1"
+          # P2P-handshake mode: workers + owner discover each other directly via
+          # the owner's segment port; no HTTP metadata server needed for 1-node.
+          MOONCAKE_MASTER: "127.0.0.1:50051"
+          MOONCAKE_TE_META_DATA_SERVER: "P2PHANDSHAKE"
+          # 4 GiB CPU pool → force disk-tier spillover
+          MC_OWNER_CPU_MEM_GIB: "4"
+          MC_OWNER_DISK_GIB: "1000"
+          MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
+          VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+          # Timeouts
+          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+          VLLM_RPC_TIMEOUT: "600000"
+          VLLM_LOG_STATS_INTERVAL: "1"
+          # UCX config for MNNVL
+          UCX_MEMTYPE_CACHE: "n"
+          UCX_MEMTYPE_REG_WHOLE: "n"
+          UCX_TLS: "cuda_copy,cuda_ipc,tcp"
+          UCX_CUDA_IPC_ENABLE_MNNVL: "y"
+          UCX_RC_TIMEOUT: "5s"
+          UCX_RC_RETRY_COUNT: "14"
+          UCX_RC_RNR_TIMEOUT: "10ms"
+          UCX_RC_RNR_RETRY_COUNT: "14"
+          # Model cache (shared filesystem)
+          HF_HOME: /mnt/lustre/hf-models
+          # NCCL for GB200 NVL72
+          NCCL_P2P_DISABLE: "0"
+          NCCL_P2P_LEVEL: NVL
+          NCCL_SOCKET_IFNAME: enp192s2
+          NCCL_IB_HCA: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
+          NCCL_NET_GDR_LEVEL: "5"
+          NCCL_SHM_DISABLE: "1"
+          NCCL_DEBUG: WARN
+          NCCL_TIMEOUT: "1800"
+          TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+          GLOO_SOCKET_IFNAME: enp192s2
+        health_check:
+          url: "http://localhost:{port}/health"
+          timeout_s: 3600
+          poll_interval_s: 10
+
+  # ---- Router (round-robin, no PD disaggregation) ----
+  router:
+    repo_path: /home/${USER}/repos/router-internal
+    cmd: >-
+      cargo run --release --
+      --policy consistent_hash
+      --prometheus-port {prometheus_port}
+      --host 0.0.0.0
+      --port {router_port}
+      --intra-node-data-parallel-size 4
+      {worker_flags}
+    health_check:
+      url: http://localhost:{router_port}/health
+      timeout_s: 300
+      poll_interval_s: 5
+
+  remote:
+    launcher: slurm
+    slurm:
+      partition: normal
+      time_limit: "12:00:00"
+      # nodelist: "gb200-rack1-[10,11]"
+      grace_period_s: 120
+
+post_serve:
+  - vmon: start
+  - cmd: >-
+      vllm-bench
+      --backend openai-chat
+      --base-url http://localhost:{router_port}
+      --model {model}
+      --dataset-name random
+      --random-input-len 16000
+      --random-output-len 300
+      --num-prompts 100
+      --multi-turn
+      --multi-turn-num-turns 3
+      --multi-turn-concurrency 32
+      --multi-turn-delay-ms 500
+      --multi-turn-prefix-global-ratio 0.1
+      --multi-turn-prefix-conversation-ratio 0.8
+      --percentile-metrics "ttft,tpot,itl,e2el"
+      --result-dir {log_dir}
+      --save-result
+  - vmon: stop
+  - cmd: bash scripts/mooncake/legacy/start_mooncake_master.sh --stop
+    repo_path: /home/${USER}/repos/vllm-mooncake

--- a/scripts/mooncake/legacy/mooncake_config.json
+++ b/scripts/mooncake/legacy/mooncake_config.json
@@ -1,0 +1,1 @@
+../mooncake_config.json

--- a/scripts/mooncake/legacy/mooncake_example.py
+++ b/scripts/mooncake/legacy/mooncake_example.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from mooncake.store import MooncakeDistributedStore
+
+# 1. Create store instance
+store = MooncakeDistributedStore()
+
+# 2. Setup with all required parameters
+store.setup(
+    "localhost",  # Your node's address
+    "http://localhost:8080/metadata",  # HTTP metadata server
+    512 * 1024 * 1024,  # 512MB segment size
+    128 * 1024 * 1024,  # 128MB local buffer
+    "tcp",  # Use TCP (RDMA for high performance)
+    "",  # Leave empty; Mooncake auto-picks RDMA devices when needed
+    "localhost:50051",  # Master service
+)
+
+# 3. Store data
+store.put("hello_key", b"Hello, Mooncake Store!")
+
+# 4. Retrieve data
+data = store.get("hello_key")
+print(data.decode())  # Output: Hello, Mooncake Store!
+
+# 5. Clean up
+store.close()

--- a/scripts/mooncake/legacy/network_utils.sh
+++ b/scripts/mooncake/legacy/network_utils.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+first_global_ipv4() {
+    local host_ip=""
+
+    if command -v ip >/dev/null 2>&1; then
+        host_ip="$(ip -o -4 addr show up scope global 2>/dev/null | awk 'NR == 1 {split($4, a, "/"); print a[1]}')"
+        if [[ -n "${host_ip//[[:space:]]/}" ]]; then
+            printf '%s\n' "$host_ip"
+            return 0
+        fi
+    fi
+
+    host_ip="$(hostname -I 2>/dev/null | awk '{for (i = 1; i <= NF; ++i) if ($i !~ /^127\\./) { print $i; exit }}')"
+    if [[ -n "${host_ip//[[:space:]]/}" ]]; then
+        printf '%s\n' "$host_ip"
+        return 0
+    fi
+
+    return 1
+}
+
+detect_local_advertise_host() {
+    local preferred="${1:-}"
+    local host_name=""
+
+    if [[ -n "${preferred//[[:space:]]/}" ]]; then
+        printf '%s\n' "$preferred"
+        return 0
+    fi
+
+    if first_global_ipv4; then
+        return 0
+    fi
+
+    host_name="$(hostname -f 2>/dev/null || hostname 2>/dev/null || true)"
+    if [[ -n "${host_name//[[:space:]]/}" ]]; then
+        printf '%s\n' "$host_name"
+        return 0
+    fi
+
+    return 1
+}
+
+tcp_port_is_listening() {
+    local port=$1
+    ss -ltnH 2>/dev/null | awk '{print $4}' | grep -Eq "(^|[:.])${port}$"
+}
+
+all_tcp_ports_listening() {
+    local port=""
+    for port in "$@"; do
+        if ! tcp_port_is_listening "$port"; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+any_tcp_ports_in_use() {
+    local port=""
+    for port in "$@"; do
+        if tcp_port_is_listening "$port"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+wait_for_tcp_port() {
+    local port=$1
+    local timeout_s=${2:-30}
+    local pid=${3:-}
+
+    for _ in $(seq "$timeout_s"); do
+        if [[ -n "${pid:-}" ]] && ! kill -0 "$pid" 2>/dev/null; then
+            return 1
+        fi
+        if tcp_port_is_listening "$port"; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}

--- a/scripts/mooncake/legacy/rdma_config_utils.sh
+++ b/scripts/mooncake/legacy/rdma_config_utils.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+
+normalize_pci_bus_id() {
+    local raw="${1,,}"
+    local domain=""
+    local bus=""
+    local device=""
+    local function=""
+
+    if [[ "$raw" =~ ^(([0-9a-f]{4,8}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-7])$ ]]; then
+        domain="${BASH_REMATCH[2]:-0}"
+        bus="${BASH_REMATCH[3]}"
+        device="${BASH_REMATCH[4]}"
+        function="${BASH_REMATCH[5]}"
+        printf '%08x:%02x:%02x.%x\n' \
+            "$((16#$domain))" \
+            "$((16#$bus))" \
+            "$((16#$device))" \
+            "$((16#$function))"
+        return 0
+    fi
+    return 1
+}
+
+port_is_active() {
+    local device_name=$1
+    local port=$2
+    local state_file="/sys/class/infiniband/${device_name}/ports/${port}/state"
+    [[ -r "$state_file" ]] || return 1
+    grep -q "ACTIVE" "$state_file"
+}
+
+device_matches_gid_index() {
+    local device_name=$1
+    local port=$2
+    local gid_index=$3
+    local ndev_file="/sys/class/infiniband/${device_name}/ports/${port}/gid_attrs/ndevs/${gid_index}"
+    local gid_file="/sys/class/infiniband/${device_name}/ports/${port}/gids/${gid_index}"
+    local ndev=""
+    local gid=""
+    local compact_gid=""
+
+    [[ -r "$ndev_file" && -r "$gid_file" ]] || return 1
+    ndev="$(cat "$ndev_file" 2>/dev/null)" || return 1
+    [[ -n "${ndev//[[:space:]]/}" ]] || return 1
+
+    gid="$(cat "$gid_file" 2>/dev/null)" || return 1
+    compact_gid="${gid//[:[:space:]]/}"
+    [[ -n "$compact_gid" ]] || return 1
+    [[ "$compact_gid" != "00000000000000000000000000000000" ]]
+}
+
+gid_entry_is_non_link_local() {
+    local device_name=$1
+    local port=$2
+    local gid_index=$3
+    local gid_file="/sys/class/infiniband/${device_name}/ports/${port}/gids/${gid_index}"
+    local gid=""
+    local compact_gid=""
+
+    [[ -r "$gid_file" ]] || return 1
+    gid="$(cat "$gid_file" 2>/dev/null)" || return 1
+    compact_gid="${gid//[:[:space:]]/}"
+    [[ -n "$compact_gid" ]] || return 1
+    [[ "$compact_gid" != "00000000000000000000000000000000" ]] || return 1
+    [[ "$compact_gid" != fe80* ]]
+}
+
+get_gid_entry_type() {
+    local device_name=$1
+    local port=$2
+    local gid_index=$3
+    local type_file="/sys/class/infiniband/${device_name}/ports/${port}/gid_attrs/types/${gid_index}"
+
+    [[ -r "$type_file" ]] || return 1
+    cat "$type_file" 2>/dev/null
+}
+
+gid_entry_is_roce_v2() {
+    local gid_type=""
+    gid_type="$(get_gid_entry_type "$1" "$2" "$3" 2>/dev/null || true)"
+    [[ "$gid_type" == "RoCE v2" ]]
+}
+
+device_is_active_for_gid_index() {
+    local device_name=$1
+    local gid_index=${2:-}
+    local port_path=""
+    local port=""
+
+    for port_path in "/sys/class/infiniband/${device_name}"/ports/*; do
+        [[ -d "$port_path" ]] || continue
+        port="$(basename "$port_path")"
+        if ! port_is_active "$device_name" "$port"; then
+            continue
+        fi
+        if [[ -z "$gid_index" ]]; then
+            return 0
+        fi
+        if device_matches_gid_index "$device_name" "$port" "$gid_index"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+get_rdma_device_bus_id() {
+    local device_name=$1
+    normalize_pci_bus_id "$(basename "$(readlink -f "/sys/class/infiniband/${device_name}/device")")"
+}
+
+get_pci_numa_node() {
+    local pci_bus_id=$1
+    local normalized=""
+    local numa_path=""
+
+    normalized="$(normalize_pci_bus_id "$pci_bus_id" 2>/dev/null || true)"
+    [[ -n "$normalized" ]] || {
+        printf '%s\n' "-1"
+        return 0
+    }
+
+    for numa_path in \
+        "/sys/bus/pci/devices/${normalized}/numa_node" \
+        "/sys/bus/pci/devices/0000:${normalized#*:}/numa_node"; do
+        if [[ -r "$numa_path" ]]; then
+            cat "$numa_path"
+            return 0
+        fi
+    done
+
+    printf '%s\n' "-1"
+}
+
+get_rdma_device_numa_node() {
+    local device_name=$1
+    get_pci_numa_node "$(get_rdma_device_bus_id "$device_name")"
+}
+
+get_rdma_device_netdevs_csv() {
+    local device_name=$1
+    local net_dir="/sys/class/infiniband/${device_name}/device/net"
+    local netdev_path=""
+    local netdevs=()
+
+    [[ -d "$net_dir" ]] || return 0
+    for netdev_path in "$net_dir"/*; do
+        [[ -e "$netdev_path" ]] || continue
+        netdevs+=("$(basename "$netdev_path")")
+    done
+    if [[ "${#netdevs[@]}" -gt 0 ]]; then
+        IFS=,
+        printf '%s\n' "${netdevs[*]}"
+        unset IFS
+    fi
+}
+
+list_active_rdma_devices() {
+    local gid_index=${1:-${MC_GID_INDEX:-}}
+    local device_path=""
+    local device_name=""
+    local bus_id=""
+    local numa_node=""
+    local netdevs=""
+
+    for device_path in /sys/class/infiniband/*; do
+        [[ -e "$device_path" ]] || continue
+        device_name="$(basename "$device_path")"
+        if ! device_is_active_for_gid_index "$device_name" "$gid_index"; then
+            continue
+        fi
+        bus_id="$(get_rdma_device_bus_id "$device_name" 2>/dev/null || true)"
+        [[ -n "$bus_id" ]] || continue
+        numa_node="$(get_rdma_device_numa_node "$device_name")"
+        netdevs="$(get_rdma_device_netdevs_csv "$device_name")"
+        printf '%s|%s|%s|%s\n' \
+            "$device_name" \
+            "$bus_id" \
+            "$numa_node" \
+            "$netdevs"
+    done | sort
+}
+
+detect_preferred_gid_index() {
+    local max_index=${1:-8}
+    local device_path=""
+    local device_name=""
+    local port_path=""
+    local port=""
+    local index=""
+    local best_index=""
+    local best_non_link_local_v2_count=-1
+    local best_non_link_local_count=-1
+    local best_total_v2_count=-1
+    local best_total_count=-1
+    local non_link_local_v2_count=0
+    local non_link_local_count=0
+    local total_v2_count=0
+    local total_count=0
+
+    for index in $(seq 0 "$max_index"); do
+        non_link_local_v2_count=0
+        non_link_local_count=0
+        total_v2_count=0
+        total_count=0
+        for device_path in /sys/class/infiniband/*; do
+            [[ -e "$device_path" ]] || continue
+            device_name="$(basename "$device_path")"
+            for port_path in "$device_path"/ports/*; do
+                [[ -d "$port_path" ]] || continue
+                port="$(basename "$port_path")"
+                if ! port_is_active "$device_name" "$port"; then
+                    continue
+                fi
+                if ! device_matches_gid_index "$device_name" "$port" "$index"; then
+                    continue
+                fi
+                total_count=$((total_count + 1))
+                if gid_entry_is_roce_v2 "$device_name" "$port" "$index"; then
+                    total_v2_count=$((total_v2_count + 1))
+                fi
+                if gid_entry_is_non_link_local "$device_name" "$port" "$index"; then
+                    non_link_local_count=$((non_link_local_count + 1))
+                    if gid_entry_is_roce_v2 "$device_name" "$port" "$index"; then
+                        non_link_local_v2_count=$((non_link_local_v2_count + 1))
+                    fi
+                fi
+            done
+        done
+
+        if (( non_link_local_v2_count > best_non_link_local_v2_count )); then
+            best_index="$index"
+            best_non_link_local_v2_count=$non_link_local_v2_count
+            best_non_link_local_count=$non_link_local_count
+            best_total_v2_count=$total_v2_count
+            best_total_count=$total_count
+        elif (( non_link_local_v2_count == best_non_link_local_v2_count )) && \
+             (( non_link_local_count > best_non_link_local_count )); then
+            best_index="$index"
+            best_non_link_local_count=$non_link_local_count
+            best_total_v2_count=$total_v2_count
+            best_total_count=$total_count
+        elif (( non_link_local_v2_count == best_non_link_local_v2_count )) && \
+             (( non_link_local_count == best_non_link_local_count )) && \
+             (( total_v2_count > best_total_v2_count )); then
+            best_index="$index"
+            best_total_v2_count=$total_v2_count
+            best_total_count=$total_count
+        elif (( non_link_local_v2_count == best_non_link_local_v2_count )) && \
+             (( non_link_local_count == best_non_link_local_count )) && \
+             (( total_v2_count == best_total_v2_count )) && \
+             (( total_count > best_total_count )); then
+            best_index="$index"
+            best_total_count=$total_count
+        fi
+    done
+
+    if [[ -n "$best_index" ]] && (( best_total_count > 0 )); then
+        printf '%s\n' "$best_index"
+        return 0
+    fi
+    return 1
+}
+
+validate_rdma_device_list() {
+    local device_csv=$1
+    local gid_index=${2:-${MC_GID_INDEX:-}}
+    local entry=""
+    local device_name=""
+
+    [[ -n "${device_csv//[[:space:]]/}" ]] || {
+        echo "RDMA device list is empty." >&2
+        return 1
+    }
+
+    IFS=',' read -r -a _rdma_device_entries <<< "$device_csv"
+    unset IFS
+    for entry in "${_rdma_device_entries[@]}"; do
+        device_name="${entry//[[:space:]]/}"
+        [[ -n "$device_name" ]] || {
+            echo "RDMA device list contains an empty entry." >&2
+            return 1
+        }
+        [[ -d "/sys/class/infiniband/${device_name}" ]] || {
+            echo "RDMA device ${device_name} does not exist under /sys/class/infiniband." >&2
+            return 1
+        }
+        if ! device_is_active_for_gid_index "$device_name" "$gid_index"; then
+            if [[ -n "$gid_index" ]]; then
+                echo "RDMA device ${device_name} is not active for MC_GID_INDEX=${gid_index}." >&2
+            else
+                echo "RDMA device ${device_name} is not active." >&2
+            fi
+            return 1
+        fi
+    done
+}
+
+get_local_gpu_entries() {
+    local query_output=""
+    local line=""
+    local gpu_index=""
+    local bus_id=""
+    local normalized_bus=""
+    local numa_node=""
+
+    command -v nvidia-smi >/dev/null 2>&1 || return 1
+    query_output="$(nvidia-smi --query-gpu=index,pci.bus_id --format=csv,noheader 2>/dev/null)" \
+        || return 1
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        gpu_index="${line%%,*}"
+        bus_id="${line#*,}"
+        gpu_index="${gpu_index//[[:space:]]/}"
+        bus_id="${bus_id//[[:space:]]/}"
+        normalized_bus="$(normalize_pci_bus_id "$bus_id" 2>/dev/null || true)"
+        [[ -n "$normalized_bus" ]] || continue
+        numa_node="$(get_pci_numa_node "$normalized_bus")"
+        printf '%s|%s|%s\n' "$gpu_index" "$normalized_bus" "$numa_node"
+    done <<< "$query_output"
+}
+
+gpu_matches_rnic_netdev() {
+    local gpu_index=$1
+    local netdev_csv=$2
+    local netdev=""
+
+    IFS=',' read -r -a _rdma_netdev_entries <<< "$netdev_csv"
+    unset IFS
+    for netdev in "${_rdma_netdev_entries[@]}"; do
+        if [[ "$netdev" =~ ^gpu${gpu_index}rdma[0-9]+$ ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+pci_bus_distance() {
+    local lhs
+    local rhs
+    local lhs_domain=""
+    local lhs_bus=""
+    local lhs_device=""
+    local lhs_function=""
+    local rhs_domain=""
+    local rhs_bus=""
+    local rhs_device=""
+    local rhs_function=""
+    local lhs_domain_dec=0
+    local lhs_bus_dec=0
+    local lhs_device_dec=0
+    local lhs_function_dec=0
+    local rhs_domain_dec=0
+    local rhs_bus_dec=0
+    local rhs_device_dec=0
+    local rhs_function_dec=0
+    local distance=0
+
+    lhs="$(normalize_pci_bus_id "$1" 2>/dev/null || true)"
+    rhs="$(normalize_pci_bus_id "$2" 2>/dev/null || true)"
+    [[ -n "$lhs" && -n "$rhs" ]] || {
+        printf '%s\n' "1073741824"
+        return 0
+    }
+
+    lhs_domain="${lhs%%:*}"
+    lhs_bus="${lhs#*:}"
+    lhs_bus="${lhs_bus%%:*}"
+    lhs_device="${lhs##*:}"
+    lhs_function="${lhs_device#*.}"
+    lhs_device="${lhs_device%%.*}"
+
+    rhs_domain="${rhs%%:*}"
+    rhs_bus="${rhs#*:}"
+    rhs_bus="${rhs_bus%%:*}"
+    rhs_device="${rhs##*:}"
+    rhs_function="${rhs_device#*.}"
+    rhs_device="${rhs_device%%.*}"
+
+    lhs_domain_dec=$((16#$lhs_domain))
+    lhs_bus_dec=$((16#$lhs_bus))
+    lhs_device_dec=$((16#$lhs_device))
+    lhs_function_dec=$((16#$lhs_function))
+    rhs_domain_dec=$((16#$rhs_domain))
+    rhs_bus_dec=$((16#$rhs_bus))
+    rhs_device_dec=$((16#$rhs_device))
+    rhs_function_dec=$((16#$rhs_function))
+
+    distance=$(( \
+        (lhs_domain_dec > rhs_domain_dec ? lhs_domain_dec - rhs_domain_dec : rhs_domain_dec - lhs_domain_dec) * 1000000 \
+        + (lhs_bus_dec > rhs_bus_dec ? lhs_bus_dec - rhs_bus_dec : rhs_bus_dec - lhs_bus_dec) * 1000 \
+        + (lhs_device_dec > rhs_device_dec ? lhs_device_dec - rhs_device_dec : rhs_device_dec - lhs_device_dec) * 10 \
+        + (lhs_function_dec > rhs_function_dec ? lhs_function_dec - rhs_function_dec : rhs_function_dec - lhs_function_dec) \
+    ))
+    printf '%s\n' "$distance"
+}
+
+get_active_rdma_device_names_csv() {
+    local gid_index=${1:-${MC_GID_INDEX:-}}
+    local rdma_output=""
+    local device_name=""
+    local -a devices=()
+
+    rdma_output="$(list_active_rdma_devices "$gid_index")" || return 1
+    [[ -n "${rdma_output//[[:space:]]/}" ]] || return 1
+
+    while IFS='|' read -r device_name _rest; do
+        [[ -n "$device_name" ]] || continue
+        devices+=("$device_name")
+    done <<< "$rdma_output"
+
+    IFS=,
+    printf '%s\n' "${devices[*]}"
+    unset IFS
+}
+
+plan_worker_rdma_assignments() {
+    local gid_index=${1:-${MC_GID_INDEX:-}}
+    local gpu_output=""
+    local rdma_output=""
+    local gpu_entry=""
+    local rdma_entry=""
+    local gpu_index=""
+    local gpu_bus=""
+    local gpu_numa=""
+    local rdma_name=""
+    local rdma_bus=""
+    local rdma_numa=""
+    local rdma_netdevs=""
+    local chosen_device=""
+    local chosen_reason=""
+    local best_distance=1073741824
+    local distance=0
+    local status=0
+    local -a gpu_entries=()
+    local -a rdma_entries=()
+    local -a exact_matches=()
+    local -A rdma_bus_by_name=()
+    local -A rdma_numa_by_name=()
+    local -A rdma_netdevs_by_name=()
+    local -A map_by_gpu_bdf=()
+    local -A gpu_reason_by_bdf=()
+    local -A used_device=()
+
+    gpu_output="$(get_local_gpu_entries)" || gpu_output=""
+    rdma_output="$(list_active_rdma_devices "$gid_index")" || rdma_output=""
+
+    if [[ -n "${gpu_output//[[:space:]]/}" ]]; then
+        mapfile -t gpu_entries <<< "$gpu_output"
+    fi
+    if [[ -n "${rdma_output//[[:space:]]/}" ]]; then
+        mapfile -t rdma_entries <<< "$rdma_output"
+    fi
+
+    if [[ "${#gpu_entries[@]}" -eq 0 ]]; then
+        echo "Error: no local GPUs were discovered with nvidia-smi." >&2
+        return 1
+    fi
+    if [[ "${#rdma_entries[@]}" -eq 0 ]]; then
+        echo "Error: no active RDMA devices matched MC_GID_INDEX=${gid_index}." >&2
+        return 1
+    fi
+
+    for rdma_entry in "${rdma_entries[@]}"; do
+        IFS='|' read -r rdma_name rdma_bus rdma_numa rdma_netdevs <<< "$rdma_entry"
+        unset IFS
+        rdma_bus_by_name["$rdma_name"]="$rdma_bus"
+        rdma_numa_by_name["$rdma_name"]="$rdma_numa"
+        rdma_netdevs_by_name["$rdma_name"]="$rdma_netdevs"
+    done
+
+    for gpu_entry in "${gpu_entries[@]}"; do
+        IFS='|' read -r gpu_index gpu_bus _gpu_numa <<< "$gpu_entry"
+        unset IFS
+
+        exact_matches=()
+        for rdma_name in "${!rdma_bus_by_name[@]}"; do
+            if gpu_matches_rnic_netdev "$gpu_index" \
+                "${rdma_netdevs_by_name[$rdma_name]}"; then
+                exact_matches+=("$rdma_name")
+            fi
+        done
+
+        if [[ "${#exact_matches[@]}" -gt 1 ]]; then
+            IFS=$'\n' exact_matches=($(printf '%s\n' "${exact_matches[@]}" | sort))
+            unset IFS
+            status=1
+        fi
+        if [[ "${#exact_matches[@]}" -eq 0 ]]; then
+            continue
+        fi
+
+        map_by_gpu_bdf["$gpu_bus"]="${exact_matches[0]}"
+        if [[ "${#exact_matches[@]}" -eq 1 ]]; then
+            gpu_reason_by_bdf["$gpu_bus"]="exact-netdev"
+        else
+            gpu_reason_by_bdf["$gpu_bus"]="ambiguous-exact-netdev"
+        fi
+        used_device["${exact_matches[0]}"]=1
+    done
+
+    for gpu_entry in "${gpu_entries[@]}"; do
+        IFS='|' read -r _gpu_index gpu_bus gpu_numa <<< "$gpu_entry"
+        unset IFS
+
+        if [[ -n "${map_by_gpu_bdf[$gpu_bus]+x}" ]]; then
+            continue
+        fi
+
+        chosen_device=""
+        chosen_reason=""
+        best_distance=1073741824
+
+        for rdma_name in "${!rdma_bus_by_name[@]}"; do
+            if [[ -n "${used_device[$rdma_name]+x}" ]]; then
+                continue
+            fi
+            if [[ "$gpu_numa" == "-1" || \
+                  "$gpu_numa" != "${rdma_numa_by_name[$rdma_name]}" ]]; then
+                continue
+            fi
+            distance="$(pci_bus_distance "$gpu_bus" "${rdma_bus_by_name[$rdma_name]}")"
+            if [[ -z "$chosen_device" || "$distance" -lt "$best_distance" || \
+                  ( "$distance" -eq "$best_distance" && \
+                    "$rdma_name" < "$chosen_device" ) ]]; then
+                chosen_device="$rdma_name"
+                chosen_reason="same-numa-pci-distance"
+                best_distance="$distance"
+            fi
+        done
+
+        if [[ -z "$chosen_device" ]]; then
+            for rdma_name in "${!rdma_bus_by_name[@]}"; do
+                if [[ -n "${used_device[$rdma_name]+x}" ]]; then
+                    continue
+                fi
+                distance="$(pci_bus_distance "$gpu_bus" \
+                    "${rdma_bus_by_name[$rdma_name]}")"
+                if [[ -z "$chosen_device" || "$distance" -lt "$best_distance" || \
+                      ( "$distance" -eq "$best_distance" && \
+                        "$rdma_name" < "$chosen_device" ) ]]; then
+                    chosen_device="$rdma_name"
+                    chosen_reason="global-pci-distance"
+                    best_distance="$distance"
+                fi
+            done
+        fi
+
+        if [[ -z "$chosen_device" ]]; then
+            status=1
+            gpu_reason_by_bdf["$gpu_bus"]="no-unused-rnic-match"
+            continue
+        fi
+
+        map_by_gpu_bdf["$gpu_bus"]="$chosen_device"
+        gpu_reason_by_bdf["$gpu_bus"]="$chosen_reason"
+        used_device["$chosen_device"]=1
+    done
+
+    if [[ "${#map_by_gpu_bdf[@]}" -ne "${#gpu_entries[@]}" ]]; then
+        status=1
+    fi
+
+    for gpu_entry in "${gpu_entries[@]}"; do
+        IFS='|' read -r gpu_index gpu_bus gpu_numa <<< "$gpu_entry"
+        unset IFS
+        printf '%s|%s|%s|%s|%s\n' \
+            "$gpu_index" \
+            "$gpu_bus" \
+            "$gpu_numa" \
+            "${map_by_gpu_bdf[$gpu_bus]:-}" \
+            "${gpu_reason_by_bdf[$gpu_bus]:-missing}"
+    done
+
+    return "$status"
+}
+
+get_worker_rdma_devices_csv() {
+    local gid_index=${1:-${MC_GID_INDEX:-}}
+    local plan_output=""
+    local status=0
+    local device_name=""
+    local -a devices=()
+
+    if plan_output="$(plan_worker_rdma_assignments "$gid_index")"; then
+        status=0
+    else
+        status=$?
+    fi
+    [[ -n "${plan_output//[[:space:]]/}" ]] || return "$status"
+
+    while IFS='|' read -r _gpu_index _gpu_bus _gpu_numa device_name _reason; do
+        [[ -n "$device_name" ]] || continue
+        devices+=("$device_name")
+    done <<< "$plan_output"
+
+    if [[ "${#devices[@]}" -gt 0 ]]; then
+        IFS=,
+        printf '%s\n' "${devices[*]}"
+        unset IFS
+    fi
+    return "$status"
+}

--- a/scripts/mooncake/legacy/recommend_mooncake_rnic_config.sh
+++ b/scripts/mooncake/legacy/recommend_mooncake_rnic_config.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Print the local Mooncake RDMA defaults used by the managed launcher and
+# worker auto-detection.
+#
+# The script does not modify any config. It exits non-zero if the topology is
+# ambiguous or incomplete, but still prints the best-effort recommendation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/rdma_config_utils.sh"
+
+OUTPUT_MODE="human"
+SELECTED_GID_INDEX="${MC_GID_INDEX:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --machine-readable)
+            OUTPUT_MODE="machine"
+            shift
+            ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: recommend_mooncake_rnic_config.sh [--machine-readable]
+
+Default output:
+  Prints the per-GPU worker RNIC recommendation, MOONCAKE_DEVICE, and
+  MC_OWNER_DEVICE.
+
+--machine-readable:
+  Prints exactly:
+    MC_GID_INDEX=<index>
+    MOONCAKE_DEVICE=<csv>
+    MC_OWNER_DEVICE=<csv>
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${SELECTED_GID_INDEX//[[:space:]]/}" ]]; then
+    SELECTED_GID_INDEX="$(detect_preferred_gid_index)" || {
+        echo "Error: failed to auto-detect a usable RDMA GID index." >&2
+        exit 1
+    }
+fi
+
+if PLAN_OUTPUT="$(plan_worker_rdma_assignments "$SELECTED_GID_INDEX")"; then
+    STATUS=0
+else
+    STATUS=$?
+fi
+WORKER_DEVICE_CSV="$(get_worker_rdma_devices_csv "$SELECTED_GID_INDEX" 2>/dev/null || true)"
+OWNER_DEVICE_CSV="$(get_active_rdma_device_names_csv "$SELECTED_GID_INDEX" 2>/dev/null || true)"
+
+if [[ -z "${OWNER_DEVICE_CSV//[[:space:]]/}" ]]; then
+    echo "Error: no active RDMA devices matched MC_GID_INDEX=${SELECTED_GID_INDEX}." >&2
+    exit 1
+fi
+
+WORKER_PLAN=()
+if [[ -n "${PLAN_OUTPUT//[[:space:]]/}" ]]; then
+    mapfile -t WORKER_PLAN <<< "$PLAN_OUTPUT"
+fi
+
+if [[ "$OUTPUT_MODE" == "machine" ]]; then
+    printf 'MC_GID_INDEX=%s\n' "$SELECTED_GID_INDEX"
+    printf 'MOONCAKE_DEVICE=%s\n' "$WORKER_DEVICE_CSV"
+    printf 'MC_OWNER_DEVICE=%s\n' "$OWNER_DEVICE_CSV"
+    if [[ "$STATUS" -ne 0 ]]; then
+        echo "Unsafe best-effort recommendation: at least one GPU->RNIC choice was ambiguous or missing." >&2
+        echo "Review the human-readable diagnostics from recommend_mooncake_rnic_config.sh." >&2
+    fi
+    exit "$STATUS"
+fi
+
+if [[ "$STATUS" -ne 0 ]]; then
+    echo "Unsafe best-effort recommendation: at least one GPU->RNIC choice was ambiguous or missing." >&2
+    echo "Review the diagnostics below and set MOONCAKE_DEVICE explicitly if needed." >&2
+fi
+
+echo "# Recommendations filtered by MC_GID_INDEX=${SELECTED_GID_INDEX}"
+echo "# Local GPU to RNIC diagnostics"
+for plan_entry in "${WORKER_PLAN[@]}"; do
+    IFS='|' read -r gpu_index gpu_bus gpu_numa device_name reason <<< "$plan_entry"
+    unset IFS
+    printf '# GPU %s (%s, NUMA %s) -> %s [%s]\n' \
+        "$gpu_index" \
+        "$gpu_bus" \
+        "$gpu_numa" \
+        "${device_name:-<missing>}" \
+        "${reason:-missing}"
+done
+echo
+
+echo "# worker env"
+printf 'MOONCAKE_DEVICE=%s\n' "$WORKER_DEVICE_CSV"
+echo
+
+echo "# owner env"
+printf 'MC_OWNER_DEVICE=%s\n' "$OWNER_DEVICE_CSV"
+echo
+echo "# note"
+echo "# MOONCAKE_DEVICE is a comma-separated per-GPU worker list. If unset, requesters fall back to Mooncake auto-selection."
+
+exit "$STATUS"

--- a/scripts/mooncake/legacy/run_vllm_with_mooncake_owner.sh
+++ b/scripts/mooncake/legacy/run_vllm_with_mooncake_owner.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# Launch a node-local Mooncake owner and a vLLM server in one managed process
+# tree so the owner is cleaned up automatically when serving exits.
+#
+# Required env:
+#   MC_OWNER_CPU_MEM_GIB   Owner CPU memory size in GiB
+#
+# Optional env:
+#   MC_GID_INDEX                    RDMA GID index filter for RNIC detection
+#   MC_MASTER_ENV_FILE              Shared env file written by start_mooncake_master.sh
+#   MOONCAKE_DEVICE                 Optional explicit worker RDMA device or
+#                                   comma-separated per-GPU device list
+#   MC_OWNER_DEVICE                 Optional explicit owner RDMA device CSV
+#   MC_OWNER_DISK_GIB               Owner disk offload quota in GiB
+#   MC_OWNER_DISK_PATH              Base directory for managed owner disk offload data
+#   MC_OWNER_HOST                   Advertised owner host/IP
+#   MC_OWNER_RPC_PORT               Owner RPC port (default: 50052)
+#   MC_OWNER_SEGMENT_PORT           Owner segment port (default: 50053)
+#   MC_OWNER_READY_TIMEOUT_S        Readiness timeout in seconds (default: 120)
+#
+# The wrapper owns Mooncake-specific config:
+#   - reads MOONCAKE_MASTER / metadata server from the master env file
+#   - auto-detects a default GID index and owner RNIC union
+#   - injects --kv-transfer-config for MooncakeStoreConnector
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/network_utils.sh"
+source "${SCRIPT_DIR}/rdma_config_utils.sh"
+
+HOST_TAG="$(hostname -s 2>/dev/null || echo local)"
+
+OWNER_CPU_MEM_GIB="${MC_OWNER_CPU_MEM_GIB:-}"
+OWNER_DISK_GIB="${MC_OWNER_DISK_GIB:-}"
+OWNER_DISK_PATH="${MC_OWNER_DISK_PATH:-}"
+WORKER_DEVICE="${MOONCAKE_DEVICE:-}"
+OWNER_DEVICE="${MC_OWNER_DEVICE:-}"
+OWNER_HOST="${MC_OWNER_HOST:-}"
+OWNER_RPC_PORT="${MC_OWNER_RPC_PORT:-50052}"
+OWNER_SEGMENT_PORT="${MC_OWNER_SEGMENT_PORT:-50053}"
+OWNER_READY_TIMEOUT_S="${MC_OWNER_READY_TIMEOUT_S:-120}"
+OWNER_LOG_FILE=""
+MASTER_ENV_FILE="${MC_MASTER_ENV_FILE:-}"
+MOONCAKE_PROTOCOL="${MOONCAKE_PROTOCOL:-rdma}"
+
+OWNER_PID=""
+SERVER_PID=""
+OWNER_DISK_RUN_PATH=""
+
+stop_pid() {
+    local pid="$1"
+    [[ -n "$pid" ]] || return 0
+    if ! kill -0 "$pid" 2>/dev/null; then
+        return 0
+    fi
+
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 10); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            wait "$pid" 2>/dev/null || true
+            return 0
+        fi
+        sleep 1
+    done
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+local_owner_segment_process_exists() {
+    ps -eo user=,args= 2>/dev/null | awk \
+        -v user_name="$(id -un)" \
+        -v owner_host="$OWNER_HOST" \
+        -v segment_port="$OWNER_SEGMENT_PORT" '
+            $1 == user_name && $0 ~ /mooncake_client/ &&
+            $0 ~ ("--host=" owner_host ":" segment_port) {
+                found = 1
+            }
+            END { exit(found ? 0 : 1) }
+        '
+}
+
+metadata_key_http_code() {
+    local key="$1"
+    curl -sS -o /dev/null -w '%{http_code}' \
+        --get \
+        --data-urlencode "key=${key}" \
+        "$MOONCAKE_TE_META_DATA_SERVER" \
+        || true
+}
+
+delete_metadata_key() {
+    local key="$1"
+    local http_code=""
+    http_code="$(
+        curl -sS -o /dev/null -w '%{http_code}' \
+            -X DELETE \
+            --get \
+            --data-urlencode "key=${key}" \
+            "$MOONCAKE_TE_META_DATA_SERVER" \
+            || true
+    )"
+
+    case "$http_code" in
+        200|404)
+            return 0
+            ;;
+        *)
+            echo "Failed to delete Mooncake metadata key ${key} via ${MOONCAKE_TE_META_DATA_SERVER} (http ${http_code})." >&2
+            return 1
+            ;;
+    esac
+}
+
+wait_for_metadata_absent() {
+    local key="$1"
+    local timeout_s="${2:-5}"
+    local http_code=""
+
+    for _ in $(seq "$timeout_s"); do
+        http_code="$(metadata_key_http_code "$key")"
+        case "$http_code" in
+            404)
+                return 0
+                ;;
+            200)
+                sleep 1
+                ;;
+            *)
+                echo "Unexpected response while checking Mooncake metadata key ${key}: http ${http_code}." >&2
+                return 1
+                ;;
+        esac
+    done
+
+    echo "Timed out waiting for Mooncake metadata key ${key} to disappear." >&2
+    return 1
+}
+
+owner_failed_with_duplicate_rpc_meta() {
+    [[ -f "$OWNER_LOG_FILE" ]] && \
+        grep -q "Duplicate rpc_meta key not allowed" "$OWNER_LOG_FILE"
+}
+
+reclaim_stale_owner_metadata() {
+    local segment_name="${OWNER_HOST}:${OWNER_SEGMENT_PORT}"
+    local rpc_meta_key="mooncake/rpc_meta/${segment_name}"
+    local ram_key="mooncake/ram/${segment_name}"
+
+    if local_owner_segment_process_exists; then
+        echo "Refusing to reclaim Mooncake metadata for ${segment_name}: a local mooncake_client is still advertising that segment." >&2
+        return 1
+    fi
+
+    echo "Reclaiming stale Mooncake metadata for ${segment_name}" >&2
+    delete_metadata_key "$rpc_meta_key"
+    delete_metadata_key "$ram_key"
+    wait_for_metadata_absent "$rpc_meta_key"
+    wait_for_metadata_absent "$ram_key"
+}
+
+cleanup() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    stop_pid "${SERVER_PID:-}"
+    stop_pid "${OWNER_PID:-}"
+    if [[ -n "${OWNER_DISK_RUN_PATH:-}" ]]; then
+        rm -rf -- "${OWNER_DISK_RUN_PATH}"
+    fi
+    exit "$exit_code"
+}
+
+prepare_owner_disk_path() {
+    [[ -n "$OWNER_DISK_GIB" ]] || return 0
+    [[ -n "$OWNER_DISK_PATH" ]] || return 0
+
+    local base_path="${OWNER_DISK_PATH%/}"
+    [[ -n "$base_path" ]] || base_path="$OWNER_DISK_PATH"
+    [[ -n "$base_path" ]] || return 0
+
+    mkdir -p "$base_path"
+    OWNER_DISK_RUN_PATH="${base_path}/${HOST_TAG}.rpc${OWNER_RPC_PORT}.$$"
+    rm -rf -- "$OWNER_DISK_RUN_PATH"
+    mkdir -p "$OWNER_DISK_RUN_PATH"
+}
+
+print_owner_failure_hint() {
+    [[ -f "$OWNER_LOG_FILE" ]] || return 0
+    if grep -q "Duplicate rpc_meta key not allowed" "$OWNER_LOG_FILE"; then
+        echo "Hint: stale Mooncake owner metadata is still registered. Stop the old owner or clean the stale metadata before retrying." >&2
+    fi
+}
+
+wait_for_owner_ready() {
+    # The mooncake_client owner exposes its RPC endpoint as an abstract Unix
+    # socket (@mooncake_client_<rpc_port>.sock), not a TCP port. The segment
+    # port is the real TCP listener that signals the owner is serving.
+    if wait_for_tcp_port "$OWNER_SEGMENT_PORT" "$OWNER_READY_TIMEOUT_S" "${OWNER_PID:-}"; then
+        return 0
+    fi
+    if [[ -n "${OWNER_PID:-}" ]] && ! kill -0 "$OWNER_PID" 2>/dev/null; then
+        echo "Mooncake owner exited before becoming ready." >&2
+    else
+        echo "Timed out waiting for Mooncake owner segment port ${OWNER_SEGMENT_PORT}." >&2
+    fi
+    tail -n 50 "$OWNER_LOG_FILE" >&2 || true
+    print_owner_failure_hint
+    return 1
+}
+
+start_owner_once() {
+    "${OWNER_CMD[@]}" >>"$OWNER_LOG_FILE" 2>&1 &
+    OWNER_PID=$!
+    if wait_for_owner_ready; then
+        return 0
+    fi
+    wait "$OWNER_PID" 2>/dev/null || true
+    OWNER_PID=""
+    return 1
+}
+
+start_owner() {
+    echo "Starting managed Mooncake owner; log: $OWNER_LOG_FILE"
+    : > "$OWNER_LOG_FILE"
+    if start_owner_once; then
+        return 0
+    fi
+
+    if owner_failed_with_duplicate_rpc_meta; then
+        if reclaim_stale_owner_metadata; then
+            printf '\nRetrying managed Mooncake owner after stale-metadata cleanup.\n' >>"$OWNER_LOG_FILE"
+            start_owner_once
+            return $?
+        fi
+    fi
+
+    return 1
+}
+
+load_master_connection_env() {
+    local candidate=""
+    if [[ -n "${MOONCAKE_MASTER:-}" && -n "${MOONCAKE_TE_META_DATA_SERVER:-}" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${MASTER_ENV_FILE//[[:space:]]/}" && ! -r "$MASTER_ENV_FILE" ]]; then
+        candidate="$(dirname "$(dirname "$MASTER_ENV_FILE")")/$(basename "$MASTER_ENV_FILE")"
+        if [[ -r "$candidate" ]]; then
+            MASTER_ENV_FILE="$candidate"
+        fi
+    fi
+
+    if [[ -z "${MASTER_ENV_FILE//[[:space:]]/}" && -r "${SCRIPT_DIR}/mooncake_master.env" ]]; then
+        MASTER_ENV_FILE="${SCRIPT_DIR}/mooncake_master.env"
+    fi
+
+    if [[ -z "${MASTER_ENV_FILE//[[:space:]]/}" || ! -r "$MASTER_ENV_FILE" ]]; then
+        echo "Error: Mooncake master env file not found: $MASTER_ENV_FILE" >&2
+        echo "Hint: start the master via pre_serve with:" >&2
+        echo "  bash scripts/mooncake/start_mooncake_master.sh --bg --env-file {log_dir}/mooncake_master.env" >&2
+        return 1
+    fi
+
+    set -a
+    # shellcheck disable=SC1090
+    source "$MASTER_ENV_FILE"
+    set +a
+
+    if [[ -z "${MOONCAKE_MASTER:-}" || -z "${MOONCAKE_TE_META_DATA_SERVER:-}" ]]; then
+        echo "Error: master env file is missing MOONCAKE_MASTER or MOONCAKE_TE_META_DATA_SERVER: $MASTER_ENV_FILE" >&2
+        return 1
+    fi
+}
+
+detect_default_gid_index() {
+    if [[ -n "${MC_GID_INDEX:-}" ]]; then
+        return 0
+    fi
+
+    local detected_gid_index=""
+    detected_gid_index="$(detect_preferred_gid_index)" || {
+        echo "Error: failed to auto-detect a usable RDMA GID index." >&2
+        return 1
+    }
+    export MC_GID_INDEX="$detected_gid_index"
+}
+
+command_has_kv_transfer_config() {
+    local arg=""
+    for arg in "$@"; do
+        if [[ "$arg" == "--kv-transfer-config" || "$arg" == --kv-transfer-config=* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+build_kv_transfer_config_json() {
+    printf '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true,"enable_cross_layers_blocks":true}}\n'
+}
+
+if [[ -z "$OWNER_CPU_MEM_GIB" ]]; then
+    echo "Error: MC_OWNER_CPU_MEM_GIB must be set." >&2
+    exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <command> [args...]" >&2
+    exit 1
+fi
+
+export MOONCAKE_CONFIG_PATH="${MOONCAKE_CONFIG_PATH:-${SCRIPT_DIR}/mooncake_config.json}"
+if [[ ! -r "$MOONCAKE_CONFIG_PATH" ]]; then
+    echo "Error: MOONCAKE_CONFIG_PATH does not exist: $MOONCAKE_CONFIG_PATH" >&2
+    exit 1
+fi
+
+load_master_connection_env
+
+if [[ -n "${MASTER_ENV_FILE//[[:space:]]/}" ]]; then
+    OWNER_LOG_DIR="$(dirname "$MASTER_ENV_FILE")"
+else
+    OWNER_LOG_DIR="$SCRIPT_DIR"
+fi
+mkdir -p "$OWNER_LOG_DIR"
+OWNER_LOG_FILE="${OWNER_LOG_DIR}/mooncake_owner.${HOST_TAG}.managed.log"
+
+if [[ "$MOONCAKE_PROTOCOL" == "rdma" || "$MOONCAKE_PROTOCOL" == "efa" ]]; then
+    export MC_ENABLE_DEST_DEVICE_AFFINITY="${MC_ENABLE_DEST_DEVICE_AFFINITY:-1}"
+    detect_default_gid_index
+    if [[ -n "${WORKER_DEVICE//[[:space:]]/}" ]]; then
+        if ! validate_rdma_device_list "$WORKER_DEVICE"; then
+            exit 1
+        fi
+    elif ! WORKER_DEVICE="$(get_worker_rdma_devices_csv "$MC_GID_INDEX")"; then
+        echo "Error: failed to determine per-GPU Mooncake worker RNICs." >&2
+        echo "Hint: run scripts/mooncake/recommend_mooncake_rnic_config.sh or set MOONCAKE_DEVICE explicitly." >&2
+        exit 1
+    fi
+    export MOONCAKE_DEVICE="$WORKER_DEVICE"
+    if [[ -n "${OWNER_DEVICE//[[:space:]]/}" ]] && \
+       ! validate_rdma_device_list "$OWNER_DEVICE"; then
+        exit 1
+    fi
+fi
+
+prepare_owner_disk_path
+
+if [[ -z "${OWNER_HOST//[[:space:]]/}" ]]; then
+    OWNER_HOST="$(detect_local_advertise_host "$OWNER_HOST" || true)"
+fi
+if [[ -z "${OWNER_HOST//[[:space:]]/}" ]]; then
+    echo "Error: failed to determine owner host automatically; set MC_OWNER_HOST." >&2
+    exit 1
+fi
+
+export MOONCAKE_PREFERRED_SEGMENT="${OWNER_HOST}:${OWNER_SEGMENT_PORT}"
+echo "Mooncake preferred segment: $MOONCAKE_PREFERRED_SEGMENT"
+
+OWNER_CMD=(
+    bash "${SCRIPT_DIR}/start_mooncake_owner.sh"
+    --cpu-mem-size "$OWNER_CPU_MEM_GIB"
+    --rpc-port "$OWNER_RPC_PORT"
+    --segment-port "$OWNER_SEGMENT_PORT"
+)
+
+if [[ -n "$OWNER_DISK_GIB" ]]; then
+    OWNER_CMD+=(--disk-size "$OWNER_DISK_GIB")
+fi
+if [[ -n "$OWNER_DISK_RUN_PATH" ]]; then
+    OWNER_CMD+=(--disk-path "$OWNER_DISK_RUN_PATH")
+elif [[ -n "$OWNER_DISK_PATH" ]]; then
+    OWNER_CMD+=(--disk-path "$OWNER_DISK_PATH")
+fi
+if [[ -n "$OWNER_DEVICE" ]]; then
+    export MC_OWNER_DEVICE="$OWNER_DEVICE"
+    OWNER_CMD+=(--device "$OWNER_DEVICE")
+fi
+if [[ -n "$OWNER_HOST" ]]; then
+    OWNER_CMD+=(--host "$OWNER_HOST")
+fi
+
+echo "Mooncake master: $MOONCAKE_MASTER"
+echo "Mooncake metadata server: $MOONCAKE_TE_META_DATA_SERVER"
+if [[ -n "${MC_GID_INDEX:-}" ]]; then
+    echo "Detected GID index: $MC_GID_INDEX"
+fi
+if [[ -n "${WORKER_DEVICE:-}" ]]; then
+    echo "Detected worker RNICs: $WORKER_DEVICE"
+fi
+if [[ -n "${OWNER_DEVICE:-}" ]]; then
+    echo "Detected owner RNICs: $OWNER_DEVICE"
+fi
+
+if command_has_kv_transfer_config "$@"; then
+    echo "Wrapped command already has --kv-transfer-config; skipping wrapper auto-inject."
+    SERVER_CMD=("$@")
+else
+    KV_TRANSFER_CONFIG_JSON="$(build_kv_transfer_config_json)"
+    SERVER_CMD=("$@" "--kv-transfer-config" "$KV_TRANSFER_CONFIG_JSON")
+fi
+
+trap cleanup EXIT INT TERM
+
+start_owner
+
+echo "Starting managed server: ${SERVER_CMD[*]}"
+"${SERVER_CMD[@]}" &
+SERVER_PID=$!
+
+wait "$SERVER_PID"

--- a/scripts/mooncake/legacy/setup_vllm_env.sh
+++ b/scripts/mooncake/legacy/setup_vllm_env.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Set up requester-side environment variables for a vLLM worker with Mooncake KV offloading.
+#
+# Usage:
+#   source setup_vllm_env.sh --cpu-mem-size 80
+#   source setup_vllm_env.sh --cpu-mem-size 80 --disk-size 400
+#
+# Options:
+#   --cpu-mem-size <GB>  Requester local-buffer hint in GB (required)
+#   --disk-size    <GB>  Accepted for compatibility; owner disk offload is started separately
+#
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Parse arguments --------------------------------------------------------
+CPU_MEM_GB=""
+DISK_GB=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cpu-mem-size)
+            CPU_MEM_GB="$2"; shift 2 ;;
+        --disk-size)
+            DISK_GB="$2"; shift 2 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: source $0 --cpu-mem-size <GB> [--disk-size <GB>]" >&2
+            return 1 2>/dev/null || exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$CPU_MEM_GB" ]]; then
+    echo "Error: --cpu-mem-size is required" >&2
+    echo "Usage: source $0 --cpu-mem-size <GB> [--disk-size <GB>]" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+# --- Mooncake connection pool -----------------------------------------------
+export MC_TCP_ENABLE_CONNECTION_POOL=1
+export MOONCAKE_CONFIG_PATH="${MOONCAKE_CONFIG_PATH:-${SCRIPTS_DIR}/mooncake_config.json}"
+export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES="$(( CPU_MEM_GB * 1073741824 ))"
+
+echo "Mooncake env configured:"
+echo "  Config:   $MOONCAKE_CONFIG_PATH"
+echo "  Local buffer hint: ${CPU_MEM_GB} GB"
+echo "  Owner:    external Mooncake service must be started separately"
+if [[ -n "$DISK_GB" ]]; then
+    echo "  Disk:     requester-only setup ignores --disk-size; start the owner with disk offload separately"
+fi

--- a/scripts/mooncake/legacy/start_mooncake_master.sh
+++ b/scripts/mooncake/legacy/start_mooncake_master.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Start a local Mooncake master server for benchmarking.
+#
+# The master provides two services:
+#   - RPC (port 50051): object metadata, allocation, eviction
+#   - HTTP metadata (port 8080): transfer engine peer discovery
+#
+# Usage:
+#   bash start_mooncake_master.sh                          # foreground
+#   bash start_mooncake_master.sh --bg                     # background (PID → mooncake_master.pid)
+#   bash start_mooncake_master.sh --bg --env-file /path/to/mooncake_master.env
+#                                                      # background + connection env file
+#   bash start_mooncake_master.sh --enable-offload --bg    # background with disk offloading
+#   bash start_mooncake_master.sh --stop                   # kill backgrounded master
+#
+# Flags can appear in any order; --stop is processed first and ignores others.
+#
+# Environment variables (all optional):
+#   MC_RPC_PORT       - Master RPC port           (default: 50051)
+#   MC_HTTP_PORT      - HTTP metadata port         (default: 8080)
+#   MC_METRICS_PORT   - Prometheus metrics port    (default: 9003)
+#   MC_RPC_THREADS    - RPC worker threads         (default: 4)
+#   MC_LEASE_TTL      - KV lease TTL in ms         (default: 1800000)
+#   MC_EVICT_HI       - Eviction high watermark    (default: 0.95)
+#   MC_EVICT_RATIO    - Fraction to evict per pass (default: 0.1)
+#   MC_MASTER_HOST    - Advertised host/IP for workers (default: first hostname -I entry)
+
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/network_utils.sh"
+PID_FILE="$SCRIPT_DIR/mooncake_master.pid"
+LOG_FILE="$SCRIPT_DIR/mooncake_master.log"
+
+# --- Parse flags -----------------------------------------------------------
+OPT_BG=false
+OPT_STOP=false
+OPT_OFFLOAD=false
+ENV_FILE=""
+MASTER_HOST="${MC_MASTER_HOST:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bg)
+            OPT_BG=true
+            shift
+            ;;
+        --stop)
+            OPT_STOP=true
+            shift
+            ;;
+        --enable-offload)
+            OPT_OFFLOAD=true
+            shift
+            ;;
+        --env-file)
+            ENV_FILE="$2"
+            shift 2
+            ;;
+        --host)
+            MASTER_HOST="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            echo "Usage: $0 [--bg] [--enable-offload] [--stop] [--env-file <path>] [--host <ip-or-host>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# --- Master settings -------------------------------------------------------
+MC_RPC_PORT="${MC_RPC_PORT:-50051}"
+MC_HTTP_PORT="${MC_HTTP_PORT:-8080}"
+MC_METRICS_PORT="${MC_METRICS_PORT:-9003}"
+MC_RPC_THREADS="${MC_RPC_THREADS:-4}"
+MC_LEASE_TTL="${MC_LEASE_TTL:-1800000}"
+MC_EVICT_HI="${MC_EVICT_HI:-0.95}"
+MC_EVICT_RATIO="${MC_EVICT_RATIO:-0.1}"
+
+resolve_master_bin() {
+    local wrapper_bin
+    local wrapper_dir
+    local candidate
+
+    wrapper_bin="$(command -v mooncake_master)"
+    wrapper_dir="$(cd "$(dirname "$wrapper_bin")" && pwd)"
+
+    shopt -s nullglob
+    for candidate in "$wrapper_dir"/../lib/python*/site-packages/mooncake/mooncake_master; do
+        if [[ -x "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            shopt -u nullglob
+            return 0
+        fi
+    done
+    shopt -u nullglob
+
+    printf '%s\n' "$wrapper_bin"
+}
+
+MASTER_BIN="$(resolve_master_bin)"
+
+
+write_master_env_file() {
+    local env_file=$1
+    [[ -n "${env_file//[[:space:]]/}" ]] || return 0
+
+    mkdir -p "$(dirname "$env_file")"
+    cat >"$env_file" <<EOF
+export MOONCAKE_MASTER=${MASTER_HOST}:${MC_RPC_PORT}
+export MOONCAKE_TE_META_DATA_SERVER=http://${MASTER_HOST}:${MC_HTTP_PORT}/metadata
+EOF
+}
+
+
+# --- Helper: stop a previously backgrounded master -------------------------
+is_our_master() {
+    local pid=$1
+    kill -0 "$pid" 2>/dev/null || return 1
+    [[ "$(ps -o comm= -p "$pid" 2>/dev/null)" == mooncake_maste* ]] || return 1
+    [[ "$(ps -o uid= -p "$pid" 2>/dev/null | tr -d ' ')" == "$(id -u)" ]]
+}
+
+stop_master() {
+    [[ -f "$PID_FILE" ]] || return 0
+    local pid=$(<"$PID_FILE")
+
+    if ! is_our_master "$pid"; then
+        rm -f "$PID_FILE"
+        return 0
+    fi
+
+    echo "Stopping mooncake_master (PID $pid) ..."
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 5); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+    rm -f "$PID_FILE"
+}
+
+if $OPT_STOP; then
+    stop_master
+    exit 0
+fi
+
+if [[ -f "$PID_FILE" ]]; then
+    pid="$(<"$PID_FILE")"
+    if is_our_master "$pid"; then
+        MASTER_HOST="$(detect_local_advertise_host "$MASTER_HOST")" || {
+            echo "Error: failed to determine Mooncake master host automatically; pass --host <ip-or-host> or set MC_MASTER_HOST." >&2
+            exit 1
+        }
+        write_master_env_file "$ENV_FILE"
+        if all_tcp_ports_listening "$MC_RPC_PORT" "$MC_HTTP_PORT" "$MC_METRICS_PORT"; then
+            echo "Reusing existing mooncake_master (PID $pid)."
+            if [[ -n "${ENV_FILE//[[:space:]]/}" ]]; then
+                echo "  Env file: $ENV_FILE"
+            fi
+            exit 0
+        fi
+        echo "Error: mooncake_master PID file points to a running process (PID $pid), but the expected ports are not all listening." >&2
+        exit 1
+    fi
+    rm -f "$PID_FILE"
+fi
+
+if any_tcp_ports_in_use "$MC_RPC_PORT" "$MC_HTTP_PORT" "$MC_METRICS_PORT"; then
+    echo "Error: one of the Mooncake master ports (${MC_RPC_PORT}, ${MC_HTTP_PORT}, ${MC_METRICS_PORT}) is already in use." >&2
+    exit 1
+fi
+
+MASTER_HOST="$(detect_local_advertise_host "$MASTER_HOST")" || {
+    echo "Error: failed to determine Mooncake master host automatically; pass --host <ip-or-host> or set MC_MASTER_HOST." >&2
+    exit 1
+}
+
+# --- Build command ----------------------------------------------------------
+CMD=(
+    "$MASTER_BIN"
+    -rpc_port="$MC_RPC_PORT"
+    -rpc_thread_num="$MC_RPC_THREADS"
+    -rpc_address=0.0.0.0
+    -rpc_enable_tcp_no_delay=true
+    -enable_http_metadata_server=true
+    -http_metadata_server_host=0.0.0.0
+    -http_metadata_server_port="$MC_HTTP_PORT"
+    -enable_metric_reporting=true
+    -metrics_port="$MC_METRICS_PORT"
+    -default_kv_lease_ttl="$MC_LEASE_TTL"
+    -eviction_high_watermark_ratio="$MC_EVICT_HI"
+    -eviction_ratio="$MC_EVICT_RATIO"
+    -logtostderr
+)
+
+if $OPT_OFFLOAD; then
+    CMD+=( -enable_offload=true )
+    # Note: do NOT pass -root_fs_dir here. That enables direct disk writes
+    # during put, which segfaults on GPU-resident data. Disk offload for
+    # vLLM works via the client-side FileStorage heartbeat path instead:
+    # CPU memory -> SSD (background), not GPU -> SSD (inline).
+fi
+
+# --- Start ------------------------------------------------------------------
+echo "Starting mooncake_master"
+echo "  RPC:      0.0.0.0:${MC_RPC_PORT}"
+echo "  HTTP:     0.0.0.0:${MC_HTTP_PORT}/metadata"
+echo "  Metrics:  0.0.0.0:${MC_METRICS_PORT}"
+echo "  Advertise: ${MASTER_HOST}"
+if $OPT_OFFLOAD; then
+    echo "  Offload:  ON"
+else
+    echo "  Offload:  OFF (pass --enable-offload to enable)"
+fi
+
+if $OPT_BG; then
+    : > "$LOG_FILE"
+    nohup "${CMD[@]}" > "$LOG_FILE" 2>&1 < /dev/null &
+    echo $! > "$PID_FILE"
+    for _ in $(seq 30); do
+        if is_our_master "$(cat "$PID_FILE")" \
+            && all_tcp_ports_listening "$MC_RPC_PORT" "$MC_HTTP_PORT" "$MC_METRICS_PORT"; then
+            break
+        fi
+        sleep 1
+    done
+    if ! is_our_master "$(cat "$PID_FILE")"; then
+        echo "  ERROR: mooncake_master failed to stay running" >&2
+        tail -n 50 "$LOG_FILE" >&2 || true
+        rm -f "$PID_FILE"
+        exit 1
+    fi
+    write_master_env_file "$ENV_FILE"
+    echo "  PID:      $(<"$PID_FILE") (written to $PID_FILE)"
+    echo "  Log:      $LOG_FILE"
+    if [[ -n "${ENV_FILE//[[:space:]]/}" ]]; then
+        echo "  Env file: $ENV_FILE"
+    fi
+    echo ""
+    echo "Stop with:  bash $0 --stop"
+else
+    write_master_env_file "$ENV_FILE"
+    echo "  (foreground — Ctrl-C to stop)"
+    exec "${CMD[@]}"
+fi

--- a/scripts/mooncake/legacy/start_mooncake_owner.sh
+++ b/scripts/mooncake/legacy/start_mooncake_owner.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Start a node-local Mooncake owner (real client) for vLLM requester ranks.
+#
+# Usage:
+#   MC_OWNER_DEVICE=rocep139s0,rocep140s0 \
+#   bash start_mooncake_owner.sh --cpu-mem-size 80
+#
+#   MC_OWNER_DEVICE=rocep139s0,rocep140s0 \
+#   bash start_mooncake_owner.sh --cpu-mem-size 80 --disk-size 400 --bg
+#
+#   bash start_mooncake_owner.sh --stop
+#
+# Flags:
+#   --cpu-mem-size <GB>   Owner CPU memory size in GB (required unless --stop)
+#   --disk-size <GB>      Enable disk offload with the given quota in GB
+#   --disk-path <dir>     Disk offload directory (default: /mnt/data/mooncake_offload)
+#   --host <ip-or-host>   Owner host/IP to advertise (default: first hostname -I entry)
+#   --segment-port <p>    Advertised owner segment port (default: 50053)
+#   --rpc-port <p>        Owner RPC port (default: 50052)
+#   --master <addr>       Mooncake master address (default: MOONCAKE_MASTER or 127.0.0.1:50051)
+#   --metadata-server <u> Metadata server URL (default: MOONCAKE_TE_META_DATA_SERVER or http://127.0.0.1:8080/metadata)
+#   --protocol <name>     Transport protocol (default: MOONCAKE_PROTOCOL or rdma)
+#   --device <names>      RDMA device name(s) (default: MC_OWNER_DEVICE)
+#   --threads <n>         Owner RPC worker threads (default: 1)
+#   --bg                  Run in background
+#   --stop                Stop the backgrounded owner launched by this script
+#
+# The owner auto-selects active RDMA devices when MC_OWNER_DEVICE/--device is
+# unset. For diagnostics, use:
+#   bash scripts/mooncake/recommend_mooncake_rnic_config.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/network_utils.sh"
+source "${SCRIPT_DIR}/rdma_config_utils.sh"
+
+HOST_TAG="$(hostname -s 2>/dev/null || echo local)"
+PID_FILE="${SCRIPT_DIR}/mooncake_owner.${HOST_TAG}.pid"
+LOG_FILE="${SCRIPT_DIR}/mooncake_owner.${HOST_TAG}.log"
+
+OPT_BG=false
+OPT_STOP=false
+CPU_MEM_GB=""
+DISK_GB=""
+DISK_PATH="/mnt/data/mooncake_offload"
+OWNER_HOST=""
+SEGMENT_PORT="${MC_OWNER_SEGMENT_PORT:-50053}"
+RPC_PORT="${MC_OWNER_RPC_PORT:-50052}"
+MASTER_SERVER="${MOONCAKE_MASTER:-127.0.0.1:50051}"
+METADATA_SERVER="${MOONCAKE_TE_META_DATA_SERVER:-http://127.0.0.1:8080/metadata}"
+PROTOCOL="${MOONCAKE_PROTOCOL:-rdma}"
+DEVICE_NAME="${MC_OWNER_DEVICE:-}"
+THREADS="${MC_OWNER_THREADS:-1}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cpu-mem-size)
+            CPU_MEM_GB="$2"; shift 2 ;;
+        --disk-size)
+            DISK_GB="$2"; shift 2 ;;
+        --disk-path)
+            DISK_PATH="$2"; shift 2 ;;
+        --host)
+            OWNER_HOST="$2"; shift 2 ;;
+        --segment-port)
+            SEGMENT_PORT="$2"; shift 2 ;;
+        --rpc-port)
+            RPC_PORT="$2"; shift 2 ;;
+        --master)
+            MASTER_SERVER="$2"; shift 2 ;;
+        --metadata-server)
+            METADATA_SERVER="$2"; shift 2 ;;
+        --protocol)
+            PROTOCOL="$2"; shift 2 ;;
+        --device)
+            DEVICE_NAME="$2"; shift 2 ;;
+        --threads)
+            THREADS="$2"; shift 2 ;;
+        --bg)
+            OPT_BG=true; shift ;;
+        --stop)
+            OPT_STOP=true; shift ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            echo "Usage: $0 [--bg] [--stop] --cpu-mem-size <GB> [--disk-size <GB>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+is_our_owner() {
+    local pid=$1
+    kill -0 "$pid" 2>/dev/null || return 1
+    [[ "$(ps -o comm= -p "$pid" 2>/dev/null)" == mooncake_clie* ]] || return 1
+    [[ "$(ps -o uid= -p "$pid" 2>/dev/null | tr -d ' ')" == "$(id -u)" ]]
+}
+
+print_rnic_hint() {
+    echo "Hint: use scripts/mooncake/recommend_mooncake_rnic_config.sh to inspect local Mooncake RDMA detection." >&2
+}
+
+detect_owner_devices() {
+    local detected_gid_index=""
+    local rdma_entries=()
+    local rdma_entry=""
+    local device_name=""
+    local devices=()
+
+    [[ "$PROTOCOL" == "rdma" || "$PROTOCOL" == "efa" ]] || return 0
+    [[ -z "${DEVICE_NAME//[[:space:]]/}" ]] || return 0
+
+    if [[ -z "${MC_GID_INDEX:-}" ]]; then
+        detected_gid_index="$(detect_preferred_gid_index)" || {
+            echo "Error: failed to auto-detect a usable RDMA GID index." >&2
+            return 1
+        }
+        export MC_GID_INDEX="$detected_gid_index"
+    fi
+
+    mapfile -t rdma_entries < <(list_active_rdma_devices "${MC_GID_INDEX:-}")
+    if [[ "${#rdma_entries[@]}" -eq 0 ]]; then
+        if [[ -n "${MC_GID_INDEX:-}" ]]; then
+            echo "Error: no active RDMA devices matched MC_GID_INDEX=${MC_GID_INDEX}." >&2
+        else
+            echo "Error: no active RDMA devices were discovered." >&2
+        fi
+        return 1
+    fi
+
+    for rdma_entry in "${rdma_entries[@]}"; do
+        IFS='|' read -r device_name _rest <<< "$rdma_entry"
+        unset IFS
+        devices+=("$device_name")
+    done
+
+    DEVICE_NAME="$(IFS=,; printf '%s' "${devices[*]}")"
+}
+
+wait_for_owner_ready() {
+    local pid=$1
+    local timeout_s=${2:-30}
+    # The RPC port is exposed as an abstract Unix socket; the segment port
+    # is the real TCP listener that indicates the owner is up.
+    wait_for_tcp_port "$SEGMENT_PORT" "$timeout_s" "$pid"
+}
+
+stop_owner() {
+    [[ -f "$PID_FILE" ]] || return 0
+    local pid
+    pid=$(<"$PID_FILE")
+
+    if ! is_our_owner "$pid"; then
+        rm -f "$PID_FILE"
+        return 0
+    fi
+
+    echo "Stopping mooncake_client owner (PID $pid) ..."
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in $(seq 5); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+    rm -f "$PID_FILE"
+}
+
+if $OPT_STOP; then
+    stop_owner
+    exit 0
+fi
+
+if [[ -z "$CPU_MEM_GB" ]]; then
+    echo "Error: --cpu-mem-size is required unless --stop is used." >&2
+    exit 1
+fi
+
+if [[ -z "$OWNER_HOST" ]]; then
+    OWNER_HOST="$(detect_local_advertise_host "$OWNER_HOST" || true)"
+fi
+[[ -n "${OWNER_HOST//[[:space:]]/}" ]] || {
+    echo "Error: failed to determine owner host automatically; pass --host <ip-or-host>." >&2
+    exit 1
+}
+
+if [[ -f "$PID_FILE" ]]; then
+    pid="$(<"$PID_FILE")"
+    if is_our_owner "$pid"; then
+        echo "Error: mooncake_client owner is already running with PID $pid. Use '$0 --stop' first." >&2
+        exit 1
+    fi
+    rm -f "$PID_FILE"
+fi
+
+if tcp_port_is_listening "$SEGMENT_PORT"; then
+    echo "Error: owner segment port ${SEGMENT_PORT} is already in use." >&2
+    exit 1
+fi
+
+if [[ "$PROTOCOL" == "rdma" || "$PROTOCOL" == "efa" ]]; then
+    if ! detect_owner_devices; then
+        print_rnic_hint
+        exit 1
+    fi
+    if ! validate_rdma_device_list "$DEVICE_NAME"; then
+        print_rnic_hint
+        exit 1
+    fi
+fi
+
+if [[ -n "$DISK_GB" ]]; then
+    DISK_BYTES=$(( DISK_GB * 1073741824 ))
+    HEADROOM_BYTES=$(( 40 * 1073741824 ))
+
+    export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$DISK_PATH"
+    export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR="${MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR:-bucket_storage_backend}"
+    export MOONCAKE_BUCKET_EVICTION_POLICY="${MOONCAKE_BUCKET_EVICTION_POLICY:-lru}"
+    export MOONCAKE_USE_URING="${MOONCAKE_USE_URING:-true}"
+    export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES="${MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES:-$((32*1024*1024*1024))}"
+    export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES="$DISK_BYTES"
+    export MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS="${MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS:-1}"
+    if (( DISK_BYTES > HEADROOM_BYTES )); then
+        export MOONCAKE_BUCKET_MAX_TOTAL_SIZE=$(( DISK_BYTES - HEADROOM_BYTES ))
+    else
+        export MOONCAKE_BUCKET_MAX_TOTAL_SIZE=$(( DISK_BYTES * 9 / 10 ))
+    fi
+
+    mkdir -p "$MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"
+fi
+
+CMD=(
+    mooncake_client
+    --master_server_address="$MASTER_SERVER"
+    --metadata_server="$METADATA_SERVER"
+    --host="${OWNER_HOST}:${SEGMENT_PORT}"
+    --port="$RPC_PORT"
+    --protocol="$PROTOCOL"
+    --device_names="$DEVICE_NAME"
+    --global_segment_size="${CPU_MEM_GB}GB"
+    --threads="$THREADS"
+)
+
+if [[ -n "$DISK_GB" ]]; then
+    CMD+=( --enable_offload=true )
+fi
+
+echo "Starting Mooncake owner"
+echo "  Master:        $MASTER_SERVER"
+echo "  Metadata:      $METADATA_SERVER"
+echo "  Host:          ${OWNER_HOST}:${SEGMENT_PORT}"
+echo "  RPC:           127.0.0.1:${RPC_PORT}"
+echo "  Protocol:      $PROTOCOL"
+echo "  Device:        ${DEVICE_NAME:-<none>}"
+echo "  CPU memory:    ${CPU_MEM_GB} GB"
+if [[ -n "$DISK_GB" ]]; then
+    echo "  Disk offload:  ON (${DISK_GB} GB at ${MOONCAKE_OFFLOAD_FILE_STORAGE_PATH})"
+else
+    echo "  Disk offload:  OFF"
+fi
+
+if $OPT_BG; then
+    : > "$LOG_FILE"
+    nohup "${CMD[@]}" > "$LOG_FILE" 2>&1 < /dev/null &
+    echo $! > "$PID_FILE"
+    if ! wait_for_owner_ready "$(cat "$PID_FILE")" 30; then
+        echo "  ERROR: mooncake_client failed to become ready" >&2
+        tail -n 50 "$LOG_FILE" >&2 || true
+        rm -f "$PID_FILE"
+        exit 1
+    fi
+    echo "  PID:           $(<"$PID_FILE") (written to $PID_FILE)"
+    echo "  Log:           $LOG_FILE"
+    echo
+    echo "Stop with:       bash $0 --stop"
+else
+    echo "  (foreground — Ctrl-C to stop)"
+    exec "${CMD[@]}"
+fi

--- a/scripts/mooncake/mooncake_config.json
+++ b/scripts/mooncake/mooncake_config.json
@@ -1,0 +1,10 @@
+{
+  "mode": "owner-client",
+  "metadata_server": "http://127.0.0.1:8080/metadata",
+  "master_server_address": "127.0.0.1:50051",
+  "global_segment_size": 0,
+  "local_buffer_size": "4GB",
+  "protocol": "rdma",
+  "device_name": "",
+  "enable_offload": true
+}

--- a/scripts/mooncake/verify/RUNBOOK.md
+++ b/scripts/mooncake/verify/RUNBOOK.md
@@ -1,0 +1,287 @@
+# MooncakeStore Disk-Offload — Launch Runbook
+
+How to launch vLLM with the Mooncake distributed-KV store backing it,
+including the per-node disk-tier offload path. The supported launch flow
+is the **zero-scripts** vigil YAML pipeline (`mndp_noscripts.yaml`), which
+calls `mooncake_master` and `mooncake_client` directly with no `.sh` shims.
+
+Validated on GB200 1-node × 4 GPU + Qwen3-8B.
+
+## TL;DR
+
+**Validated path (today):**
+```bash
+cd ~/repos/vllm-mooncake
+~/repos/model-ci/.venv/bin/vigil -c mndp.yaml          # uses scripts/mooncake/*.sh wrappers
+```
+
+**Zero-scripts path (work in progress — see "Known gap" below):**
+```bash
+~/repos/model-ci/.venv/bin/vigil -c mndp_noscripts.yaml
+```
+
+Three processes start in this order:
+
+1. `mooncake_master` (object-store metadata + HTTP-metadata peer-discovery + eviction)
+2. `mooncake_client` (per-node owner — CPU pool + SSD tier)
+3. `vllm serve` with `--kv-transfer-config '{"kv_connector":"MooncakeStoreConnector",...}'`
+
+After the bench finishes, vigil's `post_serve` SIGTERMs the owner + master via PID files written during startup.
+
+## Dual-mode topology — `real-client` vs `owner-client`
+
+The vllm-side `MooncakeStoreConfig` now has an explicit `mode` field that
+selects the deployment topology. **`mooncake_config.json` ships with
+`mode: "owner-client"`** to match the way our pipelines (both verify and
+legacy) spawn a separate `mooncake_client` owner per node.
+
+```jsonc
+// scripts/mooncake/mooncake_config.json
+{
+  "mode": "owner-client",          // vllm rank = pure requester
+  "global_segment_size": 0,        // must be 0 in owner-client mode
+  "local_buffer_size":   "4GB",    // RDMA scratch buffer on this rank
+  "metadata_server":     "http://127.0.0.1:8080/metadata",
+  "master_server_address":"127.0.0.1:50051",
+  "protocol":            "rdma",
+  "device_name":         ""
+}
+```
+
+The connector validates at startup and raises if `mode` and
+`global_segment_size` disagree:
+
+| `mode` | Required `global_segment_size` | Failure if violated |
+|---|---|---|
+| `real-client` (default — PR-40900 baseline) | `> 0` | `ValueError: real-client mode requires global_segment_size > 0` |
+| `owner-client` | `== 0` | `ValueError: owner-client mode requires global_segment_size == 0` |
+
+Confirm which mode is live by grepping the worker log:
+```
+INFO [worker.py:875] Mooncake mode=owner-client (global_segment_size=0,
+                     local_buffer_size=4294967296, preferred_segment=127.0.0.1:50053,
+                     enable_offload=True)
+```
+
+If you want to run the PR-40900 baseline topology instead (every rank
+contributes a CPU segment, no separate owner), set `mode: "real-client"`
+in the JSON and `global_segment_size: "4GB"` (or similar). The pipelines
+in `scripts/mooncake/verify/` will fail validation in that mode because
+they spawn a separate owner — use the legacy CPU-only PR-40900 config
+shape instead, or skip the per-node owner step.
+
+See `~/repos/disk/design/dual-mode-design.md` and
+`~/repos/disk/design/toggle-runbook.md` for the full design + toggle
+procedure.
+
+## ⚠️ Known gap (2026-05-13)
+
+The zero-scripts `mndp_noscripts.yaml` **does not yet do per-rank RNIC
+assignment**. With `-dp 4` on 4 GPUs the no-scripts yaml lets the Mooncake
+transfer engine auto-discover RDMA devices — all 4 vllm ranks then contend
+on the same NICs and the bench stalls under sustained offload pressure
+(19 reqs queued, 0 running, 0 progress for >5 min, GPU OOM never
+recovers).
+
+The wrapper script (`run_vllm_with_mooncake_owner.sh` →
+`rdma_config_utils.sh::get_worker_rdma_devices_csv`) queries each GPU's
+PCI-affine RNIC via `ibdev2netdev` + `rdma link show`, then exports
+`MOONCAKE_DEVICE=<rank0_nic>,<rank1_nic>,...` so the vllm-side
+`rdma_utils.py` can pin each local rank to its dedicated NIC.
+
+**Until we move that detection into Python**, the validated launch path is
+still `mndp.yaml` (with the wrapper script). The zero-scripts yaml is
+provided for reference / for setups where you can hardcode the per-rank
+device list.
+
+## Prerequisites
+
+### 1. Build / install Mooncake (provides `mooncake_master` + `mooncake_client`)
+
+```bash
+git clone https://github.com/ivanium/Mooncake ~/repos/Mooncake
+cd ~/repos/Mooncake
+git checkout yifan/dev
+./scripts/dev_compile.sh
+./scripts/dev_install.sh    # installs into ~/repos/vllm-mooncake/.venv
+```
+
+After install, `mooncake_master` and `mooncake_client` are on `PATH` whenever the venv is active. Vigil activates the venv automatically when `repo_path: /home/$USER/repos/vllm-mooncake` is set on the step.
+
+### 2. Install vLLM (already in the validation venv)
+
+```bash
+cd ~/repos/vllm-mooncake
+# venv is .venv/; vllm binary is .venv/bin/vllm
+```
+
+### 3. SSD scratch path
+
+The owner offloads CPU spillover to disk. The default path is
+`/mnt/data/$USER/mooncake_offload/`. Create + chown if it doesn't exist:
+
+```bash
+sudo mkdir -p /mnt/data/$USER && sudo chown $USER /mnt/data/$USER
+```
+
+The path **must be a real local SSD**, not NFS / Lustre — Mooncake uses
+`O_DIRECT` writev with 4 KiB alignment which networked filesystems either
+silently fall back to buffered I/O or reject.
+
+### 4. Discover your RDMA RNICs
+
+The owner exposes its CPU pool over RDMA. Find your RNICs:
+
+```bash
+rdma link show
+```
+
+Edit `mndp_noscripts.yaml`'s `MC_OWNER_DEVICES` to match. The validated GB200 hardware uses:
+
+```yaml
+MC_OWNER_DEVICES: "rocep139s0,rocep140s0,rocep195s0,rocep196s0"
+```
+
+### 5. `nc` (netcat) on PATH
+
+Used for port-readiness probes between phases.
+
+```bash
+which nc || sudo apt-get install netcat-openbsd
+```
+
+## Run
+
+### Pre-flight cleanup
+
+vigil's `post_serve` cleanup is best-effort. If a previous run crashed mid-flight, leftover `mooncake_master` / `mooncake_client` / `EngineCore` processes can leak. Always sweep before a new run:
+
+```bash
+pkill -9 -f mooncake_client mooncake_master 'vllm serve' EngineCore
+sleep 2
+nvidia-smi --query-gpu=memory.used --format=csv,noheader   # should all show 0 MiB
+```
+
+### Launch
+
+```bash
+cd ~/repos/vllm-mooncake
+~/repos/model-ci/.venv/bin/vigil -c mndp_noscripts.yaml
+```
+
+Vigil orchestrates everything:
+
+| Phase | What | Time |
+|---|---|---|
+| precheck | binary + venv existence | <1 s |
+| collect-env | dump env_info.log | <1 s |
+| pre_serve[0] | spawn `mooncake_master`, wait for RPC :50051 + HTTP :8080 | ~1.5 s |
+| pre_serve[1] | spawn `mooncake_client`, wait for segment :50053 | ~10 s |
+| serving | `vllm serve` ready (port 8100) | ~70 s |
+| router | round-robin router on `{router_port}` | ~10 s |
+| post_serve[0] | vmon start (resource tracker) | <1 s |
+| post_serve[1] | `vllm-bench` — 100 conv × 3 turns × 32 concurrency, 16 k input | ~13 min |
+| post_serve[2] | vmon stop | <1 s |
+| post_serve[3] | kill owner + master via PID files | ~2 s |
+
+### Watch progress
+
+```bash
+RUN=$(ls -td ~/repos/model-ci/logs/mndp_noscripts/$(date +%Y-%m-%d)/* | head -1)
+tail -f $RUN/worker_0.log              # vllm + tier-log lines
+tail -f $RUN/mooncake_master.log
+tail -f $RUN/mooncake_owner.log
+tail -f $RUN/hook_post_serve_1_vllm-bench.log   # bench progress
+```
+
+Watch for tier-log lines in `worker_0.log` like:
+
+```
+Mooncake load tier summary: req_id=… batch_keys=226 memory_keys=0
+   disk_keys=226 unknown_keys=0 success_keys=226 failed_keys=0
+   bytes_by_tier={'memory': 0, 'disk': 533200896, 'unknown': 0}
+```
+
+`disk_keys > 0` + `failed_keys = 0` means the disk-tier readback path is healthy.
+
+### Expected results
+
+Validation runs against `feat/mooncake-store-connector` + PR-47:
+
+| Signal | Expected |
+|---|---|
+| Successful requests (100×3 turns) | 100/100 |
+| Mean TTFT | 60–70 s |
+| Median TTFT | 60–80 s |
+| Failed requests / RPC_FAIL / tracebacks | 0 / 0 / 0 |
+| Tier-log lines | 100–130 |
+| Disk bytes returned | 50–70 GB |
+
+## What can go wrong
+
+### `mooncake_master crashed during startup`
+
+The pre_serve readiness probe reports this when `mooncake_master` exits within the first 60 × 0.5 s. Causes:
+
+- Port 50051 or 8080 already bound → check `ss -tlnp | grep -E ":(50051|8080)\s"`. Kill the holder, re-run.
+- Binary not on PATH → confirm `command -v mooncake_master` returns a path. If not, the venv didn't activate; check `repo_path` on the step is set to `/home/$USER/repos/vllm-mooncake`.
+
+### `mooncake_client crashed during startup` with "Duplicate rpc_meta key"
+
+A previous owner registered its segment descriptor in the HTTP metadata server before crashing, and the descriptor outlives the process. Fix:
+
+```bash
+# Inspect what's stuck
+curl -s "http://127.0.0.1:8080/metadata?key=mooncake/rpc_meta/127.0.0.1:50053"
+# Delete it (or DELETE the whole rpc_meta tree)
+curl -X DELETE "http://127.0.0.1:8080/metadata?key=mooncake/rpc_meta/127.0.0.1:50053"
+curl -X DELETE "http://127.0.0.1:8080/metadata?key=mooncake/ram/127.0.0.1:50053"
+```
+
+Then re-run. The shell-script wrapper version (`run_vllm_with_mooncake_owner.sh`) did this cleanup automatically; the no-scripts yaml does not (yet). Long-term, switching peer discovery to P2PHANDSHAKE eliminates this failure mode entirely (see `P2P_VS_HTTP_METADATA.md`) — but at a measured performance cost on long benchmarks.
+
+### CPU pool plateau at 95 %, no disk writes
+
+`MC_LEASE_TTL` default is 30 min. Memory replicas can't be evicted until lease expires, so the disk-tier path never fires. The yaml hardcodes `-default_kv_lease_ttl=30000` (30 s) for benchmarking; if you change it, eviction reverts to the default.
+
+### "RuntimeError: CUDA out of memory" on phase 2 startup
+
+A previous `vllm serve` left EngineCore worker processes holding GPU memory. The `pkill` cleanup snippet at the top of this runbook is the fix.
+
+### Disk bucket files accumulating
+
+vigil's cleanup kills the owner but doesn't `rm -rf /mnt/data/$USER/mooncake_offload/`. After many runs you'll see residual GB on disk. Safe to delete manually between runs:
+
+```bash
+rm -rf /mnt/data/$USER/mooncake_offload/*.bucket
+```
+
+## Switching benchmark parameters
+
+`mndp_noscripts.yaml` has these knobs you might want to tune:
+
+| Field | Default | Notes |
+|---|---|---|
+| `model` (top of file) | `Qwen/Qwen3-8B` | Any HF model |
+| `--gpu-memory-utilization` | `0.4` | Lower → smaller KV cache → more disk pressure |
+| `--num-gpu-blocks-override` | `1024` | Caps KV cache size |
+| `--max-model-len` | `16384` | Max sequence length |
+| `MC_OWNER_CPU_MEM_GIB` | `4` | Owner CPU pool. Set small to force disk spillover |
+| `MC_OWNER_DISK_GIB` | `1000` | Owner disk quota |
+| `--random-input-len` (post_serve bench) | `16000` | Input length per turn |
+| `--num-prompts` (post_serve bench) | `100` | Bench size |
+
+## Multi-node
+
+The yaml is single-node. For multi-node:
+
+1. Run `mooncake_master` on one node only; have the others point at it via `--master_server_address=<master-host>:50051` and `--metadata_server=http://<master-host>:8080/metadata`.
+2. Each compute node runs its own `mooncake_client` advertising its segment as `<node-host>:50053`.
+3. Each vllm rank on that node sets `MOONCAKE_PREFERRED_SEGMENT=<node-host>:50053` so it routes to *its* local owner (round-trips stay node-local).
+4. vigil supports `serving.roles[*].count > 1` for multi-instance launches.
+
+## See also
+
+- `P2P_VS_HTTP_METADATA.md` — why this runbook uses HTTP metadata, not P2PHANDSHAKE, and the perf trade-off
+- `~/repos/vllm-mooncake/mndp_noscripts.yaml` — the actual pipeline config
+- `~/repos/vllm-mooncake/scripts/mooncake/mooncake_config.json` — vllm-side connection params (read at runtime via `MOONCAKE_CONFIG_PATH`)

--- a/scripts/mooncake/verify/mndp_noscripts.yaml
+++ b/scripts/mooncake/verify/mndp_noscripts.yaml
@@ -1,0 +1,245 @@
+# MooncakeStore DP=4 disk-offload validation — zero shell scripts.
+#
+# Layout:
+#   pre_serve[0]   mooncake_master  (with HTTP metadata server for prod perf)
+#   pre_serve[1]   mooncake_client  (per-node owner)
+#   serving        plain `vllm serve` cmd — JSON --kv-transfer-config inlined
+#                  directly because there's no bash -c wrapping anymore.
+#   post_serve     vllm-bench, then kill owner + master via stored PID files.
+#
+# scripts/mooncake/mooncake_config.json holds the runtime connection params
+# (master/metadata/protocol/...) and is selected via MOONCAKE_CONFIG_PATH below.
+#
+# Required on PATH: mooncake_master, mooncake_client, vllm, nc.
+
+model: Qwen/Qwen3-8B
+mode: local
+precheck: true
+collect_env: true
+router_port: auto
+prometheus_port: auto
+
+# -----------------------------------------------------------------------------
+# 1) Start the Mooncake master (object-store metadata + eviction + offload sig
+#    + HTTP metadata server on port 8080 for cached peer discovery).
+# -----------------------------------------------------------------------------
+pre_serve:
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        mkdir -p {log_dir}
+        nohup mooncake_master \
+          -rpc_port=50051 \
+          -rpc_thread_num=4 \
+          -default_kv_lease_ttl=30000 \
+          -eviction_high_watermark_ratio=0.95 \
+          -eviction_ratio=0.1 \
+          -enable_metric_reporting=true \
+          -metrics_port=9003 \
+          -enable_http_metadata_server=true \
+          -http_metadata_server_host=0.0.0.0 \
+          -http_metadata_server_port=8080 \
+          -enable_offload=true \
+          -logtostderr \
+          > {log_dir}/mooncake_master.log 2>&1 < /dev/null &
+        MASTER_PID=$$!
+        echo $$MASTER_PID > {log_dir}/mooncake_master.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 50051 && nc -z 127.0.0.1 8080 && break
+          kill -0 $$MASTER_PID 2>/dev/null || {
+            echo "mooncake_master crashed during startup" >&2
+            tail -n 40 {log_dir}/mooncake_master.log >&2 || true
+            exit 1
+          }
+          sleep 0.5
+        done
+        echo "mooncake_master ready (pid=$$MASTER_PID, rpc=:50051, http=:8080)"
+      '
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+  # -----------------------------------------------------------------------------
+  # 2) Start the per-node Mooncake owner (mooncake_client). Holds the node's
+  #    CPU pool + SSD tier. Backgrounded; PID stored so post_serve can kill it.
+  # -----------------------------------------------------------------------------
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        OWNER_HOST=127.0.0.1
+        OWNER_RPC_PORT=50052
+        OWNER_SEGMENT_PORT=50053
+        OWNER_CPU_GIB=$${MC_OWNER_CPU_MEM_GIB:-4}
+        OWNER_DISK_GIB=$${MC_OWNER_DISK_GIB:-1000}
+        OWNER_DISK_PATH=$${MC_OWNER_DISK_PATH:-/mnt/data/$USER/mooncake_offload}
+        OWNER_DEVICES=$${MC_OWNER_DEVICES:-rocep139s0,rocep140s0,rocep195s0,rocep196s0}
+
+        mkdir -p "$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=bucket_storage_backend
+        export MOONCAKE_BUCKET_EVICTION_POLICY=lru
+        export MOONCAKE_USE_URING=true
+        export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES=$$(( 32 * 1073741824 ))
+        export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES=$$(( OWNER_DISK_GIB * 1073741824 ))
+
+        nohup mooncake_client \
+          --master_server_address=127.0.0.1:50051 \
+          --metadata_server=http://127.0.0.1:8080/metadata \
+          --host=$${OWNER_HOST}:$${OWNER_SEGMENT_PORT} \
+          --port=$${OWNER_RPC_PORT} \
+          --protocol=rdma \
+          --device_names="$$OWNER_DEVICES" \
+          --global_segment_size=$${OWNER_CPU_GIB}GB \
+          --enable_offload=true \
+          --threads=1 \
+          > {log_dir}/mooncake_owner.log 2>&1 < /dev/null &
+        OWNER_PID=$$!
+        echo $$OWNER_PID > {log_dir}/mooncake_owner.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 $${OWNER_SEGMENT_PORT} && break
+          kill -0 $$OWNER_PID 2>/dev/null || {
+            echo "mooncake_client crashed during startup" >&2
+            tail -n 60 {log_dir}/mooncake_owner.log >&2 || true
+            exit 1
+          }
+          sleep 1
+        done
+        echo "mooncake_client ready (pid=$$OWNER_PID, segment=127.0.0.1:$${OWNER_SEGMENT_PORT})"
+      '
+    env:
+      MC_OWNER_CPU_MEM_GIB: "4"
+      MC_OWNER_DISK_GIB: "1000"
+      MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
+      MC_OWNER_DEVICES: "rocep139s0,rocep140s0,rocep195s0,rocep196s0"
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+# -----------------------------------------------------------------------------
+# 3) Serving — plain `vllm serve`. No bash -c wrapping, so the inline
+#    --kv-transfer-config JSON works exactly like ci-fork pd_xpyd recipes.
+# -----------------------------------------------------------------------------
+serving:
+  roles:
+    - role: worker
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      base_port: 8100
+      vllm_engine:
+        repo_path: /home/${USER}/repos/vllm-mooncake
+        cmd: >-
+          vllm serve {model}
+          --port {port}
+          --trust-remote-code
+          --load-format dummy
+          --enforce-eager
+          -dp 4
+          --gpu-memory-utilization 0.4
+          --num-gpu-blocks-override 1024
+          --max-model-len 16384
+          --max-num-seqs 32
+          --max-num-batched-tokens 8192
+          --enable-prefix-caching
+          --enable-chunked-prefill
+          --disable-uvicorn-access-log
+          --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true,"enable_cross_layers_blocks":true,"enable_offload":true}}'
+        env:
+          # Connection params for the vllm-side MooncakeStoreConfig.
+          MOONCAKE_CONFIG_PATH: "/home/${USER}/repos/vllm-mooncake/scripts/mooncake/mooncake_config.json"
+          # Steer this rank to the owner we just spawned (same node, port 50053).
+          MOONCAKE_PREFERRED_SEGMENT: "127.0.0.1:50053"
+          # vLLM-side tier logging.
+          VLLM_MOONCAKE_STORE_TIER_LOG: "1"
+          GLOG_v: "1"
+          VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+          # Timeouts.
+          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+          VLLM_RPC_TIMEOUT: "600000"
+          VLLM_LOG_STATS_INTERVAL: "1"
+          # UCX for MNNVL.
+          UCX_MEMTYPE_CACHE: "n"
+          UCX_MEMTYPE_REG_WHOLE: "n"
+          UCX_TLS: "cuda_copy,cuda_ipc,tcp"
+          UCX_CUDA_IPC_ENABLE_MNNVL: "y"
+          UCX_RC_TIMEOUT: "5s"
+          UCX_RC_RETRY_COUNT: "14"
+          UCX_RC_RNR_TIMEOUT: "10ms"
+          UCX_RC_RNR_RETRY_COUNT: "14"
+          # Model cache.
+          HF_HOME: /mnt/lustre/hf-models
+          # NCCL for GB200 NVL72.
+          NCCL_P2P_DISABLE: "0"
+          NCCL_P2P_LEVEL: NVL
+          NCCL_SOCKET_IFNAME: enp192s2
+          NCCL_IB_HCA: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
+          NCCL_NET_GDR_LEVEL: "5"
+          NCCL_SHM_DISABLE: "1"
+          NCCL_DEBUG: WARN
+          NCCL_TIMEOUT: "1800"
+          TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+          GLOO_SOCKET_IFNAME: enp192s2
+        health_check:
+          url: "http://localhost:{port}/health"
+          timeout_s: 3600
+          poll_interval_s: 10
+
+  router:
+    repo_path: /home/${USER}/repos/router-internal
+    cmd: >-
+      cargo run --release --
+      --policy consistent_hash
+      --prometheus-port {prometheus_port}
+      --host 0.0.0.0
+      --port {router_port}
+      --intra-node-data-parallel-size 4
+      {worker_flags}
+    health_check:
+      url: http://localhost:{router_port}/health
+      timeout_s: 300
+      poll_interval_s: 5
+
+  remote:
+    launcher: slurm
+    slurm:
+      partition: normal
+      time_limit: "12:00:00"
+      grace_period_s: 120
+
+# -----------------------------------------------------------------------------
+# 4) Benchmark, then kill owner + master via PID files we wrote earlier.
+# -----------------------------------------------------------------------------
+post_serve:
+  - vmon: start
+  - cmd: >-
+      vllm-bench
+      --backend openai-chat
+      --base-url http://localhost:{router_port}
+      --model {model}
+      --dataset-name random
+      --random-input-len 16000
+      --random-output-len 300
+      --num-prompts 100
+      --multi-turn
+      --multi-turn-num-turns 3
+      --multi-turn-concurrency 32
+      --multi-turn-delay-ms 500
+      --multi-turn-prefix-global-ratio 0.1
+      --multi-turn-prefix-conversation-ratio 0.8
+      --percentile-metrics "ttft,tpot,itl,e2el"
+      --result-dir {log_dir}
+      --save-result
+  - vmon: stop
+  - cmd: |
+      bash -c '
+        for tag in owner master; do
+          PID_FILE={log_dir}/mooncake_$${tag}.pid
+          if [[ -f $$PID_FILE ]]; then
+            PID=$$(<$$PID_FILE)
+            kill -TERM "$$PID" 2>/dev/null || true
+            for _ in $$(seq 5); do kill -0 "$$PID" 2>/dev/null || break; sleep 1; done
+            kill -KILL "$$PID" 2>/dev/null || true
+            rm -f $$PID_FILE
+          fi
+        done
+        # Safety-net.
+        pkill -u $USER -x mooncake_client 2>/dev/null || true
+        pkill -u $USER -x mooncake_master 2>/dev/null || true
+        true
+      '

--- a/scripts/mooncake/verify/mndp_noscripts_fixed_nics.yaml
+++ b/scripts/mooncake/verify/mndp_noscripts_fixed_nics.yaml
@@ -1,0 +1,248 @@
+# MooncakeStore DP=4 disk-offload validation — zero shell scripts.
+#
+# Layout (fixed-NIC variant — opts OUT of Python auto-discovery):
+#   pre_serve[0]   mooncake_master  (with HTTP metadata server for prod perf)
+#   pre_serve[1]   mooncake_client  (per-node owner)
+#   serving        plain `vllm serve` cmd — JSON --kv-transfer-config inlined
+#                  directly because there's no bash -c wrapping anymore.
+#   post_serve     vllm-bench, then kill owner + master via stored PID files.
+#
+# scripts/mooncake/mooncake_config.json holds the runtime connection params
+# (master/metadata/protocol/...) and is selected via MOONCAKE_CONFIG_PATH below.
+#
+# Required on PATH: mooncake_master, mooncake_client, vllm, nc.
+
+model: Qwen/Qwen3-8B
+mode: local
+precheck: true
+collect_env: true
+router_port: auto
+prometheus_port: auto
+
+# -----------------------------------------------------------------------------
+# 1) Start the Mooncake master (object-store metadata + eviction + offload sig
+#    + HTTP metadata server on port 8080 for cached peer discovery).
+# -----------------------------------------------------------------------------
+pre_serve:
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        mkdir -p {log_dir}
+        nohup mooncake_master \
+          -rpc_port=50051 \
+          -rpc_thread_num=4 \
+          -default_kv_lease_ttl=30000 \
+          -eviction_high_watermark_ratio=0.95 \
+          -eviction_ratio=0.1 \
+          -enable_metric_reporting=true \
+          -metrics_port=9003 \
+          -enable_http_metadata_server=true \
+          -http_metadata_server_host=0.0.0.0 \
+          -http_metadata_server_port=8080 \
+          -enable_offload=true \
+          -logtostderr \
+          > {log_dir}/mooncake_master.log 2>&1 < /dev/null &
+        MASTER_PID=$$!
+        echo $$MASTER_PID > {log_dir}/mooncake_master.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 50051 && nc -z 127.0.0.1 8080 && break
+          kill -0 $$MASTER_PID 2>/dev/null || {
+            echo "mooncake_master crashed during startup" >&2
+            tail -n 40 {log_dir}/mooncake_master.log >&2 || true
+            exit 1
+          }
+          sleep 0.5
+        done
+        echo "mooncake_master ready (pid=$$MASTER_PID, rpc=:50051, http=:8080)"
+      '
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+  # -----------------------------------------------------------------------------
+  # 2) Start the per-node Mooncake owner (mooncake_client). Holds the node's
+  #    CPU pool + SSD tier. Backgrounded; PID stored so post_serve can kill it.
+  # -----------------------------------------------------------------------------
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        OWNER_HOST=127.0.0.1
+        OWNER_RPC_PORT=50052
+        OWNER_SEGMENT_PORT=50053
+        OWNER_CPU_GIB=$${MC_OWNER_CPU_MEM_GIB:-4}
+        OWNER_DISK_GIB=$${MC_OWNER_DISK_GIB:-1000}
+        OWNER_DISK_PATH=$${MC_OWNER_DISK_PATH:-/mnt/data/$USER/mooncake_offload}
+        OWNER_DEVICES=$${MC_OWNER_DEVICES:-rocep139s0,rocep140s0,rocep195s0,rocep196s0}
+
+        mkdir -p "$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=bucket_storage_backend
+        export MOONCAKE_BUCKET_EVICTION_POLICY=lru
+        export MOONCAKE_USE_URING=true
+        export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES=$$(( 32 * 1073741824 ))
+        export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES=$$(( OWNER_DISK_GIB * 1073741824 ))
+
+        nohup mooncake_client \
+          --master_server_address=127.0.0.1:50051 \
+          --metadata_server=http://127.0.0.1:8080/metadata \
+          --host=$${OWNER_HOST}:$${OWNER_SEGMENT_PORT} \
+          --port=$${OWNER_RPC_PORT} \
+          --protocol=rdma \
+          --device_names="$$OWNER_DEVICES" \
+          --global_segment_size=$${OWNER_CPU_GIB}GB \
+          --enable_offload=true \
+          --threads=1 \
+          > {log_dir}/mooncake_owner.log 2>&1 < /dev/null &
+        OWNER_PID=$$!
+        echo $$OWNER_PID > {log_dir}/mooncake_owner.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 $${OWNER_SEGMENT_PORT} && break
+          kill -0 $$OWNER_PID 2>/dev/null || {
+            echo "mooncake_client crashed during startup" >&2
+            tail -n 60 {log_dir}/mooncake_owner.log >&2 || true
+            exit 1
+          }
+          sleep 1
+        done
+        echo "mooncake_client ready (pid=$$OWNER_PID, segment=127.0.0.1:$${OWNER_SEGMENT_PORT})"
+      '
+    env:
+      MC_OWNER_CPU_MEM_GIB: "4"
+      MC_OWNER_DISK_GIB: "1000"
+      MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
+      MC_OWNER_DEVICES: "rocep139s0,rocep140s0,rocep195s0,rocep196s0"
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+# -----------------------------------------------------------------------------
+# 3) Serving — plain `vllm serve`. No bash -c wrapping, so the inline
+#    --kv-transfer-config JSON works exactly like ci-fork pd_xpyd recipes.
+# -----------------------------------------------------------------------------
+serving:
+  roles:
+    - role: worker
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      base_port: 8100
+      vllm_engine:
+        repo_path: /home/${USER}/repos/vllm-mooncake
+        cmd: >-
+          vllm serve {model}
+          --port {port}
+          --trust-remote-code
+          --load-format dummy
+          --enforce-eager
+          -dp 4
+          --gpu-memory-utilization 0.4
+          --num-gpu-blocks-override 1024
+          --max-model-len 16384
+          --max-num-seqs 32
+          --max-num-batched-tokens 8192
+          --enable-prefix-caching
+          --enable-chunked-prefill
+          --disable-uvicorn-access-log
+          --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true,"enable_cross_layers_blocks":true,"enable_offload":true}}'
+        env:
+          # Connection params for the vllm-side MooncakeStoreConfig.
+          MOONCAKE_CONFIG_PATH: "/home/${USER}/repos/vllm-mooncake/scripts/mooncake/mooncake_config.json"
+          # Steer this rank to the owner we just spawned (same node, port 50053).
+          MOONCAKE_PREFERRED_SEGMENT: "127.0.0.1:50053"
+          # FIXED-NIC override — bypasses Python auto-discovery.
+          # CSV position N → vllm rank with local GPU N picks entries[N].
+          MOONCAKE_DEVICE: "rocep139s0,rocep140s0,rocep195s0,rocep196s0"
+          # vLLM-side tier logging.
+          VLLM_MOONCAKE_STORE_TIER_LOG: "1"
+          GLOG_v: "1"
+          VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+          # Timeouts.
+          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+          VLLM_RPC_TIMEOUT: "600000"
+          VLLM_LOG_STATS_INTERVAL: "1"
+          # UCX for MNNVL.
+          UCX_MEMTYPE_CACHE: "n"
+          UCX_MEMTYPE_REG_WHOLE: "n"
+          UCX_TLS: "cuda_copy,cuda_ipc,tcp"
+          UCX_CUDA_IPC_ENABLE_MNNVL: "y"
+          UCX_RC_TIMEOUT: "5s"
+          UCX_RC_RETRY_COUNT: "14"
+          UCX_RC_RNR_TIMEOUT: "10ms"
+          UCX_RC_RNR_RETRY_COUNT: "14"
+          # Model cache.
+          HF_HOME: /mnt/lustre/hf-models
+          # NCCL for GB200 NVL72.
+          NCCL_P2P_DISABLE: "0"
+          NCCL_P2P_LEVEL: NVL
+          NCCL_SOCKET_IFNAME: enp192s2
+          NCCL_IB_HCA: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
+          NCCL_NET_GDR_LEVEL: "5"
+          NCCL_SHM_DISABLE: "1"
+          NCCL_DEBUG: WARN
+          NCCL_TIMEOUT: "1800"
+          TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+          GLOO_SOCKET_IFNAME: enp192s2
+        health_check:
+          url: "http://localhost:{port}/health"
+          timeout_s: 3600
+          poll_interval_s: 10
+
+  router:
+    repo_path: /home/${USER}/repos/router-internal
+    cmd: >-
+      cargo run --release --
+      --policy consistent_hash
+      --prometheus-port {prometheus_port}
+      --host 0.0.0.0
+      --port {router_port}
+      --intra-node-data-parallel-size 4
+      {worker_flags}
+    health_check:
+      url: http://localhost:{router_port}/health
+      timeout_s: 300
+      poll_interval_s: 5
+
+  remote:
+    launcher: slurm
+    slurm:
+      partition: normal
+      time_limit: "12:00:00"
+      grace_period_s: 120
+
+# -----------------------------------------------------------------------------
+# 4) Benchmark, then kill owner + master via PID files we wrote earlier.
+# -----------------------------------------------------------------------------
+post_serve:
+  - vmon: start
+  - cmd: >-
+      vllm-bench
+      --backend openai-chat
+      --base-url http://localhost:{router_port}
+      --model {model}
+      --dataset-name random
+      --random-input-len 16000
+      --random-output-len 300
+      --num-prompts 100
+      --multi-turn
+      --multi-turn-num-turns 3
+      --multi-turn-concurrency 32
+      --multi-turn-delay-ms 500
+      --multi-turn-prefix-global-ratio 0.1
+      --multi-turn-prefix-conversation-ratio 0.8
+      --percentile-metrics "ttft,tpot,itl,e2el"
+      --result-dir {log_dir}
+      --save-result
+  - vmon: stop
+  - cmd: |
+      bash -c '
+        for tag in owner master; do
+          PID_FILE={log_dir}/mooncake_$${tag}.pid
+          if [[ -f $$PID_FILE ]]; then
+            PID=$$(<$$PID_FILE)
+            kill -TERM "$$PID" 2>/dev/null || true
+            for _ in $$(seq 5); do kill -0 "$$PID" 2>/dev/null || break; sleep 1; done
+            kill -KILL "$$PID" 2>/dev/null || true
+            rm -f $$PID_FILE
+          fi
+        done
+        # Safety-net.
+        pkill -u $USER -x mooncake_client 2>/dev/null || true
+        pkill -u $USER -x mooncake_master 2>/dev/null || true
+        true
+      '

--- a/scripts/mooncake/verify/mndp_noscripts_p2p.yaml
+++ b/scripts/mooncake/verify/mndp_noscripts_p2p.yaml
@@ -1,0 +1,243 @@
+# MooncakeStore DP=4 disk-offload validation — zero shell scripts.
+#
+# Layout (P2P variant):
+#   pre_serve[0]   mooncake_master  (no HTTP metadata server — P2PHANDSHAKE peer discovery)
+#   pre_serve[1]   mooncake_client  (per-node owner)
+#   serving        plain `vllm serve` cmd — JSON --kv-transfer-config inlined
+#                  directly because there's no bash -c wrapping anymore.
+#   post_serve     vllm-bench, then kill owner + master via stored PID files.
+#
+# scripts/mooncake/mooncake_config.json holds the runtime connection params
+# (master/metadata/protocol/...) and is selected via MOONCAKE_CONFIG_PATH below.
+#
+# Required on PATH: mooncake_master, mooncake_client, vllm, nc.
+
+model: Qwen/Qwen3-8B
+mode: local
+precheck: true
+collect_env: true
+router_port: auto
+prometheus_port: auto
+
+# -----------------------------------------------------------------------------
+# 1) Start the Mooncake master (object-store metadata + eviction + offload sig
+#    + HTTP metadata server on port 8080 for cached peer discovery).
+# -----------------------------------------------------------------------------
+pre_serve:
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        mkdir -p {log_dir}
+        nohup mooncake_master \
+          -rpc_port=50051 \
+          -rpc_thread_num=4 \
+          -default_kv_lease_ttl=30000 \
+          -eviction_high_watermark_ratio=0.95 \
+          -eviction_ratio=0.1 \
+          -enable_metric_reporting=true \
+          -metrics_port=9003 \
+          -enable_offload=true \
+          -logtostderr \
+          > {log_dir}/mooncake_master.log 2>&1 < /dev/null &
+        MASTER_PID=$$!
+        echo $$MASTER_PID > {log_dir}/mooncake_master.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 50051 && break
+          kill -0 $$MASTER_PID 2>/dev/null || {
+            echo "mooncake_master crashed during startup" >&2
+            tail -n 40 {log_dir}/mooncake_master.log >&2 || true
+            exit 1
+          }
+          sleep 0.5
+        done
+        echo "mooncake_master ready (pid=$$MASTER_PID, rpc=:50051)"
+      '
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+  # -----------------------------------------------------------------------------
+  # 2) Start the per-node Mooncake owner (mooncake_client). Holds the node's
+  #    CPU pool + SSD tier. Backgrounded; PID stored so post_serve can kill it.
+  # -----------------------------------------------------------------------------
+  - cmd: |
+      bash -c '
+        set -euo pipefail
+        OWNER_HOST=127.0.0.1
+        OWNER_RPC_PORT=50052
+        OWNER_SEGMENT_PORT=50053
+        OWNER_CPU_GIB=$${MC_OWNER_CPU_MEM_GIB:-4}
+        OWNER_DISK_GIB=$${MC_OWNER_DISK_GIB:-1000}
+        OWNER_DISK_PATH=$${MC_OWNER_DISK_PATH:-/mnt/data/$USER/mooncake_offload}
+        OWNER_DEVICES=$${MC_OWNER_DEVICES:-rocep139s0,rocep140s0,rocep195s0,rocep196s0}
+
+        mkdir -p "$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$$OWNER_DISK_PATH"
+        export MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=bucket_storage_backend
+        export MOONCAKE_BUCKET_EVICTION_POLICY=lru
+        export MOONCAKE_USE_URING=true
+        export MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES=$$(( 32 * 1073741824 ))
+        export MOONCAKE_OFFLOAD_TOTAL_SIZE_LIMIT_BYTES=$$(( OWNER_DISK_GIB * 1073741824 ))
+
+        nohup mooncake_client \
+          --master_server_address=127.0.0.1:50051 \
+          --metadata_server=P2PHANDSHAKE \
+          --host=$${OWNER_HOST}:$${OWNER_SEGMENT_PORT} \
+          --port=$${OWNER_RPC_PORT} \
+          --protocol=rdma \
+          --device_names="$$OWNER_DEVICES" \
+          --global_segment_size=$${OWNER_CPU_GIB}GB \
+          --enable_offload=true \
+          --threads=1 \
+          > {log_dir}/mooncake_owner.log 2>&1 < /dev/null &
+        OWNER_PID=$$!
+        echo $$OWNER_PID > {log_dir}/mooncake_owner.pid
+        for _ in $$(seq 60); do
+          nc -z 127.0.0.1 $${OWNER_SEGMENT_PORT} && break
+          kill -0 $$OWNER_PID 2>/dev/null || {
+            echo "mooncake_client crashed during startup" >&2
+            tail -n 60 {log_dir}/mooncake_owner.log >&2 || true
+            exit 1
+          }
+          sleep 1
+        done
+        echo "mooncake_client ready (pid=$$OWNER_PID, segment=127.0.0.1:$${OWNER_SEGMENT_PORT})"
+      '
+    env:
+      MC_OWNER_CPU_MEM_GIB: "4"
+      MC_OWNER_DISK_GIB: "1000"
+      MC_OWNER_DISK_PATH: "/mnt/data/${USER}/mooncake_offload"
+      MC_OWNER_DEVICES: "rocep139s0,rocep140s0,rocep195s0,rocep196s0"
+    repo_path: /home/${USER}/repos/vllm-mooncake
+
+# -----------------------------------------------------------------------------
+# 3) Serving — plain `vllm serve`. No bash -c wrapping, so the inline
+#    --kv-transfer-config JSON works exactly like ci-fork pd_xpyd recipes.
+# -----------------------------------------------------------------------------
+serving:
+  roles:
+    - role: worker
+      count: 1
+      nodes_per_instance: 1
+      gpus_per_node: 4
+      base_port: 8100
+      vllm_engine:
+        repo_path: /home/${USER}/repos/vllm-mooncake
+        cmd: >-
+          vllm serve {model}
+          --port {port}
+          --trust-remote-code
+          --load-format dummy
+          --enforce-eager
+          -dp 4
+          --gpu-memory-utilization 0.4
+          --num-gpu-blocks-override 1024
+          --max-model-len 16384
+          --max-num-seqs 32
+          --max-num-batched-tokens 8192
+          --enable-prefix-caching
+          --enable-chunked-prefill
+          --disable-uvicorn-access-log
+          --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true,"enable_cross_layers_blocks":true,"enable_offload":true}}'
+        env:
+          # Connection params for the vllm-side MooncakeStoreConfig.
+          MOONCAKE_CONFIG_PATH: "/home/${USER}/repos/vllm-mooncake/scripts/mooncake/mooncake_config.json"
+          # Steer this rank to the owner we just spawned (same node, port 50053).
+          MOONCAKE_PREFERRED_SEGMENT: "127.0.0.1:50053"
+          MOONCAKE_TE_META_DATA_SERVER: "P2PHANDSHAKE"
+          # vLLM-side tier logging.
+          VLLM_MOONCAKE_STORE_TIER_LOG: "1"
+          GLOG_v: "1"
+          VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+          # Timeouts.
+          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+          VLLM_RPC_TIMEOUT: "600000"
+          VLLM_LOG_STATS_INTERVAL: "1"
+          # UCX for MNNVL.
+          UCX_MEMTYPE_CACHE: "n"
+          UCX_MEMTYPE_REG_WHOLE: "n"
+          UCX_TLS: "cuda_copy,cuda_ipc,tcp"
+          UCX_CUDA_IPC_ENABLE_MNNVL: "y"
+          UCX_RC_TIMEOUT: "5s"
+          UCX_RC_RETRY_COUNT: "14"
+          UCX_RC_RNR_TIMEOUT: "10ms"
+          UCX_RC_RNR_RETRY_COUNT: "14"
+          # Model cache.
+          HF_HOME: /mnt/lustre/hf-models
+          # NCCL for GB200 NVL72.
+          NCCL_P2P_DISABLE: "0"
+          NCCL_P2P_LEVEL: NVL
+          NCCL_SOCKET_IFNAME: enp192s2
+          NCCL_IB_HCA: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
+          NCCL_NET_GDR_LEVEL: "5"
+          NCCL_SHM_DISABLE: "1"
+          NCCL_DEBUG: WARN
+          NCCL_TIMEOUT: "1800"
+          TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+          GLOO_SOCKET_IFNAME: enp192s2
+        health_check:
+          url: "http://localhost:{port}/health"
+          timeout_s: 3600
+          poll_interval_s: 10
+
+  router:
+    repo_path: /home/${USER}/repos/router-internal
+    cmd: >-
+      cargo run --release --
+      --policy consistent_hash
+      --prometheus-port {prometheus_port}
+      --host 0.0.0.0
+      --port {router_port}
+      --intra-node-data-parallel-size 4
+      {worker_flags}
+    health_check:
+      url: http://localhost:{router_port}/health
+      timeout_s: 300
+      poll_interval_s: 5
+
+  remote:
+    launcher: slurm
+    slurm:
+      partition: normal
+      time_limit: "12:00:00"
+      grace_period_s: 120
+
+# -----------------------------------------------------------------------------
+# 4) Benchmark, then kill owner + master via PID files we wrote earlier.
+# -----------------------------------------------------------------------------
+post_serve:
+  - vmon: start
+  - cmd: >-
+      vllm-bench
+      --backend openai-chat
+      --base-url http://localhost:{router_port}
+      --model {model}
+      --dataset-name random
+      --random-input-len 16000
+      --random-output-len 300
+      --num-prompts 100
+      --multi-turn
+      --multi-turn-num-turns 3
+      --multi-turn-concurrency 32
+      --multi-turn-delay-ms 500
+      --multi-turn-prefix-global-ratio 0.1
+      --multi-turn-prefix-conversation-ratio 0.8
+      --percentile-metrics "ttft,tpot,itl,e2el"
+      --result-dir {log_dir}
+      --save-result
+  - vmon: stop
+  - cmd: |
+      bash -c '
+        for tag in owner master; do
+          PID_FILE={log_dir}/mooncake_$${tag}.pid
+          if [[ -f $$PID_FILE ]]; then
+            PID=$$(<$$PID_FILE)
+            kill -TERM "$$PID" 2>/dev/null || true
+            for _ in $$(seq 5); do kill -0 "$$PID" 2>/dev/null || break; sleep 1; done
+            kill -KILL "$$PID" 2>/dev/null || true
+            rm -f $$PID_FILE
+          fi
+        done
+        # Safety-net.
+        pkill -u $USER -x mooncake_client 2>/dev/null || true
+        pkill -u $USER -x mooncake_master 2>/dev/null || true
+        true
+      '

--- a/scripts/report_network_gpu_topology.sh
+++ b/scripts/report_network_gpu_topology.sh
@@ -1,0 +1,763 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+have_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: report_network_gpu_topology.sh
+
+Generate a human-readable report about:
+- physical NICs and their drivers / PCI placement
+- RDMA devices and whether they are Ethernet RDMA or InfiniBand RDMA
+- GPUs, NUMA affinity, and local CPU affinity
+- NVIDIA GPU/NIC topology and NVLink visibility
+- a concise summary of likely intra-node and inter-node fabrics
+
+Notes:
+- virtual interfaces such as loopback / veth are omitted by default
+- the report is best-effort and degrades cleanly when rdma, ethtool, lspci,
+  or nvidia-smi are unavailable
+EOF
+}
+
+trim() {
+    local s="$*"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+join_by() {
+    local sep="$1"
+    shift || true
+    local first=1
+    local item
+    for item in "$@"; do
+        if (( first )); then
+            printf '%s' "$item"
+            first=0
+        else
+            printf '%s%s' "$sep" "$item"
+        fi
+    done
+}
+
+section() {
+    printf '\n== %s ==\n' "$1"
+}
+
+subsection() {
+    printf '\n[%s]\n' "$1"
+}
+
+read_first_line() {
+    local path="$1"
+    local line=""
+    if [[ -r "$path" ]]; then
+        IFS= read -r line < "$path" || true
+    fi
+    if [[ -z "$line" ]]; then
+        printf 'N/A'
+    else
+        printf '%s' "$line"
+    fi
+}
+
+normalize_bdf() {
+    local raw
+    raw=$(trim "$*")
+    if [[ -z "$raw" || "$raw" == "N/A" ]]; then
+        printf 'N/A'
+        return
+    fi
+    raw="${raw#00000000:}"
+    if [[ "$raw" =~ ^[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$ ]]; then
+        raw="0000:$raw"
+    fi
+    printf '%s' "$(printf '%s' "$raw" | tr 'A-F' 'a-f')"
+}
+
+pci_bdf_from_path() {
+    local path="$1"
+    local base=""
+    if [[ -n "$path" ]]; then
+        base=$(basename "$path")
+    fi
+    if [[ "$base" =~ ^[0-9A-Fa-f]{4}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$ ]]; then
+        normalize_bdf "$base"
+    else
+        printf 'N/A'
+    fi
+}
+
+device_numa() {
+    local bdf="$1"
+    local path="/sys/bus/pci/devices/$bdf/numa_node"
+    if [[ "$bdf" == "N/A" || ! -r "$path" ]]; then
+        printf 'N/A'
+        return
+    fi
+    read_first_line "$path"
+}
+
+device_cpulist() {
+    local bdf="$1"
+    local path="/sys/bus/pci/devices/$bdf/local_cpulist"
+    if [[ "$bdf" == "N/A" || ! -r "$path" ]]; then
+        printf 'N/A'
+        return
+    fi
+    read_first_line "$path"
+}
+
+pci_desc() {
+    local bdf="$1"
+    if ! have_cmd lspci || [[ "$bdf" == "N/A" ]]; then
+        printf 'N/A'
+        return
+    fi
+    local line
+    line=$(lspci -nn -s "$bdf" 2>/dev/null | sed 's/^[^ ]* //')
+    if [[ -z "$line" ]]; then
+        printf 'N/A'
+    else
+        printf '%s' "$line"
+    fi
+}
+
+netdev_driver() {
+    local dev="$1"
+    local driver=""
+    if have_cmd ethtool; then
+        driver=$(ethtool -i "$dev" 2>/dev/null | awk -F': ' '/^driver:/{print $2; exit}')
+    fi
+    if [[ -z "$driver" && -L "/sys/class/net/$dev/device/driver" ]]; then
+        driver=$(basename "$(readlink -f "/sys/class/net/$dev/device/driver")")
+    fi
+    if [[ -z "$driver" ]]; then
+        printf 'N/A'
+    else
+        printf '%s' "$driver"
+    fi
+}
+
+netdev_businfo() {
+    local dev="$1"
+    local bus=""
+    if have_cmd ethtool; then
+        bus=$(ethtool -i "$dev" 2>/dev/null | awk -F': ' '/^bus-info:/{print $2; exit}')
+    fi
+    if [[ -z "$bus" || "$bus" == "N/A" ]]; then
+        bus=$(pci_bdf_from_path "$(readlink -f "/sys/class/net/$dev/device" 2>/dev/null || true)")
+    fi
+    normalize_bdf "$bus"
+}
+
+netdev_addrs() {
+    local dev="$1"
+    local -a addrs=()
+    if have_cmd ip; then
+        mapfile -t addrs < <(ip -o addr show dev "$dev" 2>/dev/null | awk '$3 ~ /^(inet|inet6)$/ {print $4}')
+    fi
+    if (( ${#addrs[@]} == 0 )); then
+        printf '-'
+    else
+        join_by ', ' "${addrs[@]}"
+    fi
+}
+
+strip_numeric_prefix() {
+    local value="$1"
+    value=$(trim "$value")
+    printf '%s' "${value#*: }"
+}
+
+relation_rank() {
+    case "$1" in
+        X) printf '0' ;;
+        NV*) printf '0' ;;
+        PIX) printf '1' ;;
+        PXB) printf '2' ;;
+        PHB) printf '3' ;;
+        NODE) printf '4' ;;
+        SYS) printf '5' ;;
+        *) printf '99' ;;
+    esac
+}
+
+rdma_fabric_type() {
+    local rdma_dev="$1"
+    local link_layer="${RDMA_LINK_LAYER[$rdma_dev]:-N/A}"
+    if [[ "$link_layer" == "Ethernet" ]]; then
+        printf 'Ethernet RDMA (RoCE-family)'
+    elif [[ "$link_layer" == "InfiniBand" ]]; then
+        printf 'InfiniBand RDMA'
+    elif [[ "$link_layer" == "N/A" ]]; then
+        printf 'RDMA (link layer unavailable)'
+    else
+        printf 'RDMA over %s' "$link_layer"
+    fi
+}
+
+print_kv() {
+    printf '  %-15s %s\n' "$1" "$2"
+}
+
+declare -a NETDEVS_PHYS=()
+declare -i VIRTUAL_OMITTED=0
+declare -A NETDEV_STATE=()
+declare -A NETDEV_MTU=()
+declare -A NETDEV_MAC=()
+declare -A NETDEV_DRIVER=()
+declare -A NETDEV_BDF=()
+declare -A NETDEV_NUMA=()
+declare -A NETDEV_CPUS=()
+declare -A NETDEV_ADDRS=()
+declare -A NETDEV_DESC=()
+declare -A NETDEV_RDMA=()
+
+declare -a RDMA_DEVS=()
+declare -A RDMA_NETDEV=()
+declare -A RDMA_BDF=()
+declare -A RDMA_NUMA=()
+declare -A RDMA_CPUS=()
+declare -A RDMA_FW=()
+declare -A RDMA_HCA=()
+declare -A RDMA_LINK_LAYER=()
+declare -A RDMA_STATE=()
+declare -A RDMA_PHYS_STATE=()
+
+declare -a GPU_INDEXES=()
+declare -A GPU_BDF=()
+declare -A GPU_NAME=()
+declare -A GPU_UUID=()
+declare -A GPU_NUMA=()
+declare -A GPU_CPUS=()
+
+declare -a TOPO_COLS=()
+declare -a TOPO_GPU_KEYS=()
+declare -a TOPO_NIC_KEYS=()
+declare -A TOPO_ALIAS_TO_RDMA=()
+declare -A TOPO_RDMA_TO_ALIAS=()
+declare -A TOPO_REL=()
+TOPO_RAW=""
+
+collect_netdevs() {
+    local net_path dev resolved bdf
+    for net_path in /sys/class/net/*; do
+        dev=$(basename "$net_path")
+        resolved=$(readlink -f "$net_path" 2>/dev/null || true)
+        if [[ "$dev" == "lo" || "$resolved" == /sys/devices/virtual/* ]]; then
+            ((VIRTUAL_OMITTED += 1))
+            continue
+        fi
+
+        NETDEVS_PHYS+=("$dev")
+        NETDEV_STATE["$dev"]=$(read_first_line "/sys/class/net/$dev/operstate")
+        NETDEV_MTU["$dev"]=$(read_first_line "/sys/class/net/$dev/mtu")
+        NETDEV_MAC["$dev"]=$(read_first_line "/sys/class/net/$dev/address")
+        NETDEV_DRIVER["$dev"]=$(netdev_driver "$dev")
+        bdf=$(netdev_businfo "$dev")
+        NETDEV_BDF["$dev"]="$bdf"
+        NETDEV_NUMA["$dev"]=$(device_numa "$bdf")
+        NETDEV_CPUS["$dev"]=$(device_cpulist "$bdf")
+        NETDEV_ADDRS["$dev"]=$(netdev_addrs "$dev")
+        NETDEV_DESC["$dev"]=$(pci_desc "$bdf")
+    done
+
+    if (( ${#NETDEVS_PHYS[@]} > 0 )); then
+        mapfile -t NETDEVS_PHYS < <(printf '%s\n' "${NETDEVS_PHYS[@]}" | sort)
+    fi
+}
+
+collect_rdma() {
+    local rdma_out line dev netdev state phys_state rdma_path bdf
+
+    if have_cmd rdma; then
+        rdma_out=$(rdma link show 2>/dev/null || true)
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            if [[ "$line" =~ ^link[[:space:]]+([^/]+)/[0-9]+[[:space:]]+state[[:space:]]+([^[:space:]]+)[[:space:]]+physical_state[[:space:]]+([^[:space:]]+).*[[:space:]]netdev[[:space:]]+([^[:space:]]+) ]]; then
+                dev="${BASH_REMATCH[1]}"
+                state="${BASH_REMATCH[2]}"
+                phys_state="${BASH_REMATCH[3]}"
+                netdev="${BASH_REMATCH[4]}"
+                RDMA_NETDEV["$dev"]="$netdev"
+                RDMA_STATE["$dev"]="$state"
+                RDMA_PHYS_STATE["$dev"]="$phys_state"
+            fi
+        done <<< "$rdma_out"
+    fi
+
+    for rdma_path in /sys/class/infiniband/*; do
+        [[ -e "$rdma_path" ]] || continue
+        dev=$(basename "$rdma_path")
+        RDMA_DEVS+=("$dev")
+        bdf=$(pci_bdf_from_path "$(readlink -f "$rdma_path/device" 2>/dev/null || true)")
+        RDMA_BDF["$dev"]="$bdf"
+        RDMA_NUMA["$dev"]=$(device_numa "$bdf")
+        RDMA_CPUS["$dev"]=$(device_cpulist "$bdf")
+        RDMA_FW["$dev"]=$(read_first_line "$rdma_path/fw_ver")
+        RDMA_HCA["$dev"]=$(read_first_line "$rdma_path/hca_type")
+        RDMA_LINK_LAYER["$dev"]=$(read_first_line "$rdma_path/ports/1/link_layer")
+
+        if [[ -z "${RDMA_STATE[$dev]:-}" ]]; then
+            RDMA_STATE["$dev"]=$(strip_numeric_prefix "$(read_first_line "$rdma_path/ports/1/state")")
+        fi
+        if [[ -z "${RDMA_PHYS_STATE[$dev]:-}" ]]; then
+            RDMA_PHYS_STATE["$dev"]=$(strip_numeric_prefix "$(read_first_line "$rdma_path/ports/1/phys_state")")
+        fi
+
+        if [[ -z "${RDMA_NETDEV[$dev]:-}" ]]; then
+            local candidate
+            for candidate in "${NETDEVS_PHYS[@]}"; do
+                if [[ -e "/sys/class/net/$candidate/device/infiniband/$dev" ]]; then
+                    RDMA_NETDEV["$dev"]="$candidate"
+                    break
+                fi
+            done
+        fi
+    done
+
+    if (( ${#RDMA_DEVS[@]} > 0 )); then
+        mapfile -t RDMA_DEVS < <(printf '%s\n' "${RDMA_DEVS[@]}" | sort)
+    fi
+
+    local rdma_dev
+    for rdma_dev in "${RDMA_DEVS[@]}"; do
+        netdev="${RDMA_NETDEV[$rdma_dev]:-}"
+        if [[ -n "$netdev" ]]; then
+            if [[ -n "${NETDEV_RDMA[$netdev]:-}" ]]; then
+                NETDEV_RDMA["$netdev"]+=",${rdma_dev}"
+            else
+                NETDEV_RDMA["$netdev"]="$rdma_dev"
+            fi
+        fi
+    done
+}
+
+collect_gpus() {
+    local line idx bdf name uuid
+    if ! have_cmd nvidia-smi; then
+        return
+    fi
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        IFS=',' read -r idx bdf name uuid <<< "$line"
+        idx=$(trim "$idx")
+        bdf=$(normalize_bdf "$bdf")
+        name=$(trim "$name")
+        uuid=$(trim "$uuid")
+        GPU_INDEXES+=("$idx")
+        GPU_BDF["$idx"]="$bdf"
+        GPU_NAME["$idx"]="$name"
+        GPU_UUID["$idx"]="$uuid"
+        GPU_NUMA["$idx"]=$(device_numa "$bdf")
+        GPU_CPUS["$idx"]=$(device_cpulist "$bdf")
+    done < <(nvidia-smi --query-gpu=index,pci.bus_id,name,uuid --format=csv,noheader 2>/dev/null || true)
+}
+
+parse_topology() {
+    local topo_clean parsed line idx col alias rdma_dev row col_idx rel
+    if ! have_cmd nvidia-smi; then
+        return
+    fi
+
+    topo_clean=$(nvidia-smi topo -m 2>/dev/null | sed -r 's/\x1B\[[0-9;]*[A-Za-z]//g' || true)
+    if [[ -z "$topo_clean" ]]; then
+        return
+    fi
+    TOPO_RAW="$topo_clean"
+
+    parsed=$(printf '%s\n' "$topo_clean" | awk -F'\t' '
+        function trim(s) {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+            return s
+        }
+        NR == 1 {
+            n = 0
+            for (i = 1; i <= NF; i++) {
+                f = trim($i)
+                if (f ~ /^(GPU[0-9]+|NIC[0-9]+)$/) {
+                    cols[++n] = f
+                }
+            }
+            print "COUNT", n
+            for (i = 1; i <= n; i++) {
+                print "COL", i, cols[i]
+            }
+            next
+        }
+        /^NIC Legend:/ {
+            legend = 1
+            next
+        }
+        legend {
+            line = $0
+            if (line ~ /^[[:space:]]*NIC[0-9]+:[[:space:]]*/) {
+                sub(/^[[:space:]]*/, "", line)
+                split(line, a, /:[[:space:]]*/)
+                print "ALIAS", a[1], a[2]
+            }
+        }
+        {
+            row = trim($1)
+            if (row ~ /^(GPU[0-9]+|NIC[0-9]+)$/) {
+                printf "ROW %s", row
+                out = 0
+                for (i = 2; i <= NF && out < n; i++) {
+                    f = trim($i)
+                    if (f == "") {
+                        continue
+                    }
+                    printf " %s", f
+                    out++
+                }
+                print ""
+            }
+        }')
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        set -- $line
+        case "$1" in
+            COUNT)
+                ;;
+            COL)
+                idx="$2"
+                col="$3"
+                TOPO_COLS[$((idx - 1))]="$col"
+                if [[ "$col" == GPU* ]]; then
+                    TOPO_GPU_KEYS+=("$col")
+                elif [[ "$col" == NIC* ]]; then
+                    TOPO_NIC_KEYS+=("$col")
+                fi
+                ;;
+            ALIAS)
+                alias="$2"
+                rdma_dev="$3"
+                TOPO_ALIAS_TO_RDMA["$alias"]="$rdma_dev"
+                TOPO_RDMA_TO_ALIAS["$rdma_dev"]="$alias"
+                ;;
+            ROW)
+                row="$2"
+                shift 2
+                col_idx=0
+                for rel in "$@"; do
+                    if (( col_idx < ${#TOPO_COLS[@]} )); then
+                        col="${TOPO_COLS[$col_idx]}"
+                        TOPO_REL["$row|$col"]="$rel"
+                    fi
+                    ((col_idx += 1))
+                done
+                ;;
+        esac
+    done <<< "$parsed"
+}
+
+best_nics_for_gpu() {
+    local gpu_key="$1"
+    local best_rank=999
+    local -a matches=()
+    local alias rdma_dev netdev rel rank
+
+    for alias in "${TOPO_NIC_KEYS[@]}"; do
+        rel="${TOPO_REL[$gpu_key|$alias]:-}"
+        [[ -z "$rel" || "$rel" == "X" ]] && continue
+        rank=$(relation_rank "$rel")
+        if (( rank < best_rank )); then
+            best_rank=$rank
+            matches=()
+        fi
+        if (( rank == best_rank )); then
+            rdma_dev="${TOPO_ALIAS_TO_RDMA[$alias]:-$alias}"
+            netdev="${RDMA_NETDEV[$rdma_dev]:-unknown-netdev}"
+            matches+=("${netdev} (${rdma_dev}, ${rel})")
+        fi
+    done
+
+    if (( ${#matches[@]} == 0 )); then
+        printf 'N/A'
+    else
+        join_by '; ' "${matches[@]}"
+    fi
+}
+
+best_gpus_for_alias() {
+    local alias="$1"
+    local best_rank=999
+    local -a matches=()
+    local gpu_key rel rank
+
+    for gpu_key in "${TOPO_GPU_KEYS[@]}"; do
+        rel="${TOPO_REL[$alias|$gpu_key]:-}"
+        [[ -z "$rel" || "$rel" == "X" ]] && continue
+        rank=$(relation_rank "$rel")
+        if (( rank < best_rank )); then
+            best_rank=$rank
+            matches=()
+        fi
+        if (( rank == best_rank )); then
+            matches+=("${gpu_key} (${rel})")
+        fi
+    done
+
+    if (( ${#matches[@]} == 0 )); then
+        printf 'N/A'
+    else
+        join_by '; ' "${matches[@]}"
+    fi
+}
+
+nvlink_summary() {
+    local i j a b rel total_pairs=0 nv_pairs=0
+    local -a pairs=()
+    for ((i = 0; i < ${#TOPO_GPU_KEYS[@]}; i++)); do
+        for ((j = i + 1; j < ${#TOPO_GPU_KEYS[@]}; j++)); do
+            a="${TOPO_GPU_KEYS[$i]}"
+            b="${TOPO_GPU_KEYS[$j]}"
+            rel="${TOPO_REL[$a|$b]:-}"
+            ((total_pairs += 1))
+            if [[ "$rel" == NV* ]]; then
+                ((nv_pairs += 1))
+                pairs+=("${a}<->${b} (${rel})")
+            fi
+        done
+    done
+
+    if (( total_pairs == 0 )); then
+        printf 'No multi-GPU topology available'
+    elif (( nv_pairs == 0 )); then
+        printf 'No NVLink relationships reported across %d GPU pairs' "$total_pairs"
+    elif (( nv_pairs == total_pairs )); then
+        printf 'NVLink reported on all %d GPU pairs: %s' \
+            "$total_pairs" "$(join_by '; ' "${pairs[@]}")"
+    else
+        printf 'NVLink reported on %d/%d GPU pairs: %s' \
+            "$nv_pairs" "$total_pairs" "$(join_by '; ' "${pairs[@]}")"
+    fi
+}
+
+emit_host_summary() {
+    section "Host Summary"
+    print_kv "hostname" "$(hostname 2>/dev/null || echo N/A)"
+    print_kv "kernel" "$(uname -r 2>/dev/null || echo N/A)"
+    print_kv "arch" "$(uname -m 2>/dev/null || echo N/A)"
+    print_kv "date_utc" "$(date -u '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || echo N/A)"
+}
+
+emit_netdev_inventory() {
+    section "Physical NIC Inventory"
+    if (( ${#NETDEVS_PHYS[@]} == 0 )); then
+        printf 'No physical netdevs found.\n'
+        return
+    fi
+
+    local dev rdma_info kind rdma_dev rdma_types
+    for dev in "${NETDEVS_PHYS[@]}"; do
+        subsection "$dev"
+        if [[ -n "${NETDEV_RDMA[$dev]:-}" ]]; then
+            kind="RDMA-capable Ethernet NIC"
+            IFS=',' read -r -a rdma_types <<< "${NETDEV_RDMA[$dev]}"
+            local -a rdma_parts=()
+            for rdma_dev in "${rdma_types[@]}"; do
+                rdma_parts+=("${rdma_dev} [$(rdma_fabric_type "$rdma_dev"); state=${RDMA_STATE[$rdma_dev]:-N/A}/${RDMA_PHYS_STATE[$rdma_dev]:-N/A}]")
+            done
+            rdma_info=$(join_by '; ' "${rdma_parts[@]}")
+        else
+            kind="Regular Ethernet NIC"
+            rdma_info="no"
+        fi
+        print_kv "type" "$kind"
+        print_kv "driver" "${NETDEV_DRIVER[$dev]}"
+        print_kv "pci_bdf" "${NETDEV_BDF[$dev]}"
+        print_kv "pci_desc" "${NETDEV_DESC[$dev]}"
+        print_kv "state" "${NETDEV_STATE[$dev]}"
+        print_kv "mac" "${NETDEV_MAC[$dev]}"
+        print_kv "ips" "${NETDEV_ADDRS[$dev]}"
+        print_kv "mtu" "${NETDEV_MTU[$dev]}"
+        print_kv "numa" "${NETDEV_NUMA[$dev]}"
+        print_kv "local_cpus" "${NETDEV_CPUS[$dev]}"
+        print_kv "rdma" "$rdma_info"
+    done
+
+    if (( VIRTUAL_OMITTED > 0 )); then
+        printf '\nVirtual-only interfaces omitted: %d\n' "$VIRTUAL_OMITTED"
+    fi
+}
+
+emit_rdma_inventory() {
+    section "RDMA Inventory"
+    if (( ${#RDMA_DEVS[@]} == 0 )); then
+        printf 'No RDMA devices found.\n'
+        return
+    fi
+
+    local dev
+    for dev in "${RDMA_DEVS[@]}"; do
+        subsection "$dev"
+        print_kv "netdev" "${RDMA_NETDEV[$dev]:-N/A}"
+        print_kv "rdma_fabric" "$(rdma_fabric_type "$dev")"
+        print_kv "link_layer" "${RDMA_LINK_LAYER[$dev]}"
+        print_kv "state" "${RDMA_STATE[$dev]:-N/A}"
+        print_kv "phys_state" "${RDMA_PHYS_STATE[$dev]:-N/A}"
+        print_kv "pci_bdf" "${RDMA_BDF[$dev]}"
+        print_kv "pci_desc" "$(pci_desc "${RDMA_BDF[$dev]}")"
+        print_kv "firmware" "${RDMA_FW[$dev]}"
+        print_kv "hca_type" "${RDMA_HCA[$dev]}"
+        print_kv "numa" "${RDMA_NUMA[$dev]}"
+        print_kv "local_cpus" "${RDMA_CPUS[$dev]}"
+    done
+}
+
+emit_gpu_inventory() {
+    section "GPU Inventory"
+    if (( ${#GPU_INDEXES[@]} == 0 )); then
+        printf 'No NVIDIA GPUs found or nvidia-smi unavailable.\n'
+        return
+    fi
+
+    local idx
+    for idx in "${GPU_INDEXES[@]}"; do
+        subsection "GPU$idx"
+        print_kv "name" "${GPU_NAME[$idx]}"
+        print_kv "uuid" "${GPU_UUID[$idx]}"
+        print_kv "pci_bdf" "${GPU_BDF[$idx]}"
+        print_kv "numa" "${GPU_NUMA[$idx]}"
+        print_kv "local_cpus" "${GPU_CPUS[$idx]}"
+    done
+}
+
+emit_topology_matrix() {
+    section "NVIDIA Topology Matrix"
+    if [[ -z "$TOPO_RAW" ]]; then
+        printf 'nvidia-smi topo -m unavailable.\n'
+        return
+    fi
+    printf '%s\n' "$TOPO_RAW"
+}
+
+emit_affinity_summary() {
+    section "Derived GPU / NIC Affinity"
+    if [[ -z "$TOPO_RAW" || ${#TOPO_NIC_KEYS[@]} -eq 0 || ${#TOPO_GPU_KEYS[@]} -eq 0 ]]; then
+        printf 'Detailed GPU/NIC topology unavailable.\n'
+        return
+    fi
+
+    local idx alias rdma_dev netdev
+
+    printf 'Closest RDMA NICs per GPU:\n'
+    for idx in "${GPU_INDEXES[@]}"; do
+        printf '  GPU%s -> %s\n' "$idx" "$(best_nics_for_gpu "GPU$idx")"
+    done
+
+    printf '\nClosest GPUs per RDMA NIC:\n'
+    for alias in "${TOPO_NIC_KEYS[@]}"; do
+        rdma_dev="${TOPO_ALIAS_TO_RDMA[$alias]:-$alias}"
+        netdev="${RDMA_NETDEV[$rdma_dev]:-unknown-netdev}"
+        printf '  %s / %s -> %s\n' "$netdev" "$rdma_dev" "$(best_gpus_for_alias "$alias")"
+    done
+
+    printf '\nNVLink summary:\n'
+    printf '  %s\n' "$(nvlink_summary)"
+}
+
+emit_final_summary() {
+    section "Final Summary"
+
+    local -a regular_nics=()
+    local -a rdma_nics=()
+    local dev rdma_dev alias summary_line
+
+    for dev in "${NETDEVS_PHYS[@]}"; do
+        if [[ -n "${NETDEV_RDMA[$dev]:-}" ]]; then
+            rdma_nics+=("$dev")
+        else
+            regular_nics+=("$dev")
+        fi
+    done
+
+    if (( ${#regular_nics[@]} > 0 )); then
+        printf 'Regular Ethernet NICs: %s\n' "$(join_by ', ' "${regular_nics[@]}")"
+    else
+        printf 'Regular Ethernet NICs: none\n'
+    fi
+
+    if (( ${#rdma_nics[@]} > 0 )); then
+        local -a rdma_lines=()
+        for dev in "${rdma_nics[@]}"; do
+            IFS=',' read -r -a aliases <<< "${NETDEV_RDMA[$dev]}"
+            local -a nic_parts=()
+            for rdma_dev in "${aliases[@]}"; do
+                nic_parts+=("${rdma_dev} ($(rdma_fabric_type "$rdma_dev"))")
+            done
+            rdma_lines+=("${dev}: $(join_by '; ' "${nic_parts[@]}")")
+        done
+        printf 'RDMA NICs for inter-node traffic: %s\n' "$(join_by ' | ' "${rdma_lines[@]}")"
+    else
+        printf 'RDMA NICs for inter-node traffic: none\n'
+    fi
+
+    if [[ -n "$TOPO_RAW" && ${#TOPO_GPU_KEYS[@]} -gt 1 ]]; then
+        printf 'Intra-node GPU fabric: %s\n' "$(nvlink_summary)"
+    elif (( ${#GPU_INDEXES[@]} > 1 )); then
+        printf 'Intra-node GPU fabric: multiple GPUs detected, but NVLink topology is unavailable\n'
+    else
+        printf 'Intra-node GPU fabric: not applicable\n'
+    fi
+
+    if [[ -n "$TOPO_RAW" && ${#TOPO_NIC_KEYS[@]} -gt 0 ]]; then
+        printf 'Best GPU to RDMA-NIC pairings:\n'
+        local idx
+        for idx in "${GPU_INDEXES[@]}"; do
+            summary_line=$(best_nics_for_gpu "GPU$idx")
+            printf '  GPU%s -> %s\n' "$idx" "$summary_line"
+        done
+    elif (( ${#GPU_INDEXES[@]} > 0 && ${#RDMA_DEVS[@]} > 0 )); then
+        printf 'Best GPU to RDMA-NIC pairings: topology matrix unavailable; use shared NUMA node as first approximation\n'
+    else
+        printf 'Best GPU to RDMA-NIC pairings: not applicable\n'
+    fi
+
+    printf '\nInterpretation:\n'
+    printf '  - NVLink is an intra-node GPU fabric. NICs themselves are not NVLink devices.\n'
+    printf '  - RDMA NICs are the inter-node data path when GPUDirect RDMA / NCCL / UCX use the network.\n'
+    printf '  - The topology matrix shows proximity, not proof that a live workload is using GDRDMA.\n'
+}
+
+main() {
+    if (( $# > 0 )); then
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                printf 'Unknown argument: %s\n\n' "$1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+    fi
+
+    collect_netdevs
+    collect_rdma
+    collect_gpus
+    parse_topology
+
+    emit_host_summary
+    emit_netdev_inventory
+    emit_rdma_inventory
+    emit_gpu_inventory
+    emit_topology_matrix
+    emit_affinity_summary
+    emit_final_summary
+}
+
+main "$@"

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -9,10 +9,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
-    connector,
-    worker,
+    connector as mooncake_store_connector,
+    worker as mooncake_store_worker,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     MooncakeStoreConnectorMetadata,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -53,15 +53,17 @@ def test_scheduler_role_initializes_store_scheduler_only():
             "connector.MooncakeStoreWorker"
         ) as mock_worker,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.SCHEDULER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
 
     mock_scheduler.assert_called_once_with(vllm_config)
     mock_worker.assert_not_called()
-    assert conn.connector_scheduler is mock_scheduler.return_value
-    assert conn.connector_worker is None
+    assert connector.connector_scheduler is mock_scheduler.return_value
+    assert connector.connector_worker is None
 
 
-def test_worker_role_initializes_store_worker_on_rank0():
+def test_worker_role_initializes_store_worker():
     vllm_config = _make_vllm_config()
 
     with (
@@ -75,12 +77,14 @@ def test_worker_role_initializes_store_worker_on_rank0():
             "connector.MooncakeStoreWorker"
         ) as mock_worker,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
     mock_scheduler.assert_not_called()
     mock_worker.assert_called_once_with(vllm_config)
-    assert conn.connector_scheduler is None
-    assert conn.connector_worker is mock_worker.return_value
+    assert connector.connector_scheduler is None
+    assert connector.connector_worker is mock_worker.return_value
 
 
 def test_worker_role_initializes_on_nonzero_rank():
@@ -94,7 +98,9 @@ def test_worker_role_initializes_on_nonzero_rank():
             "connector.MooncakeStoreWorker"
         ) as mock_worker,
     ):
-        connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
     mock_worker.assert_called_once_with(vllm_config)
 
@@ -104,9 +110,14 @@ def test_lookup_rpc_path_uses_data_parallel_index_in_dense_dp():
     vllm_config.parallel_config.data_parallel_rank = 0
     vllm_config.parallel_config.data_parallel_index = 3
 
-    path = worker.get_zmq_rpc_path_lookup(vllm_config)
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+        "worker.socket.gethostname",
+        return_value="node-a",
+    ):
+        path = mooncake_store_worker.get_zmq_rpc_path_lookup(vllm_config)
 
-    assert path.endswith("_dp_rank3")
+    assert path.endswith("_host_node-a_dp_rank3")
 
 
 def test_lookup_rpc_path_uses_local_rank_when_local_engines_only():
@@ -115,9 +126,14 @@ def test_lookup_rpc_path_uses_local_rank_when_local_engines_only():
     vllm_config.parallel_config.data_parallel_rank_local = 1
     vllm_config.parallel_config.data_parallel_hybrid_lb = True
 
-    path = worker.get_zmq_rpc_path_lookup(vllm_config)
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+        "worker.socket.gethostname",
+        return_value="node-b",
+    ):
+        path = mooncake_store_worker.get_zmq_rpc_path_lookup(vllm_config)
 
-    assert path.endswith("_dp_rank1")
+    assert path.endswith("_host_node-b_dp_rank1")
 
 
 def test_worker_methods_delegate_to_store_worker():
@@ -133,17 +149,19 @@ def test_worker_methods_delegate_to_store_worker():
             "connector.MooncakeStoreWorker"
         ) as mock_worker_cls,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
-    worker_inst = mock_worker_cls.return_value
-    worker_inst.get_finished.return_value = ({"req-1"}, {"req-2"})
-    conn.bind_connector_metadata(metadata)
+    worker = mock_worker_cls.return_value
+    worker.get_finished.return_value = ({"req-1"}, {"req-2"})
+    connector.bind_connector_metadata(metadata)
 
-    conn.register_kv_caches(kv_caches)
-    result = conn.get_finished(finished_req_ids)
+    connector.register_kv_caches(kv_caches)
+    result = connector.get_finished(finished_req_ids)
 
-    worker_inst.register_kv_caches.assert_called_once_with(kv_caches)
-    worker_inst.get_finished.assert_called_once_with(finished_req_ids, metadata)
+    worker.register_kv_caches.assert_called_once_with(kv_caches)
+    worker.get_finished.assert_called_once_with(finished_req_ids, metadata)
     assert result == ({"req-1"}, {"req-2"})
 
 
@@ -157,10 +175,12 @@ def test_get_kv_connector_kv_cache_events_returns_none_when_empty():
             "connector.MooncakeStoreWorker"
         ) as mock_worker_cls,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
     mock_worker_cls.return_value.get_kv_events.return_value = []
-    assert conn.get_kv_connector_kv_cache_events() is None
+    assert connector.get_kv_connector_kv_cache_events() is None
 
 
 def test_get_kv_connector_kv_cache_events_wraps_worker_events():
@@ -174,12 +194,14 @@ def test_get_kv_connector_kv_cache_events_wraps_worker_events():
             "connector.MooncakeStoreWorker"
         ) as mock_worker_cls,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
     mock_worker_cls.return_value.get_kv_events.return_value = [event]
-    kv_events = conn.get_kv_connector_kv_cache_events()
+    kv_events = connector.get_kv_connector_kv_cache_events()
 
-    assert isinstance(kv_events, connector.MooncakeStoreKVEvents)
+    assert isinstance(kv_events, mooncake_store_connector.MooncakeStoreKVEvents)
     assert kv_events.get_number_of_workers() == 1
     assert kv_events.get_all_events() == [event]
 
@@ -194,8 +216,10 @@ def test_prefer_cross_layer_blocks_from_config():
             "connector.MooncakeStoreScheduler"
         ),
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.SCHEDULER)
-    assert conn.prefer_cross_layer_blocks is False
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
+    assert connector.prefer_cross_layer_blocks is False
 
     # Enabled via config
     vllm_config_enabled = create_vllm_config(
@@ -210,10 +234,10 @@ def test_prefer_cross_layer_blocks_from_config():
             "connector.MooncakeStoreScheduler"
         ),
     ):
-        conn_enabled = connector.MooncakeStoreConnector(
+        connector_enabled = mooncake_store_connector.MooncakeStoreConnector(
             vllm_config_enabled, KVConnectorRole.SCHEDULER
         )
-    assert conn_enabled.prefer_cross_layer_blocks is True
+    assert connector_enabled.prefer_cross_layer_blocks is True
 
 
 def test_register_cross_layers_kv_cache_delegates_to_worker():
@@ -226,14 +250,16 @@ def test_register_cross_layers_kv_cache_delegates_to_worker():
             "connector.MooncakeStoreWorker"
         ) as mock_worker_cls,
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.WORKER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.WORKER
+        )
 
     fake_tensor = MagicMock()
     fake_backend = MagicMock()
-    conn.register_cross_layers_kv_cache(fake_tensor, fake_backend)
+    connector.register_cross_layers_kv_cache(fake_tensor, fake_backend)
 
-    worker_inst = mock_worker_cls.return_value
-    worker_inst.register_cross_layers_kv_caches.assert_called_once_with(fake_tensor)
+    worker = mock_worker_cls.return_value
+    worker.register_cross_layers_kv_caches.assert_called_once_with(fake_tensor)
 
 
 def test_update_connector_output_and_take_events():
@@ -247,12 +273,14 @@ def test_update_connector_output_and_take_events():
             "connector.MooncakeStoreScheduler"
         ),
     ):
-        conn = connector.MooncakeStoreConnector(vllm_config, KVConnectorRole.SCHEDULER)
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER
+        )
 
-    kv_events = connector.MooncakeStoreKVEvents(num_workers=1)
+    kv_events = mooncake_store_connector.MooncakeStoreKVEvents(num_workers=1)
     kv_events.add_events([event])
-    conn.update_connector_output(KVConnectorOutput(kv_cache_events=kv_events))
+    connector.update_connector_output(KVConnectorOutput(kv_cache_events=kv_events))
 
-    assert conn._kv_cache_events is kv_events
-    assert list(conn.take_events()) == [event]
-    assert conn._kv_cache_events is None
+    assert connector._kv_cache_events is kv_events
+    assert list(connector.take_events()) == [event]
+    assert connector._kv_cache_events is None

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1,30 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+import logging
+import math
+import sys
 import threading
+import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
-    worker,
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
+    rdma_utils,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+    worker as mooncake_store_worker,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
+    LoadSpec,
     ReqMeta,
 )
 
 
 def _make_store_sending_thread(
     store: MagicMock,
-) -> worker.KVCacheStoreSendingThread:
+    *,
+    replicate_config: object | None = None,
+) -> mooncake_store_worker.KVCacheStoreSendingThread:
     token_database = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
     )
     token_database.set_kv_caches_base_addr([0x1000])
     token_database.set_block_len([256])
-    thread = worker.KVCacheStoreSendingThread(
+    thread = mooncake_store_worker.KVCacheStoreSendingThread(
         store=store,
         token_database=token_database,
         block_size=16,
@@ -32,9 +45,53 @@ def _make_store_sending_thread(
         put_step=1,
         kv_role="kv_producer",
         ready_event=threading.Event(),
+        replicate_config=replicate_config,
     )
     thread.request_queue.task_done = MagicMock()
     return thread
+
+
+def _make_store_recving_thread(
+    store: MagicMock,
+    *,
+    disk_offload_buffer_budget_bytes: int | None = None,
+) -> mooncake_store_worker.KVCacheStoreRecvingThread:
+    token_database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0), block_size=16
+    )
+    token_database.set_kv_caches_base_addr([0x1000])
+    token_database.set_block_len([256])
+    thread = mooncake_store_worker.KVCacheStoreRecvingThread(
+        store=store,
+        token_database=token_database,
+        block_size=16,
+        tp_rank=0,
+        ready_event=threading.Event(),
+        disk_offload_buffer_budget_bytes=disk_offload_buffer_budget_bytes,
+    )
+    thread.request_queue.task_done = MagicMock()
+    return thread
+
+
+def _make_load_req(
+    req_id: str,
+    block_hashes: list[bytes],
+    *,
+    token_len: int,
+    vllm_cached_tokens: int = 0,
+) -> ReqMeta:
+    return ReqMeta(
+        req_id=req_id,
+        token_len_chunk=token_len,
+        block_ids=list(range(len(block_hashes))),
+        block_hashes=block_hashes,
+        load_spec=LoadSpec(
+            vllm_cached_tokens=vllm_cached_tokens,
+            kvpool_cached_tokens=token_len,
+            can_load=True,
+            token_len=token_len,
+        ),
+    )
 
 
 def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
@@ -46,6 +103,308 @@ def _make_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMeta:
         can_save=True,
         original_block_size=16,
     )
+
+
+_DISK_OFFLOAD_SINGLE_KEY_BYTES = (
+    mooncake_store_worker._estimate_disk_offload_staging_bytes([256])
+)
+_DISK_OFFLOAD_USABLE_BUDGET_RATIO = 0.9
+_DISK_OFFLOAD_BUDGET_FOR_THREE_KEYS = 4 * _DISK_OFFLOAD_SINGLE_KEY_BYTES
+_DISK_OFFLOAD_BUDGET_FOR_SPLIT = math.ceil(
+    2 * _DISK_OFFLOAD_SINGLE_KEY_BYTES / _DISK_OFFLOAD_USABLE_BUDGET_RATIO
+)  # Allows two 256-byte chunks but not the third.
+_DISK_OFFLOAD_BUDGET_TOO_SMALL = (
+    _DISK_OFFLOAD_SINGLE_KEY_BYTES - 1
+)  # Smaller than a single 256-byte chunk.
+
+
+class _FakeKVTransferConfig:
+    def __init__(
+        self,
+        *,
+        kv_role: str = "kv_both",
+        extra_config: dict[str, object] | None = None,
+    ) -> None:
+        self.kv_role = kv_role
+        self.kv_connector_extra_config = extra_config or {}
+
+    def get_from_extra_config(self, key: str, default: object) -> object:
+        return self.kv_connector_extra_config.get(key, default)
+
+
+class _FakeModelConfig:
+    model = "test-model"
+    use_mla = False
+
+    def get_num_layers(self, parallel_config) -> int:
+        return 1
+
+    def get_total_num_kv_heads(self) -> int:
+        return 1
+
+
+def _make_vllm_config(
+    *, extra_config: dict[str, object] | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=_FakeModelConfig(),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1,
+            rank=0,
+        ),
+        kv_transfer_config=_FakeKVTransferConfig(extra_config=extra_config),
+        cache_config=SimpleNamespace(block_size=16, num_gpu_blocks=10),
+        kv_events_config=SimpleNamespace(enable_kv_cache_events=False),
+    )
+
+
+def _write_mooncake_config(tmp_path, config: dict[str, object]) -> str:
+    config_path = tmp_path / "mooncake_config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    return str(config_path)
+
+
+def _install_fake_mooncake(monkeypatch, store_instance: MagicMock):
+    class FakeReplicateConfig:
+        def __init__(self) -> None:
+            self.preferred_segment = ""
+
+    fake_store_module = types.ModuleType("mooncake.store")
+    fake_store_module.MooncakeDistributedStore = lambda: store_instance  # type: ignore[attr-defined]
+    fake_store_module.ReplicateConfig = FakeReplicateConfig  # type: ignore[attr-defined]
+    fake_mooncake_module = types.ModuleType("mooncake")
+    fake_mooncake_module.store = fake_store_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mooncake", fake_mooncake_module)
+    monkeypatch.setitem(sys.modules, "mooncake.store", fake_store_module)
+    return FakeReplicateConfig
+
+
+def _patch_worker_runtime(monkeypatch, *, local_ip: str = "10.0.0.7") -> None:
+    single_rank_group = SimpleNamespace(world_size=1, rank_in_group=0)
+    monkeypatch.setattr(
+        mooncake_store_worker, "get_mooncake_dp_engine_index", lambda _: 0
+    )
+    monkeypatch.setattr(
+        mooncake_store_worker, "get_tensor_model_parallel_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        mooncake_store_worker, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(
+        mooncake_store_worker, "get_pcp_group", lambda: single_rank_group
+    )
+    monkeypatch.setattr(
+        mooncake_store_worker, "get_dcp_group", lambda: single_rank_group
+    )
+    monkeypatch.setattr(mooncake_store_worker, "get_ip", lambda: local_ip)
+
+
+def test_default_local_buffer_size_matches_pr40900():
+    """PR-40900 shipped a 4 GiB default for local_buffer_size; the dual-mode
+    patch preserves it (and the JSON key) so unchanged PR-40900 configs work."""
+    assert mooncake_store_worker.DEFAULT_LOCAL_BUFFER_SIZE == 4 * 1024**3
+
+
+def test_get_requester_local_hostname_prefers_override(monkeypatch):
+    monkeypatch.setenv("MOONCAKE_LOCAL_HOSTNAME", "worker-a:50053")
+
+    assert rdma_utils.get_requester_local_hostname("10.0.0.7") == "worker-a:50053"
+
+
+def test_get_configured_preferred_segment_returns_explicit_override():
+    assert (
+        rdma_utils.get_configured_preferred_segment(
+            {"preferred_segment": "10.0.0.7:50053"}
+        )
+        == "10.0.0.7:50053"
+    )
+
+
+def test_get_configured_preferred_segment_prefers_explicit_over_env(monkeypatch):
+    monkeypatch.setenv("MOONCAKE_PREFERRED_SEGMENT", "10.0.0.8:50053")
+
+    assert (
+        rdma_utils.get_configured_preferred_segment(
+            {"preferred_segment": "10.0.0.7:50053"}
+        )
+        == "10.0.0.7:50053"
+    )
+
+
+def test_get_configured_preferred_segment_returns_env_override(monkeypatch):
+    monkeypatch.setenv("MOONCAKE_PREFERRED_SEGMENT", "10.0.0.8:50053")
+
+    assert rdma_utils.get_configured_preferred_segment({}) == "10.0.0.8:50053"
+
+
+def test_get_configured_preferred_segment_rejects_empty_override():
+    with pytest.raises(ValueError, match="preferred_segment"):
+        rdma_utils.get_configured_preferred_segment({"preferred_segment": "  "})
+
+
+def test_get_configured_worker_rnic_prefers_explicit_device_name(monkeypatch):
+    store_config = mooncake_store_worker.MooncakeStoreConfig(
+        metadata_server="",
+        local_buffer_size=1,
+        protocol="rdma",
+        device_name="rocep139s0",
+        master_server_address="",
+    )
+
+    assert (
+        rdma_utils.get_configured_worker_rnic(
+            protocol=store_config.protocol,
+            configured_device=store_config.device_name,
+        )
+        == "rocep139s0"
+    )
+
+
+def test_get_configured_worker_rnic_selects_device_from_explicit_csv(monkeypatch):
+    monkeypatch.setattr(
+        rdma_utils,
+        "get_current_physical_gpu_index",
+        lambda: 1,
+    )
+    store_config = mooncake_store_worker.MooncakeStoreConfig(
+        metadata_server="",
+        local_buffer_size=1,
+        protocol="rdma",
+        device_name="rocep139s0,rocep140s0",
+        master_server_address="",
+    )
+
+    assert (
+        rdma_utils.get_configured_worker_rnic(
+            protocol=store_config.protocol,
+            configured_device=store_config.device_name,
+        )
+        == "rocep140s0"
+    )
+
+
+def test_get_configured_worker_rnic_falls_back_to_mooncake(monkeypatch):
+    """When no CSV is given AND auto-discovery cannot map the local GPU,
+    fall back to Mooncake's own auto-selection (returns "")."""
+    store_config = mooncake_store_worker.MooncakeStoreConfig(
+        metadata_server="",
+        local_buffer_size=1,
+        protocol="rdma",
+        device_name="",
+        master_server_address="",
+    )
+    # Force auto-discovery to fail (no GPU/RNIC mapping).
+    monkeypatch.setattr(rdma_utils, "_autodiscover_worker_rnic", lambda: "")
+
+    assert (
+        rdma_utils.get_configured_worker_rnic(
+            protocol=store_config.protocol,
+            configured_device=store_config.device_name,
+        )
+        == ""
+    )
+
+
+def test_get_configured_worker_rnic_uses_python_autodiscovery(monkeypatch):
+    """When no CSV is given but auto-discovery returns a mapping, use it."""
+    monkeypatch.setattr(rdma_utils, "_autodiscover_worker_rnic", lambda: "rocep139s0")
+    assert (
+        rdma_utils.get_configured_worker_rnic(
+            protocol="rdma",
+            configured_device="",
+        )
+        == "rocep139s0"
+    )
+
+
+def test_autodiscover_worker_rnic_picks_per_gpu(monkeypatch):
+    """The 3-phase assignment maps each GPU to its PCI-affine RNIC, using
+    netdev-name exact match (gpu<N>rdma<M>) as phase A."""
+    gpus = [
+        rdma_utils._GpuInfo(index=0, pci_bus="0000:89:00.0", numa=0),
+        rdma_utils._GpuInfo(index=1, pci_bus="0000:8a:00.0", numa=0),
+        rdma_utils._GpuInfo(index=2, pci_bus="0000:c1:00.0", numa=1),
+        rdma_utils._GpuInfo(index=3, pci_bus="0000:c2:00.0", numa=1),
+    ]
+    rnics = [
+        rdma_utils._RdmaDevice(
+            name="rocep139s0",
+            pci_bus="0000:8b:00.0",
+            numa=0,
+            netdevs=("gpu0rdma0",),
+        ),
+        rdma_utils._RdmaDevice(
+            name="rocep140s0",
+            pci_bus="0000:8c:00.0",
+            numa=0,
+            netdevs=("gpu1rdma0",),
+        ),
+        rdma_utils._RdmaDevice(
+            name="rocep195s0",
+            pci_bus="0000:c3:00.0",
+            numa=1,
+            netdevs=("gpu2rdma0",),
+        ),
+        rdma_utils._RdmaDevice(
+            name="rocep196s0",
+            pci_bus="0000:c4:00.0",
+            numa=1,
+            netdevs=("gpu3rdma0",),
+        ),
+    ]
+    mapping = rdma_utils._assign_rnic_per_gpu(gpus, rnics)
+    assert mapping == {
+        0: "rocep139s0",
+        1: "rocep140s0",
+        2: "rocep195s0",
+        3: "rocep196s0",
+    }
+
+
+def test_autodiscover_worker_rnic_uses_numa_pci_when_no_netdev_match():
+    """When netdev names don't follow the gpu<N>rdma<M> convention, fall back
+    to same-NUMA + minimum PCI-bus-distance (phase B)."""
+    gpus = [
+        rdma_utils._GpuInfo(index=0, pci_bus="0000:10:00.0", numa=0),
+        rdma_utils._GpuInfo(index=1, pci_bus="0000:60:00.0", numa=1),
+    ]
+    rnics = [
+        rdma_utils._RdmaDevice(
+            name="mlx5_0", pci_bus="0000:15:00.0", numa=0, netdevs=("ib0",)
+        ),
+        rdma_utils._RdmaDevice(
+            name="mlx5_1", pci_bus="0000:65:00.0", numa=1, netdevs=("ib1",)
+        ),
+    ]
+    mapping = rdma_utils._assign_rnic_per_gpu(gpus, rnics)
+    assert mapping == {0: "mlx5_0", 1: "mlx5_1"}
+
+
+def test_get_configured_worker_rnic_rejects_short_explicit_csv(monkeypatch):
+    monkeypatch.setattr(
+        rdma_utils,
+        "get_current_physical_gpu_index",
+        lambda: 2,
+    )
+    with pytest.raises(ValueError, match="does not cover local GPU 2"):
+        rdma_utils.get_configured_worker_rnic(
+            protocol="rdma",
+            configured_device="rocep139s0,rocep140s0",
+        )
+
+
+class _ReplicaDesc:
+    def __init__(self, tier: str):
+        self.tier = tier
+
+    def is_memory_replica(self) -> bool:
+        return self.tier == "memory"
+
+    def is_disk_replica(self) -> bool:
+        return self.tier == "disk"
+
+    def is_local_disk_replica(self) -> bool:
+        return self.tier == "disk"
 
 
 def test_store_sending_thread_skips_request_during_cpu_pressure():
@@ -105,6 +464,400 @@ def test_store_sending_thread_only_skips_on_no_available_handle():
     assert store.batch_put_from_multi_buffers.call_count == 2
 
 
+def test_store_sending_thread_passes_replicate_config_when_preferred_segment_set():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    replicate_config = SimpleNamespace(preferred_segment="10.0.0.7:50053")
+    thread = _make_store_sending_thread(store, replicate_config=replicate_config)
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 1
+    call_args = store.batch_put_from_multi_buffers.call_args.args
+    assert len(call_args) == 4
+    assert call_args[3] is replicate_config
+
+
+def test_store_sending_thread_uses_default_write_path_without_preferred_segment():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.return_value = [256, 256]
+    thread = _make_store_sending_thread(store)
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 1
+    call_args = store.batch_put_from_multi_buffers.call_args.args
+    assert len(call_args) == 3
+
+
+def test_get_disk_offload_buffer_budget_bytes_uses_requester_budget_override(
+    monkeypatch,
+):
+    monkeypatch.setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "2mb")
+
+    assert (
+        mooncake_store_worker._get_disk_offload_buffer_budget_bytes(enable_offload=True)
+        == 2 * 1024 * 1024
+    )
+
+
+def test_get_disk_offload_buffer_budget_bytes_uses_requester_default(monkeypatch):
+    monkeypatch.delenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", raising=False)
+
+    assert (
+        mooncake_store_worker._get_disk_offload_buffer_budget_bytes(enable_offload=True)
+        == mooncake_store_worker.DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE
+    )
+
+
+def test_get_disk_offload_buffer_budget_bytes_returns_none_when_disabled():
+    assert (
+        mooncake_store_worker._get_disk_offload_buffer_budget_bytes(
+            enable_offload=False
+        )
+        is None
+    )
+
+
+def test_estimate_disk_offload_staging_bytes_sums_multi_segment_sizes():
+    assert (
+        mooncake_store_worker._estimate_disk_offload_staging_bytes([256, 512]) == 12288
+    )
+
+
+def test_recv_thread_uses_single_batch_when_no_disk_offload_budget(monkeypatch):
+    monkeypatch.delenv("VLLM_MOONCAKE_STORE_TIER_LOG", raising=False)
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, 256]
+    thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+    keys, addrs, sizes = store.batch_get_into_multi_buffers.call_args.args
+    assert keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    assert sizes == [[256], [256], [256]]
+    store.batch_get_replica_desc.assert_not_called()
+
+
+def test_recv_thread_logs_tier_summary_when_enabled(monkeypatch, caplog_vllm):
+    monkeypatch.setenv("VLLM_MOONCAKE_STORE_TIER_LOG", "1")
+    caplog_vllm.set_level(logging.INFO, logger=mooncake_store_worker.logger.name)
+
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, -10]
+    thread = _make_store_recving_thread(store, disk_offload_buffer_budget_bytes=None)
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+    expected_keys = [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    store.batch_get_replica_desc.return_value = {
+        expected_keys[0]: [_ReplicaDesc("memory")],
+        expected_keys[1]: [_ReplicaDesc("disk")],
+        expected_keys[2]: [],
+    }
+
+    thread._handle_request(req)
+
+    assert store.batch_get_replica_desc.call_args.args == (expected_keys,)
+    assert store.method_calls[0][0] == "batch_get_replica_desc"
+    assert store.method_calls[1][0] == "batch_get_into_multi_buffers"
+
+    messages = [record.getMessage() for record in caplog_vllm.records]
+    assert any(
+        "Mooncake load tier summary" in message
+        and "req_id=req-a" in message
+        and "batch_keys=3" in message
+        and "memory_keys=1" in message
+        and "disk_keys=1" in message
+        and "unknown_keys=1" in message
+        and "success_keys=2" in message
+        and "failed_keys=1" in message
+        and "bytes_by_tier={'memory': 256, 'disk': 256, 'unknown': 0}" in message
+        for message in messages
+    )
+
+
+def test_recv_thread_uses_ratio_scaled_budget_for_first_pass_split():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [
+        [256],
+        [256],
+    ]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=2 * _DISK_OFFLOAD_SINGLE_KEY_BYTES,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1"],
+        token_len=32,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 2
+    first_keys = store.batch_get_into_multi_buffers.call_args_list[0].args[0]
+    second_keys = store.batch_get_into_multi_buffers.call_args_list[1].args[0]
+    assert first_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+    ]
+    assert second_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+    ]
+
+
+def test_recv_thread_splits_disk_offload_loads_by_budget():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = [
+        [256, 256],
+        [256],
+    ]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 2
+
+    first_keys = store.batch_get_into_multi_buffers.call_args_list[0].args[0]
+    second_keys = store.batch_get_into_multi_buffers.call_args_list[1].args[0]
+    first_addrs = store.batch_get_into_multi_buffers.call_args_list[0].args[1]
+    second_addrs = store.batch_get_into_multi_buffers.call_args_list[1].args[1]
+    first_sizes = store.batch_get_into_multi_buffers.call_args_list[0].args[2]
+    second_sizes = store.batch_get_into_multi_buffers.call_args_list[1].args[2]
+    assert first_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+    ]
+    assert second_keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+    base_addr = thread.token_database.kv_caches_base_addr[0]
+    block_len = thread.token_database.block_len[0]
+    assert first_addrs == [[base_addr], [base_addr + block_len]]
+    assert second_addrs == [[base_addr + 2 * block_len]]
+    expected_size = block_len
+    assert first_sizes == [[expected_size], [expected_size]]
+    assert second_sizes == [[expected_size]]
+
+
+def test_recv_thread_stops_after_first_failing_disk_offload_sub_batch():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [-10, -10]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+
+
+def test_recv_thread_skips_split_when_budget_holds_all_keys():
+    """PR-36 removed the count-based split trigger; with budget for 3 keys,
+    all three should be requested in a single call."""
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256, 256]
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_THREE_KEYS,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+    assert store.batch_get_into_multi_buffers.call_args_list[0].args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6131",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@6132",
+    ]
+
+
+def test_recv_thread_reports_unsplittable_key_larger_than_budget():
+    store = MagicMock()
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_TOO_SMALL,
+    )
+
+    req = _make_load_req(
+        "req-a",
+        [b"a0"],
+        token_len=16,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 0
+
+
+def test_requester_worker_init_uses_positional_setup(tmp_path, monkeypatch):
+    store = MagicMock()
+    store.setup.return_value = 0
+    _install_fake_mooncake(monkeypatch, store)
+    _patch_worker_runtime(monkeypatch)
+    monkeypatch.setenv(
+        "MOONCAKE_CONFIG_PATH",
+        _write_mooncake_config(
+            tmp_path,
+            {
+                "metadata_server": "http://metadata/endpoint",
+                "global_segment_size": "4gb",
+                "local_buffer_size": "64mb",
+                "protocol": "rdma",
+                "device_name": "mlx5_0",
+                "master_server_address": "10.0.0.7:50051",
+                "enable_offload": True,
+            },
+        ),
+    )
+    worker = mooncake_store_worker.MooncakeStoreWorker(_make_vllm_config())
+
+    assert not hasattr(worker, "_isolate_offload_resources")
+    assert store.setup.call_args.args == (
+        "10.0.0.7",
+        "http://metadata/endpoint",
+        4 * 1024 * 1024 * 1024,  # global_segment_size: "4gb" honored
+        64 * 1024 * 1024,
+        "rdma",
+        "mlx5_0",
+        "10.0.0.7:50051",
+    )
+
+
+def test_requester_worker_init_prefers_local_hostname_override(
+    tmp_path,
+    monkeypatch,
+):
+    store = MagicMock()
+    store.setup.return_value = 0
+    _install_fake_mooncake(monkeypatch, store)
+    _patch_worker_runtime(monkeypatch)
+    monkeypatch.setenv("MOONCAKE_LOCAL_HOSTNAME", "worker-a:50053")
+    monkeypatch.setenv(
+        "MOONCAKE_CONFIG_PATH",
+        _write_mooncake_config(
+            tmp_path,
+            {
+                "metadata_server": "http://metadata/endpoint",
+                "local_buffer_size": "64mb",
+                "protocol": "tcp",
+                "device_name": "",
+                "master_server_address": "10.0.0.7:50051",
+            },
+        ),
+    )
+    mooncake_store_worker.MooncakeStoreWorker(_make_vllm_config())
+
+    assert store.setup.call_args.args[0] == "worker-a:50053"
+
+
+def test_requester_worker_init_skips_disk_budget_when_offload_disabled(
+    tmp_path,
+    monkeypatch,
+):
+    """PR-36: with enable_offload=False the disk budget must be None even when
+    MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES is set, so we don't generate
+    redundant owner GET-RPCs."""
+    store = MagicMock()
+    store.setup.return_value = 0
+    _install_fake_mooncake(monkeypatch, store)
+    _patch_worker_runtime(monkeypatch)
+    monkeypatch.setenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES", "4mb")
+    monkeypatch.setenv(
+        "MOONCAKE_CONFIG_PATH",
+        _write_mooncake_config(
+            tmp_path,
+            {
+                "metadata_server": "http://metadata/endpoint",
+                "protocol": "tcp",
+                "device_name": "",
+                "master_server_address": "10.0.0.7:50051",
+                "enable_offload": False,
+            },
+        ),
+    )
+    worker = mooncake_store_worker.MooncakeStoreWorker(_make_vllm_config())
+
+    assert worker.disk_offload_buffer_budget_bytes is None
+
+
+def test_requester_worker_init_builds_replicate_config_for_preferred_segment(
+    tmp_path,
+    monkeypatch,
+):
+    store = MagicMock()
+    store.setup.return_value = 0
+    fake_replicate_config_cls = _install_fake_mooncake(monkeypatch, store)
+    _patch_worker_runtime(monkeypatch)
+    monkeypatch.setenv(
+        "MOONCAKE_CONFIG_PATH",
+        _write_mooncake_config(
+            tmp_path,
+            {
+                "metadata_server": "http://metadata/endpoint",
+                "protocol": "tcp",
+                "device_name": "",
+                "master_server_address": "10.0.0.7:50051",
+            },
+        ),
+    )
+    worker = mooncake_store_worker.MooncakeStoreWorker(
+        _make_vllm_config(
+            extra_config={
+                "preferred_segment": "10.0.0.7:50053",
+            }
+        )
+    )
+
+    assert isinstance(worker.store_replicate_config, fake_replicate_config_cls)
+    assert worker.store_replicate_config.preferred_segment == "10.0.0.7:50053"
+
+
 # ---------------------------------------------------------------------------
 # Helpers for register_kv_caches tests
 # ---------------------------------------------------------------------------
@@ -126,30 +879,31 @@ def _make_bare_worker(
     num_gpu_blocks: int = 10,
     block_size: int = 16,
     kv_role: str = "kv_both",
-) -> worker.MooncakeStoreWorker:
+) -> mooncake_store_worker.MooncakeStoreWorker:
     """Construct a MooncakeStoreWorker via __new__, bypassing __init__.
 
     Sets only the attributes that register_kv_caches() reads so we can
     test the stride-based layout detection without a real
     MooncakeDistributedStore.
     """
-    w = object.__new__(worker.MooncakeStoreWorker)
-    w.cache_config = MagicMock()
-    w.cache_config.num_gpu_blocks = num_gpu_blocks
-    w.store = MagicMock()
-    w.store.register_buffer.return_value = 0
-    w.use_mla = False
-    w.token_database = ChunkedTokenDatabase(
+    worker = object.__new__(mooncake_store_worker.MooncakeStoreWorker)
+    worker.cache_config = MagicMock()
+    worker.cache_config.num_gpu_blocks = num_gpu_blocks
+    worker.store = MagicMock()
+    worker.store.register_buffer.return_value = 0
+    worker.use_mla = False
+    worker.token_database = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0), block_size=block_size
     )
-    w.kv_role = kv_role
-    w.block_size = block_size
-    w.tp_rank = 0
-    w.put_step = 1
-    w.enable_kv_events = False
-    w.kv_send_thread = None
-    w.kv_recv_thread = None
-    return w
+    worker.kv_role = kv_role
+    worker.block_size = block_size
+    worker.tp_rank = 0
+    worker.put_step = 1
+    worker.enable_kv_events = False
+    worker.disk_offload_buffer_budget_bytes = None
+    worker.kv_send_thread = None
+    worker.kv_recv_thread = None
+    return worker
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +915,7 @@ def test_register_kv_caches_blocks_first_single_segment():
     """Blocks-first layout (FlashInfer/MLA): one segment per layer."""
     num_blocks = 10
     page_size_elements = 64  # elements per block
-    w = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
 
     # Shape: (num_blocks, page_size_elements) — blocks outermost, no outer_dims
     tensor = torch.zeros(num_blocks, page_size_elements, dtype=torch.float16)
@@ -178,16 +932,16 @@ def test_register_kv_caches_blocks_first_single_segment():
             side_effect=_auto_set_ready_event,
         ),
     ):
-        w.register_kv_caches({"layer0": tensor})
+        worker.register_kv_caches({"layer0": tensor})
 
-    assert len(w.kv_caches_base_addr) == 1
-    assert w.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
+    assert len(worker.kv_caches_base_addr) == 1
+    assert worker.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
 
     expected_block_len = tensor.untyped_storage().nbytes() // num_blocks
-    assert len(w.block_len) == 1
-    assert w.block_len[0] == expected_block_len
+    assert len(worker.block_len) == 1
+    assert worker.block_len[0] == expected_block_len
 
-    w.store.register_buffer.assert_called_once_with(
+    worker.store.register_buffer.assert_called_once_with(
         tensor.untyped_storage().data_ptr(),
         tensor.untyped_storage().nbytes(),
     )
@@ -200,7 +954,7 @@ def test_register_kv_caches_kv_first_two_segments():
     num_kv_heads = 4
     head_size = 8
 
-    w = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
 
     # Shape: (2, num_blocks, block_size, num_kv_heads, head_size) — K/V outermost
     tensor = torch.zeros(
@@ -224,19 +978,19 @@ def test_register_kv_caches_kv_first_two_segments():
             side_effect=_auto_set_ready_event,
         ),
     ):
-        w.register_kv_caches({"layer0": tensor})
+        worker.register_kv_caches({"layer0": tensor})
 
     # K/V-first: dim 0 has stride > page_size, so 2 segments
-    assert len(w.kv_caches_base_addr) == 2
-    assert len(w.block_len) == 2
+    assert len(worker.kv_caches_base_addr) == 2
+    assert len(worker.block_len) == 2
 
     el = tensor.element_size()
     seg_stride = tensor.stride(0) * el  # stride of the K/V dim in bytes
     base = tensor.untyped_storage().data_ptr()
-    assert w.kv_caches_base_addr[0] == base
-    assert w.kv_caches_base_addr[1] == base + seg_stride
-    assert w.block_len[0] == seg_stride // num_blocks
-    assert w.block_len[1] == seg_stride // num_blocks
+    assert worker.kv_caches_base_addr[0] == base
+    assert worker.kv_caches_base_addr[1] == base + seg_stride
+    assert worker.block_len[0] == seg_stride // num_blocks
+    assert worker.block_len[1] == seg_stride // num_blocks
 
 
 def test_register_kv_caches_cross_layer_single_segment():
@@ -245,7 +999,7 @@ def test_register_kv_caches_cross_layer_single_segment():
     num_layers = 4
     per_layer_page_elements = 64  # elements per layer per block
 
-    w = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
 
     # Cross-layer blocks-first tensor: all layers packed into a single
     # contiguous block.  Shape (num_blocks, num_layers * per_layer_page)
@@ -266,10 +1020,10 @@ def test_register_kv_caches_cross_layer_single_segment():
         ),
     ):
         # Use the cross-layer wrapper key, same as register_cross_layers_kv_caches
-        w.register_kv_caches({"__cross_layer__": tensor})
+        worker.register_kv_caches({"__cross_layer__": tensor})
 
-    assert len(w.kv_caches_base_addr) == 1
-    assert w.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
+    assert len(worker.kv_caches_base_addr) == 1
+    assert worker.kv_caches_base_addr[0] == tensor.untyped_storage().data_ptr()
 
     expected_block_len = tensor.untyped_storage().nbytes() // num_blocks
     # block_len should be per_layer_page_size * num_layers
@@ -277,11 +1031,11 @@ def test_register_kv_caches_cross_layer_single_segment():
         expected_block_len
         == num_layers * per_layer_page_elements * tensor.element_size()
     )
-    assert len(w.block_len) == 1
-    assert w.block_len[0] == expected_block_len
+    assert len(worker.block_len) == 1
+    assert worker.block_len[0] == expected_block_len
 
     # Also verify via register_cross_layers_kv_caches wrapper
-    w2 = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker2 = _make_bare_worker(num_gpu_blocks=num_blocks)
     with (
         patch(
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
@@ -294,7 +1048,88 @@ def test_register_kv_caches_cross_layer_single_segment():
             side_effect=_auto_set_ready_event,
         ),
     ):
-        w2.register_cross_layers_kv_caches(tensor)
+        worker2.register_cross_layers_kv_caches(tensor)
 
-    assert w2.kv_caches_base_addr == w.kv_caches_base_addr
-    assert w2.block_len == w.block_len
+    assert worker2.kv_caches_base_addr == worker.kv_caches_base_addr
+    assert worker2.block_len == worker.block_len
+
+
+# ---------------------------------------------------------------------------
+# Dual-mode (real-client / owner-client) config validation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides):
+    """Build a MooncakeStoreConfig with sensible defaults for validation tests.
+
+    Required dataclass fields are populated; callers override only the field
+    under test.
+    """
+    base = dict(
+        metadata_server="http://metadata/endpoint",
+        master_server_address="10.0.0.7:50051",
+        protocol="rdma",
+        device_name="mlx5_0",
+    )
+    base.update(overrides)
+    return mooncake_store_worker.MooncakeStoreConfig(**base)
+
+
+def test_config_defaults_to_real_client():
+    """A JSON without explicit mode parses as real-client with 4 GiB segment."""
+    cfg = _make_config()
+    assert cfg.mode == "real-client"
+    assert cfg.global_segment_size == mooncake_store_worker.DEFAULT_GLOBAL_SEGMENT_SIZE
+    assert cfg.local_buffer_size == mooncake_store_worker.DEFAULT_LOCAL_BUFFER_SIZE
+    assert cfg.enable_offload is False
+
+
+def test_config_pr40900_unchanged(tmp_path):
+    """A literal PR-40900 config (no mode, no enable_offload, no preferred_segment)
+    parses without raising and resolves to real-client mode."""
+    config_path = _write_mooncake_config(
+        tmp_path,
+        {
+            "metadata_server": "http://metadata/endpoint",
+            "global_segment_size": "4GB",
+            "local_buffer_size": "4GB",
+            "protocol": "rdma",
+            "device_name": "mlx5_0",
+            "master_server_address": "10.0.0.7:50051",
+        },
+    )
+    cfg = mooncake_store_worker.MooncakeStoreConfig.from_file(config_path)
+    assert cfg.mode == "real-client"
+    assert cfg.global_segment_size == 4 * 1024**3
+    assert cfg.local_buffer_size == 4 * 1024**3
+    assert cfg.enable_offload is False
+
+
+def test_config_real_client_rejects_zero_segment():
+    with pytest.raises(
+        ValueError, match=r"real-client mode requires global_segment_size > 0"
+    ):
+        _make_config(mode="real-client", global_segment_size=0)
+
+
+def test_config_owner_client_rejects_nonzero_segment():
+    with pytest.raises(
+        ValueError, match=r"owner-client mode requires global_segment_size == 0"
+    ):
+        _make_config(mode="owner-client", global_segment_size=4 * 1024**3)
+
+
+def test_config_owner_client_accepts_zero_segment():
+    cfg = _make_config(mode="owner-client", global_segment_size=0)
+    assert cfg.mode == "owner-client"
+    assert cfg.global_segment_size == 0
+
+
+def test_config_unknown_mode():
+    with pytest.raises(ValueError, match=r"unknown Mooncake mode"):
+        _make_config(mode="something-else")
+
+
+def test_config_zero_local_buffer():
+    with pytest.raises(ValueError, match=r"local_buffer_size must be > 0"):
+        _make_config(local_buffer_size=0)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/rdma_utils.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Minimal Mooncake requester config helpers.
+
+Includes per-GPU RDMA NIC auto-discovery so each vLLM DP rank pins to its
+PCI-affine RNIC when the operator did not provide an explicit
+``MOONCAKE_DEVICE=<csv>`` mapping. Without this, all DP ranks on a single
+node would converge on whichever NIC Mooncake's transfer engine
+auto-selects first, saturating one link and stalling under offload load.
+"""
+
+import functools
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_PREFERRED_SEGMENT_ENV = "MOONCAKE_PREFERRED_SEGMENT"
+_GID_INDEX_ENV = "MC_GID_INDEX"
+_INFINIBAND_ROOT = Path("/sys/class/infiniband")
+
+
+def normalize_string_override(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def get_current_physical_gpu_index() -> int | None:
+    try:
+        from vllm.platforms import current_platform
+    except ImportError:
+        return None
+
+    try:
+        device_index = torch.accelerator.current_device_index()
+        physical_device_id = current_platform.device_id_to_physical_device_id(
+            device_index
+        )
+        return int(physical_device_id)
+    except Exception:
+        return None
+
+
+def get_requester_local_hostname(local_ip: str) -> str:
+    override = normalize_string_override(os.getenv("MOONCAKE_LOCAL_HOSTNAME"))
+    if override is not None:
+        return override
+    return local_ip
+
+
+def get_configured_preferred_segment(
+    extra_config: Mapping[str, Any],
+) -> str | None:
+    preferred_segment = normalize_string_override(extra_config.get("preferred_segment"))
+    if preferred_segment is not None:
+        return preferred_segment
+    if extra_config.get("preferred_segment") is not None:
+        raise ValueError(
+            "Mooncake preferred_segment override must be a non-empty string"
+        )
+
+    env_value = normalize_string_override(os.getenv(_PREFERRED_SEGMENT_ENV))
+    if env_value is not None:
+        logger.info(
+            "Mooncake preferred_segment from %s: %s",
+            _PREFERRED_SEGMENT_ENV,
+            env_value,
+        )
+        return env_value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-GPU RDMA NIC discovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GpuInfo:
+    index: int
+    pci_bus: str  # normalized "DDDD:BB:DD.F"
+    numa: int  # -1 if unknown
+
+
+@dataclass(frozen=True)
+class _RdmaDevice:
+    name: str
+    pci_bus: str
+    numa: int
+    netdevs: tuple[str, ...]
+
+
+def _normalize_pci_bus(raw: str) -> str | None:
+    """Return PCI bus id as ``DDDD:BB:DD.F`` (lowercase, 4-digit domain) or None.
+
+    nvidia-smi emits 8-digit domains (e.g. ``00000000:89:00.0``) while sysfs
+    paths use 4-digit (``0000:89:00.0``). Normalise to the 4-digit form.
+    """
+    if not raw:
+        return None
+    raw = raw.strip().lower()
+    m = re.match(
+        r"^(?:([0-9a-f]{4,8}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-7])$", raw
+    )
+    if not m:
+        return None
+    domain_raw = m.group(1) or "0"
+    # Strip leading zeros, then zero-pad to exactly 4 hex chars.
+    domain = domain_raw.lstrip("0").zfill(4) or "0000"
+    if len(domain) > 4:  # genuine non-zero 8-digit domain — leave intact
+        return None
+    return f"{domain}:{m.group(2)}:{m.group(3)}.{m.group(4)}"
+
+
+def _pci_bus_distance(lhs: str, rhs: str) -> int:
+    """Cheap distance between two PCI bus ids — abs(lhs_bus - rhs_bus) within
+    same domain; if domains differ, large distance. Matches the bash impl."""
+    try:
+        lhs_dom, lhs_bus, _ = lhs.split(":", 2)
+        rhs_dom, rhs_bus, _ = rhs.split(":", 2)
+    except ValueError:
+        return 1 << 30
+    if lhs_dom != rhs_dom:
+        return 1 << 30
+    try:
+        return abs(int(lhs_bus, 16) - int(rhs_bus, 16))
+    except ValueError:
+        return 1 << 30
+
+
+def _read_numa(pci_bus: str) -> int:
+    try:
+        with open(f"/sys/bus/pci/devices/{pci_bus}/numa_node") as f:
+            return int(f.read().strip())
+    except OSError:
+        return -1
+
+
+def _gid_index_active(device: Path, port: str, gid_index: str) -> bool:
+    """Return True if the device/port has a non-zero GID at the requested index."""
+    gid_path = device / "ports" / port / "gids" / gid_index
+    try:
+        gid = gid_path.read_text().strip()
+    except OSError:
+        return False
+    return bool(gid) and any(c not in "0:" for c in gid)
+
+
+def _port_is_active(device: Path) -> bool:
+    for port_path in (device / "ports").glob("*"):
+        try:
+            state = (port_path / "state").read_text()
+        except OSError:
+            continue
+        # "4: ACTIVE" or "5: ACTIVE_DEFER" etc.; just check for "ACTIVE"
+        if "ACTIVE" in state:
+            return True
+    return False
+
+
+def _device_active_for_gid(device: Path, gid_index: str | None) -> bool:
+    """Match the bash `device_is_active_for_gid_index` predicate."""
+    for port_path in (device / "ports").glob("*"):
+        try:
+            state = (port_path / "state").read_text()
+        except OSError:
+            continue
+        if "ACTIVE" not in state:
+            continue
+        if gid_index is None:
+            return True
+        if _gid_index_active(device, port_path.name, gid_index):
+            return True
+    return False
+
+
+def _discover_local_gpus() -> list[_GpuInfo]:
+    if not subprocess.run(
+        ["which", "nvidia-smi"], capture_output=True, check=False
+    ).stdout:
+        return []
+    try:
+        out = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,pci.bus_id",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        ).stdout
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return []
+
+    gpus: list[_GpuInfo] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        idx_str, bus_raw = (p.strip() for p in line.split(",", 1))
+        try:
+            idx = int(idx_str)
+        except ValueError:
+            continue
+        bus = _normalize_pci_bus(bus_raw)
+        if bus is None:
+            continue
+        gpus.append(_GpuInfo(index=idx, pci_bus=bus, numa=_read_numa(bus)))
+    return gpus
+
+
+def _discover_rdma_devices(gid_index: str | None) -> list[_RdmaDevice]:
+    if not _INFINIBAND_ROOT.is_dir():
+        return []
+
+    devices: list[_RdmaDevice] = []
+    for device_path in sorted(_INFINIBAND_ROOT.iterdir()):
+        if not device_path.is_dir():
+            continue
+        if not _device_active_for_gid(device_path, gid_index):
+            continue
+        try:
+            pci_link = (device_path / "device").resolve().name
+        except OSError:
+            continue
+        pci_bus = _normalize_pci_bus(pci_link)
+        if pci_bus is None:
+            continue
+        netdevs = tuple(
+            sorted(
+                p.name
+                for p in (device_path / "device" / "net").glob("*")
+                if p.is_dir()
+            )
+        )
+        devices.append(
+            _RdmaDevice(
+                name=device_path.name,
+                pci_bus=pci_bus,
+                numa=_read_numa(pci_bus),
+                netdevs=netdevs,
+            )
+        )
+    return devices
+
+
+def _gpu_matches_rnic_netdev(gpu_index: int, netdevs: tuple[str, ...]) -> bool:
+    """Match the bash `gpu_matches_rnic_netdev` — netdev named like ``gpu0rdma0``."""
+    pattern = re.compile(rf"^gpu{gpu_index}rdma[0-9]+$")
+    return any(pattern.match(nd) for nd in netdevs)
+
+
+def _assign_rnic_per_gpu(
+    gpus: list[_GpuInfo], rnics: list[_RdmaDevice]
+) -> dict[int, str]:
+    """Map gpu_index → rnic_name. 3-phase: exact netdev → same-NUMA min PCI →
+    global min PCI. Each RNIC is used by at most one GPU.
+
+    Returns a partial map if any phase can't find a match; caller decides what
+    to do with un-mapped GPUs.
+    """
+    by_name = {r.name: r for r in rnics}
+    used: set[str] = set()
+    mapping: dict[int, str] = {}
+
+    # Phase A — exact netdev (gpu<N>rdma<M>) match
+    for gpu in gpus:
+        matches = [r for r in rnics if _gpu_matches_rnic_netdev(gpu.index, r.netdevs)]
+        if not matches:
+            continue
+        chosen = sorted(m.name for m in matches)[0]
+        mapping[gpu.index] = chosen
+        used.add(chosen)
+
+    # Phase B — among GPUs without a phase-A match, prefer same-NUMA min PCI distance
+    for gpu in gpus:
+        if gpu.index in mapping:
+            continue
+        candidates = [
+            r for r in rnics if r.name not in used and r.numa == gpu.numa and gpu.numa != -1
+        ]
+        if not candidates:
+            continue
+        candidates.sort(
+            key=lambda r: (_pci_bus_distance(gpu.pci_bus, r.pci_bus), r.name)
+        )
+        chosen = candidates[0].name
+        mapping[gpu.index] = chosen
+        used.add(chosen)
+
+    # Phase C — global min PCI distance
+    for gpu in gpus:
+        if gpu.index in mapping:
+            continue
+        candidates = [r for r in rnics if r.name not in used]
+        if not candidates:
+            continue
+        candidates.sort(
+            key=lambda r: (_pci_bus_distance(gpu.pci_bus, r.pci_bus), r.name)
+        )
+        chosen = candidates[0].name
+        mapping[gpu.index] = chosen
+        used.add(chosen)
+
+    _ = by_name  # silence unused
+    return mapping
+
+
+@functools.lru_cache(maxsize=1)
+def _autodetect_gpu_rnic_map() -> dict[int, str]:
+    """Cache the GPU→RNIC assignment for the lifetime of the process."""
+    gid_index = normalize_string_override(os.getenv(_GID_INDEX_ENV))
+    gpus = _discover_local_gpus()
+    rnics = _discover_rdma_devices(gid_index)
+    if not gpus or not rnics:
+        return {}
+    mapping = _assign_rnic_per_gpu(gpus, rnics)
+    if mapping:
+        logger.info(
+            "Mooncake RDMA auto-discovery: %s (gid_index=%s)",
+            ", ".join(f"gpu{i}->{n}" for i, n in sorted(mapping.items())),
+            gid_index or "any",
+        )
+    return mapping
+
+
+def _get_explicit_worker_rnic(device_list: str) -> str:
+    entries = [entry.strip() for entry in device_list.split(",")]
+    if any(not entry for entry in entries):
+        raise ValueError(
+            "Mooncake worker device_name contains an empty RDMA device entry"
+        )
+    if len(entries) == 1:
+        return entries[0]
+
+    gpu_index = get_current_physical_gpu_index()
+    if gpu_index is None:
+        raise RuntimeError(
+            "Mooncake RDMA requester could not determine the local physical GPU index"
+        )
+    if gpu_index >= len(entries):
+        raise ValueError(
+            "Mooncake worker device list does not cover local GPU "
+            f"{gpu_index}: {device_list}"
+        )
+    device_name = entries[gpu_index]
+    logger.info(
+        "Mooncake selected worker RNIC %s from explicit device list for local GPU %s",
+        device_name,
+        gpu_index,
+    )
+    return device_name
+
+
+def _autodiscover_worker_rnic() -> str:
+    """Fallback when the operator did not provide a ``MOONCAKE_DEVICE`` CSV.
+
+    Maps the calling rank's local GPU to its PCI-affine RNIC by reading
+    /sys/class/infiniband and ``nvidia-smi``. Returns "" if no mapping can
+    be made (Mooncake's transfer engine will then fall back to its own
+    auto-selection).
+    """
+    gpu_index = get_current_physical_gpu_index()
+    if gpu_index is None:
+        return ""
+    mapping = _autodetect_gpu_rnic_map()
+    rnic = mapping.get(gpu_index, "")
+    if rnic:
+        logger.info(
+            "Mooncake auto-discovered worker RNIC %s for local GPU %d",
+            rnic,
+            gpu_index,
+        )
+    return rnic
+
+
+def get_configured_worker_rnic(
+    *,
+    protocol: str,
+    configured_device: str,
+) -> str:
+    normalized_device = normalize_string_override(configured_device)
+    if normalized_device is not None:
+        return _get_explicit_worker_rnic(normalized_device)
+
+    if protocol not in {"rdma", "efa"}:
+        return ""
+
+    autodiscovered = _autodiscover_worker_rnic()
+    if autodiscovered:
+        return autodiscovered
+
+    logger.warning(
+        "Mooncake requester has no explicit worker RNIC configured and "
+        "Python auto-discovery could not map the local GPU to an RNIC; "
+        "falling back to Mooncake auto-selection, which may be sub-optimal."
+    )
+    return ""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -13,10 +13,12 @@ and MooncakeDistributedStore integration.
 import json
 import os
 import queue
+import socket
 import threading
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import regex as re
 import torch
@@ -31,10 +33,11 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.kv_events import BlockStored
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import rdma_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     get_mooncake_dp_engine_index,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     MooncakeStoreConnectorMetadata,
@@ -47,37 +50,75 @@ from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 
 logger = init_logger(__name__)
 
-DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
-DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
+DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB — PR-40900 default
+DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB — PR-40900 default
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
+DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE = 1280 * 1024 * 1024
+DISK_OFFLOAD_USABLE_BUDGET_RATIO = 0.9
+_DIRECT_IO_ALIGNMENT = 4096
+_DIRECT_IO_PADDING_BYTES = 2 * _DIRECT_IO_ALIGNMENT
+
+
+MooncakeMode = Literal["real-client", "owner-client"]
 
 
 @dataclass
 class MooncakeStoreConfig:
-    """Configuration for MooncakeDistributedStore."""
+    """Configuration for MooncakeDistributedStore.
+
+    ``mode`` selects the topology: ``real-client`` (PR-40900 baseline — each
+    rank contributes ``global_segment_size``) or ``owner-client`` (rank
+    contributes 0; an external ``mooncake_client`` owns the pool).
+    """
 
     metadata_server: str
-    global_segment_size: int
-    local_buffer_size: int
+    master_server_address: str
     protocol: str
     device_name: str
-    master_server_address: str
+    mode: MooncakeMode = "real-client"
+    global_segment_size: int = DEFAULT_GLOBAL_SEGMENT_SIZE
+    local_buffer_size: int = DEFAULT_LOCAL_BUFFER_SIZE
+    enable_offload: bool = False
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("real-client", "owner-client"):
+            raise ValueError(f"unknown Mooncake mode: {self.mode!r}")
+        if self.local_buffer_size <= 0:
+            raise ValueError("local_buffer_size must be > 0")
+        if self.mode == "real-client" and self.global_segment_size == 0:
+            raise ValueError("real-client mode requires global_segment_size > 0")
+        if self.mode == "owner-client" and self.global_segment_size != 0:
+            raise ValueError("owner-client mode requires global_segment_size == 0")
 
     @staticmethod
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
         return MooncakeStoreConfig(
-            metadata_server=config.get("metadata_server", ""),
+            metadata_server=_get_config_or_env_value(
+                config, "metadata_server", "MOONCAKE_TE_META_DATA_SERVER", ""
+            ),
+            master_server_address=_get_config_or_env_value(
+                config, "master_server_address", "MOONCAKE_MASTER", ""
+            ),
+            protocol=_get_config_or_env_value(
+                config, "protocol", "MOONCAKE_PROTOCOL", "rdma"
+            ),
+            device_name=_get_config_or_env_value(
+                config, "device_name", "MOONCAKE_DEVICE", ""
+            ),
+            mode=_get_config_or_env_value(
+                config, "mode", "MOONCAKE_MODE", "real-client"
+            ),
             global_segment_size=_parse_size(
                 config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
             ),
             local_buffer_size=_parse_size(
                 config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)
             ),
-            protocol=config.get("protocol", "rdma"),
-            device_name=config.get("device_name", ""),
-            master_server_address=config.get("master_server_address", ""),
+            enable_offload=_get_bool_config_or_env_value(
+                config, "enable_offload", "MOONCAKE_ENABLE_OFFLOAD", False
+            ),
         )
 
     @staticmethod
@@ -88,6 +129,40 @@ class MooncakeStoreConfig:
                 "The environment variable 'MOONCAKE_CONFIG_PATH' is not set."
             )
         return MooncakeStoreConfig.from_file(config_path)
+
+
+def _get_config_or_env_value(
+    config: Mapping[str, Any], key: str, env_var: str, default: Any
+) -> Any:
+    env_value = os.getenv(env_var)
+    if env_value not in (None, ""):
+        return env_value
+    return config.get(key, default)
+
+
+def _get_bool_config_or_env_value(
+    config: Mapping[str, Any], key: str, env_var: str, default: bool
+) -> bool:
+    env_value = os.getenv(env_var)
+    if env_value:
+        return env_value.strip().lower() in ("1", "true")
+    return bool(config.get(key, default))
+
+
+def _get_kv_connector_extra_config(vllm_config: VllmConfig) -> Mapping[str, Any]:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    if kv_transfer_config is None:
+        return {}
+    return kv_transfer_config.kv_connector_extra_config
+
+
+def _get_disk_offload_buffer_budget_bytes(enable_offload: bool) -> int | None:
+    if not enable_offload:
+        return None
+    value = os.getenv("MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE_BYTES")
+    if value is None:
+        return DEFAULT_MOONCAKE_OFFLOAD_LOCAL_BUFFER_SIZE
+    return _parse_size(value)
 
 
 def _parse_size(value: Any) -> int:
@@ -123,6 +198,148 @@ def _parse_size(value: Any) -> int:
     except ValueError as exc:
         raise ValueError(f"Invalid numeric value '{number_str}' in: '{value}'") from exc
     return int(numeric_value * multiplier)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def _estimate_disk_offload_staging_bytes(size_list: list[int]) -> int:
+    data_size = sum(size_list)
+    return _align_up(data_size, _DIRECT_IO_ALIGNMENT) + _DIRECT_IO_PADDING_BYTES
+
+
+def _get_usable_disk_offload_buffer_budget_bytes(raw_budget_bytes: int) -> int:
+    return max(1, int(raw_budget_bytes * DISK_OFFLOAD_USABLE_BUDGET_RATIO))
+
+
+def _split_disk_offload_load_batches(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+    usable_budget_bytes: int,
+    raw_budget_bytes: int,
+) -> tuple[list[tuple[list[str], list[list[int]], list[list[int]]]], str | None]:
+    batches: list[tuple[list[str], list[list[int]], list[list[int]]]] = []
+    batch_keys: list[str] = []
+    batch_addrs: list[list[int]] = []
+    batch_sizes: list[list[int]] = []
+    batch_bytes = 0
+
+    for key, addr, size in zip(keys, addrs, sizes, strict=True):
+        key_bytes = _estimate_disk_offload_staging_bytes(size)
+        if key_bytes > raw_budget_bytes:
+            return [], key
+        if key_bytes > usable_budget_bytes:
+            if batch_keys:
+                batches.append((batch_keys, batch_addrs, batch_sizes))
+                batch_keys, batch_addrs, batch_sizes = [], [], []
+                batch_bytes = 0
+            batches.append(([key], [addr], [size]))
+            continue
+        if batch_keys and batch_bytes + key_bytes > usable_budget_bytes:
+            batches.append((batch_keys, batch_addrs, batch_sizes))
+            batch_keys, batch_addrs, batch_sizes = [], [], []
+            batch_bytes = 0
+        batch_keys.append(key)
+        batch_addrs.append(addr)
+        batch_sizes.append(size)
+        batch_bytes += key_bytes
+
+    if batch_keys:
+        batches.append((batch_keys, batch_addrs, batch_sizes))
+    return batches, None
+
+
+def _call_replica_predicate(replica_desc: Any, method_name: str) -> bool:
+    method = getattr(replica_desc, method_name, None)
+    if method is None:
+        return False
+    try:
+        return bool(method())
+    except Exception:
+        return False
+
+
+def _classify_replica_tier(replica_descs: Any) -> str:
+    if not replica_descs:
+        return "unknown"
+    try:
+        replica_desc = replica_descs[0]
+    except (IndexError, KeyError, TypeError):
+        return "unknown"
+
+    if _call_replica_predicate(replica_desc, "is_memory_replica"):
+        return "memory"
+    if _call_replica_predicate(
+        replica_desc, "is_disk_replica"
+    ) or _call_replica_predicate(replica_desc, "is_local_disk_replica"):
+        return "disk"
+    return "unknown"
+
+
+def _get_replica_tiers_by_key(store: Any, keys: list[str]) -> dict[str, str]:
+    tiers_by_key = {key: "unknown" for key in keys}
+    try:
+        replica_descs_by_key = store.batch_get_replica_desc(keys)
+    except Exception as e:
+        logger.warning(
+            "Failed to get Mooncake replica descriptors for tier logging "
+            "(batch_keys=%d, error=%s); marking tiers unknown",
+            len(keys),
+            e,
+        )
+        return tiers_by_key
+
+    for key in keys:
+        if hasattr(replica_descs_by_key, "get"):
+            replica_descs = replica_descs_by_key.get(key)
+        else:
+            try:
+                replica_descs = replica_descs_by_key[key]
+            except (KeyError, TypeError):
+                replica_descs = None
+        tiers_by_key[key] = _classify_replica_tier(replica_descs)
+    return tiers_by_key
+
+
+def _log_mooncake_load_tier_summary(
+    req_id: str,
+    batch_keys: list[str],
+    load_results: list[int],
+    tiers_by_key: dict[str, str],
+) -> None:
+    tier_counts = {"memory": 0, "disk": 0, "unknown": 0}
+    bytes_by_tier = {"memory": 0, "disk": 0, "unknown": 0}
+    success_keys = 0
+    failed_keys = 0
+
+    for index, key in enumerate(batch_keys):
+        tier = tiers_by_key.get(key, "unknown")
+        if tier not in tier_counts:
+            tier = "unknown"
+        tier_counts[tier] += 1
+
+        value = load_results[index] if index < len(load_results) else -1
+        if value >= 0:
+            success_keys += 1
+            bytes_by_tier[tier] += int(value)
+        else:
+            failed_keys += 1
+
+    logger.info(
+        "Mooncake load tier summary: req_id=%s batch_keys=%d "
+        "memory_keys=%d disk_keys=%d unknown_keys=%d "
+        "success_keys=%d failed_keys=%d bytes_by_tier=%s",
+        req_id,
+        len(batch_keys),
+        tier_counts["memory"],
+        tier_counts["disk"],
+        tier_counts["unknown"],
+        success_keys,
+        failed_keys,
+        bytes_by_tier,
+    )
 
 
 # ============================================================
@@ -207,6 +424,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         kv_role: str,
         ready_event: threading.Event,
         enable_kv_event: bool = False,
+        replicate_config: Any | None = None,
     ):
         super().__init__(
             store,
@@ -220,8 +438,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.kv_role = kv_role
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.enable_kv_event = enable_kv_event
+        self.replicate_config = replicate_config
 
-        # Pause store requests when CPU offloading is under pressure.
+        # Pause store requests when CPU/disk offloading is under pressure.
         self._store_pressure_active = False
         self._skip_store_requests: set[str] = set()
 
@@ -270,7 +489,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             return
         if self._should_skip_request(req_id):
             logger.debug(
-                "Skipping Mooncake store for request %s while CPU offloading "
+                "Skipping Mooncake store for request %s while CPU/disk offloading "
                 "is under pressure",
                 req_id,
             )
@@ -357,7 +576,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
             current_event.synchronize()
 
         try:
-            res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
+            if self.replicate_config is None:
+                res = self.store.batch_put_from_multi_buffers(keys, addrs, sizes)
+            else:
+                res = self.store.batch_put_from_multi_buffers(
+                    keys,
+                    addrs,
+                    sizes,
+                    self.replicate_config,
+                )
             failed = [i for i, v in enumerate(res) if v < 0]
             if failed:
                 # Compute total bytes attempted for this batch
@@ -379,7 +606,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     and not self._mark_request_skipped_for_pressure(req_id)
                 ):
                     logger.warning(
-                        "Detected Mooncake CPU offloading pressure "
+                        "Detected Mooncake CPU/disk offloading pressure "
                         "(NO_AVAILABLE_HANDLE); skipping future store "
                         "batches for request %s until a later store "
                         "batch succeeds",
@@ -387,7 +614,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     )
             elif self._clear_store_pressure():
                 logger.info(
-                    "Mooncake CPU offloading pressure cleared after a "
+                    "Mooncake CPU/disk offloading pressure cleared after a "
                     "successful store batch"
                 )
         except Exception as e:
@@ -410,6 +637,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         block_size: int,
         tp_rank: int,
         ready_event: threading.Event,
+        disk_offload_buffer_budget_bytes: int | None = None,
     ):
         super().__init__(
             store,
@@ -418,6 +646,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             tp_rank,
             ready_event,
             name="KVCacheStoreRecvingThread",
+        )
+        self.disk_offload_buffer_budget_bytes = disk_offload_buffer_budget_bytes
+        self.usable_disk_offload_buffer_budget_bytes = (
+            None
+            if disk_offload_buffer_budget_bytes is None
+            else _get_usable_disk_offload_buffer_budget_bytes(
+                disk_offload_buffer_budget_bytes
+            )
         )
 
     def _handle_request(self, req_meta: ReqMeta):
@@ -456,26 +692,69 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             + size_list[: self.tp_rank % len(size_list)]
         )
 
-        try:
-            res = self.store.batch_get_into_multi_buffers(
-                key_list_c, addr_list_c, size_list_c
+        load_batches = [(key_list_c, addr_list_c, size_list_c)]
+        if self.usable_disk_offload_buffer_budget_bytes is not None:
+            total_staging_bytes = sum(
+                _estimate_disk_offload_staging_bytes(size) for size in size_list_c
             )
-            failed = [
-                (key, value)
-                for key, value in zip(key_list_c, res, strict=True)
-                if value < 0
-            ]
-            if failed:
-                logger.warning(
-                    "Failed to get %d Mooncake keys (batch_keys=%d, first_failures=%s)",
-                    len(failed),
-                    len(key_list_c),
-                    failed[:3],
+            if total_staging_bytes > self.usable_disk_offload_buffer_budget_bytes:
+                assert self.disk_offload_buffer_budget_bytes is not None
+                load_batches, oversized_key = _split_disk_offload_load_batches(
+                    key_list_c,
+                    addr_list_c,
+                    size_list_c,
+                    self.usable_disk_offload_buffer_budget_bytes,
+                    self.disk_offload_buffer_budget_bytes,
                 )
+                if oversized_key is not None:
+                    oversized_key_index = key_list_c.index(oversized_key)
+                    oversized_key_bytes = _estimate_disk_offload_staging_bytes(
+                        size_list_c[oversized_key_index]
+                    )
+                    logger.warning(
+                        "Skipping Mooncake load for request %s because key %s "
+                        "requires %d staging bytes, exceeding budget %d",
+                        req_id,
+                        oversized_key,
+                        oversized_key_bytes,
+                        self.disk_offload_buffer_budget_bytes,
+                    )
+                    self.set_finished_request(req_id)
+                    self.request_queue.task_done()
+                    return
+
+        current_batch_keys: list[str] = key_list_c
+        try:
+            for batch_keys, batch_addrs, batch_sizes in load_batches:
+                current_batch_keys = batch_keys
+                tiers_by_key: dict[str, str] | None = None
+                if envs.VLLM_MOONCAKE_STORE_TIER_LOG:
+                    tiers_by_key = _get_replica_tiers_by_key(self.store, batch_keys)
+                res = self.store.batch_get_into_multi_buffers(
+                    batch_keys, batch_addrs, batch_sizes
+                )
+                if tiers_by_key is not None:
+                    _log_mooncake_load_tier_summary(
+                        req_id, batch_keys, res, tiers_by_key
+                    )
+                failed = [
+                    (key, value)
+                    for key, value in zip(batch_keys, res, strict=True)
+                    if value < 0
+                ]
+                if failed:
+                    logger.warning(
+                        "Failed to get %d Mooncake keys from sub-batch "
+                        "(batch_keys=%d, first_failures=%s)",
+                        len(failed),
+                        len(batch_keys),
+                        failed[:3],
+                    )
+                    break
         except Exception as e:
             logger.warning(
-                "Failed to get Mooncake batch %s, error: %s",
-                key_list_c[:3],
+                "Failed to get Mooncake sub-batch %s, error: %s",
+                current_batch_keys[:3],
                 e,
             )
 
@@ -493,7 +772,10 @@ class MooncakeStoreWorker:
 
     def __init__(self, vllm_config: VllmConfig):
         try:
-            from mooncake.store import MooncakeDistributedStore  # type: ignore
+            from mooncake.store import (  # type: ignore  # noqa: E501
+                MooncakeDistributedStore,
+                ReplicateConfig,
+            )
         except ImportError as e:
             raise ImportError(
                 "Please install mooncake by following the instructions at "
@@ -561,23 +843,71 @@ class MooncakeStoreWorker:
 
         # Initialize MooncakeDistributedStore with its own TransferEngine
         store_config = MooncakeStoreConfig.load_from_env()
+        extra_config = _get_kv_connector_extra_config(vllm_config)
+        store_config.device_name = rdma_utils.get_configured_worker_rnic(
+            protocol=store_config.protocol,
+            configured_device=store_config.device_name,
+        )
         self.store = MooncakeDistributedStore()
-
-        local_seg = get_ip()
-        config_dict = {
-            "local_hostname": local_seg,
-            "metadata_server": store_config.metadata_server,
-            "global_segment_size": str(store_config.global_segment_size),
-            "local_buffer_size": str(store_config.local_buffer_size),
-            "protocol": store_config.protocol,
-            "rdma_devices": store_config.device_name,
-            "master_server_addr": store_config.master_server_address,
-        }
-        ret = self.store.setup(config_dict)
+        local_ip = get_ip()
+        local_hostname = rdma_utils.get_requester_local_hostname(local_ip)
+        ret = self.store.setup(
+            local_hostname,
+            store_config.metadata_server,
+            store_config.global_segment_size,
+            store_config.local_buffer_size,
+            store_config.protocol,
+            store_config.device_name,
+            store_config.master_server_address,
+        )
         if ret != 0:
             msg = "Initialize MooncakeDistributedStore failed."
             logger.error(msg)
             raise RuntimeError(msg)
+
+        preferred_segment = rdma_utils.get_configured_preferred_segment(extra_config)
+        self.preferred_segment = preferred_segment
+        self.store_replicate_config = None
+        if preferred_segment is not None:
+            self.store_replicate_config = ReplicateConfig()
+            self.store_replicate_config.preferred_segment = preferred_segment
+
+        logger.info(
+            "Mooncake mode=%s (global_segment_size=%d, local_buffer_size=%d, "
+            "preferred_segment=%s, enable_offload=%s)",
+            store_config.mode,
+            store_config.global_segment_size,
+            store_config.local_buffer_size,
+            preferred_segment or "<none>",
+            store_config.enable_offload,
+        )
+        if store_config.mode == "real-client":
+            if store_config.enable_offload and preferred_segment is None:
+                logger.warning(
+                    "enable_offload is set in real-client mode without "
+                    "preferred_segment; SSD tier will only see puts that "
+                    "happen to land on the owner segment."
+                )
+            if preferred_segment is not None:
+                logger.warning(
+                    "preferred_segment=%s with mode=real-client: rank-"
+                    "contributed segments will be idle.",
+                    preferred_segment,
+                )
+        elif store_config.mode == "owner-client" and not store_config.enable_offload:
+            logger.warning(
+                "owner-client mode without enable_offload: large prefills "
+                "may exceed the owner DirectIO budget."
+            )
+
+        self.disk_offload_buffer_budget_bytes = _get_disk_offload_buffer_budget_bytes(
+            store_config.enable_offload
+        )
+
+        # Start lookup server on rank 0 for scheduler-side prefix queries
+        self.lookup_server: LookupKeyServer | None = None
+        if vllm_config.parallel_config.rank == 0:
+            self.lookup_server = LookupKeyServer(self, vllm_config)
 
         kv_event_config = vllm_config.kv_events_config
         self.enable_kv_events = False
@@ -587,11 +917,6 @@ class MooncakeStoreWorker:
         self.kv_send_thread: KVCacheStoreSendingThread | None = None
         self.kv_recv_thread: KVCacheStoreRecvingThread | None = None
         self.finished_store_req: set[str] = set()
-
-        # Start lookup server on rank 0 for scheduler-side prefix queries
-        self.lookup_server: LookupKeyServer | None = None
-        if vllm_config.parallel_config.rank == 0:
-            self.lookup_server = LookupKeyServer(self, vllm_config)
 
     def register_cross_layers_kv_caches(self, kv_cache: torch.Tensor) -> None:
         """Register a cross-layers KV cache tensor.
@@ -695,6 +1020,7 @@ class MooncakeStoreWorker:
                 self.kv_role,
                 ready_event_sending,
                 self.enable_kv_events,
+                getattr(self, "store_replicate_config", None),
             )
             self.kv_send_thread.start()
 
@@ -705,6 +1031,7 @@ class MooncakeStoreWorker:
             self.block_size,
             self.tp_rank,
             ready_event_recving,
+            disk_offload_buffer_budget_bytes=self.disk_offload_buffer_budget_bytes,
         )
         self.kv_recv_thread.start()
         ready_event_recving.wait()
@@ -967,13 +1294,15 @@ class LookupKeyClient:
 
 def get_zmq_rpc_path_lookup(vllm_config: VllmConfig) -> str:
     """Construct IPC path for ZMQ lookup socket."""
+    assert vllm_config.kv_transfer_config is not None
     dp_rank = get_mooncake_dp_engine_index(vllm_config.parallel_config)
     base_url = envs.VLLM_RPC_BASE_PATH
     rpc_port = 0
-    assert vllm_config.kv_transfer_config is not None
+    hostname = socket.gethostname()
     extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     if "lookup_rpc_port" in extra_config:
         rpc_port = extra_config["lookup_rpc_port"]
-    uid = os.getuid()
-    logger.debug("Base URL: %s, RPC Port: %s, UID: %s", base_url, rpc_port, uid)
-    return f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_uid{uid}_dp_rank{dp_rank}"
+    logger.debug("Base URL: %s, RPC Port: %s", base_url, rpc_port)
+    return (
+        f"ipc://{base_url}/lookup_rpc_port_{rpc_port}_host_{hostname}_dp_rank{dp_rank}"
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -35,6 +35,7 @@ from vllm.v1.outputs import KVConnectorOutput
 if TYPE_CHECKING:
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.forward_context import ForwardContext
+    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -226,6 +227,11 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         for c in self._connectors:
             c.register_kv_caches(kv_caches)
+
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+        for c in self._connectors:
+            if hasattr(c, "bind_gpu_block_pool"):
+                c.bind_gpu_block_pool(gpu_block_pool)
 
     # We must override the base class method here because we need to bind
     # the metadata to each connector in the order of the connectors in the

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -189,6 +189,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
+    VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
@@ -1372,6 +1373,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for Mooncake handshake between remote agents.
     "VLLM_MOONCAKE_BOOTSTRAP_PORT": lambda: int(
         os.getenv("VLLM_MOONCAKE_BOOTSTRAP_PORT", "8998")
+    ),
+    # If set, log MooncakeStoreConnector load bytes grouped by replica tier.
+    "VLLM_MOONCAKE_STORE_TIER_LOG": lambda: (
+        os.getenv("VLLM_MOONCAKE_STORE_TIER_LOG", "False").lower() in ("true", "1")
     ),
     # Flashinfer MoE backend for vLLM's fused Mixture-of-Experts support.
     # Both require compute capability 10.0 or above.


### PR DESCRIPTION
## Summary

Forward-port of `feat/mooncake-store-int-owner-client` + PR-31/32/36/37 + the `MultiConnector.bind_gpu_block_pool` fix, on top of rebased `feat/mooncake-store-connector` (445 commits past the original fork point). One squashed commit.

Stacks on `ivanium:feat/mooncake-store-connector` (PR-40900). When that merges to `vllm-project/vllm:main`, this rebases forward.

## What's included

**Owner-client topology** — vLLM ranks become pure requesters (`global_segment_size=0`), a separate `mooncake_client` C++ binary contributes the CPU pool + SSD tier:
- `scripts/mooncake/`: master + owner launcher, RDMA auto-detection helpers, mndp recipe scripts
- `mndp.yaml`: Kimi-K2.5-NVFP4 / Qwen3-8B DP=4 vigil recipe
- `vllm/distributed/.../mooncake/rdma_utils.py`: RNIC + GID detection used by the requester worker

**Disk offload re-introduced** (after intentional revert in PR-40900 commit `0d5c2e051`):
- `_get_disk_offload_buffer_budget_bytes`, `_split_disk_offload_load_batches`, oversized-key fallback
- `KVCacheStoreRecvingThread.disk_offload_buffer_budget_bytes` field + backpressure
- `LookupKeyServer` wiring restored

**Per-tier observability (PR-32)**:
- `VLLM_MOONCAKE_STORE_TIER_LOG=1` → per-batch summary lines: `memory_keys` / `disk_keys` / `unknown_keys` / `success_keys` / `failed_keys` + `bytes_by_tier`

**Perf fix (PR-36)**:
- `_get_disk_offload_buffer_budget_bytes(enable_offload)` now returns `None` when off
- `enable_offload` field on `MooncakeStoreConfig` (read from JSON / `MOONCAKE_ENABLE_OFFLOAD`)
- Dropped redundant count-based split trigger that was always-true for ≥2 keys, doubling owner GET-RPCs

**Owner readiness probe (PR-31)**:
- `run_vllm_with_mooncake_owner.sh` polls the segment port before exec'ing `vllm serve`

**Preferred-segment env (PR-37)**:
- `MOONCAKE_PREFERRED_SEGMENT` env-var falls through to `rdma_utils.get_configured_preferred_segment`
- Wrapper exports `MOONCAKE_PREFERRED_SEGMENT="${OWNER_HOST}:${OWNER_SEGMENT_PORT}"` so the spawned vLLM picks its own node's owner

**MultiConnector fix**:
- `MultiConnector.bind_gpu_block_pool` proxy method, so `simple_cpu_backend`-style child connectors get bound to the GPU block pool in PD-disaggregated setups

## End-to-end validation

Bench: Qwen3-8B DP=4, 100 conversations × 3 turns × 32 concurrent, 16K input, `--gpu-memory-utilization 0.4 --num-gpu-blocks-override 1024`, 4 GiB owner CPU pool to force SSD spillover.

| Signal | Pre-PR-36 (run-17) | Post-PR-36 (run-18) | Δ |
|---|---:|---:|---:|
| Conversations completed | 99/100 | 92/100 | bench variance |
| **Mean TTFT** | 159 467 ms | **62 533 ms** | **−61 %** |
| Median TTFT | 78 766 ms | 62 451 ms | −21 % |
| **Mean E2EL** | 168 080 ms | **70 742 ms** | **−58 %** |
| Tier-log lines emitted | 219 | **115** | −47 % (count-trigger gone) |
| `disk_keys > 0` lines | 219 (100 %) | 113 (98 %) | classification works |
| `memory_keys > 0` lines | 0 | 2 | tier-classification now correct |
| `failed_keys > 0` lines | **0** | **0** | no regressions |
| `-900 RPC_FAIL` in bench | 0 | 0 | clean |
| Disk bytes served back | 59.50 GB | 51.64 GB | proportional to fewer convs |

Every tier-log line is in the expected post-fix shape: `disk_keys=N success_keys=N failed_keys=0 bytes_by_tier={'disk': N, …}`. PR-36's "doubling master GET-RPC pressure" claim is directly visible as the 219 → 115 halving.

## Layout

The owner-client commits assumed flat module layout (`mooncake_store_*.py`) while `feat/mooncake-store-connector` kept a `store/` subdir. Reconciled to flat layout to match upstream PR-40900 author's pre-revert state — `factory.py` registers `MooncakeStoreConnector` at `vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_store_connector`, `mooncake_store_connector.py` imports siblings via `from .mooncake_store_*`.

## Known concerns (not blockers)

- **95 MB bundled `.whl`** under `scripts/mooncake/`. GH flags the large file. Can drop and ship build-from-source instructions in a follow-up if reviewers prefer.
- **`scripts/report_network_gpu_topology.sh` (763 lines)** is orphaned — not referenced by `mndp.yaml` or any other script. Same for `start_mooncake_owner.sh`, `benchmark_*.sh`, `setup_vllm_env.sh`, `compare_results.py`, `mooncake_example.py`. Drop in follow-up if scope tightens (would save ~1620 LoC + 95 MB binary).
- **`rdma_config_utils.sh` (604 lines)** does RNIC + GID auto-detection in shell — long-term this should move into `mooncake_client`'s C++ `setup_real()` as a `--device_names=auto` mode. Out of scope here.

## Related

- vllm-project/vllm#40900 — parent PR (basic MooncakeStoreConnector)
- ivanium/vllm#31 — segment-port readiness probe (folded in)
- ivanium/vllm#32 — `VLLM_MOONCAKE_STORE_TIER_LOG` (folded in)
- ivanium/vllm#36 — `enable_offload` gate + count-trigger removal (folded in)
- ivanium/vllm#37 — `MOONCAKE_PREFERRED_SEGMENT` env (folded in)
- kvcache-ai/Mooncake#2083 — Mooncake-side `is_local_disk_replica` Python binding + standalone-binary `start_offload_rpc_server` default; required for the disk read-back path to actually return data when the owner is the C++ binary

## History

This branch went through 28 incremental commits during integration. After end-to-end validation it has been rebased onto current `feat/mooncake-store-connector` (445 commits later) and squashed to a single commit. Conflict surface: 6 files (`factory.py`, `multi_connector.py`, `envs.py`, two test files, the docs file) — all merged successfully with base's evolution preserved (including base's `kv_cache_config` parameter on `create_connector`, base's 240 lines of new env vars, etc.).