### PR TITLE
[Bugfix] Free out-of-window KV blocks on the processed-token basis

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1404,12 +1404,15 @@ def test_get_max_concurrency_for_kv_cache_config():
         enable_chunked_prefill=True,
         max_model_len=model_config.max_model_len,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        # Pin to sync: SWA per-request bounds grow with overlapping batches.
+        async_scheduling=False,
     )
 
     vllm_config = VllmConfig(
         model_config=model_config,
         scheduler_config=scheduler_config,
     )
+    assert vllm_config.max_concurrent_batches == 1
 
     full_attention_spec = FullAttentionSpec(
         block_size=16,

--- a/tests/v1/core/test_swa_inflight_window_free.py
+++ b/tests/v1/core/test_swa_inflight_window_free.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Out-of-window block frees vs in-flight GPU steps.
+
+With async scheduling / PP, `num_computed_tokens` optimistically includes
+tokens of unprocessed steps whose attention windows still read the blocks
+just below the optimistic boundary (and rejected spec tokens can roll it
+back), so `allocate_slots` frees on the processed-token basis:
+`num_computed_tokens - num_in_flight_tokens`.
+"""
+
+import torch
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler
+
+NUM_PROMPT_TOKENS = 100
+BLOCK_SIZE = 16
+SLIDING_WINDOW = 16
+# Tokens 0..84 are outside the window of the next token to compute
+# (100 - 16 + 1 = 85), i.e. 5 full blocks.
+NUM_OUT_OF_WINDOW_BLOCKS = 85 // BLOCK_SIZE
+
+
+def _make_model_runner_output(
+    scheduler_output: SchedulerOutput,
+    token_id: int = 0,
+) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens.keys())
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[token_id] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def _create_swa_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _num_null_blocks(scheduler, request_id: str) -> int:
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    null_block = manager._null_block
+    return sum(1 for b in manager.req_to_blocks[request_id] if b is null_block)
+
+
+def test_num_in_flight_tokens_accounting():
+    scheduler = create_scheduler(async_scheduling=True)
+    request = create_requests(num_requests=1, num_tokens=NUM_PROMPT_TOKENS)[0]
+    scheduler.add_request(request)
+
+    out0 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS
+    # Async: decode scheduled before the prefill output is processed.
+    out1 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS + 1
+
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 1
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert request.num_in_flight_tokens == 0
+
+
+def test_swa_free_waits_for_in_flight_step():
+    """Async: out-of-window blocks stay allocated until the step that still
+    reads them has been processed."""
+    scheduler = _create_swa_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-window blocks:
+    # they must not be freed yet.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-window
+    # blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks()
+        == free_after_prefill + NUM_OUT_OF_WINDOW_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_free_immediate_when_sync():
+    """Sync: no in-flight step at schedule time, frees happen at the first
+    decode allocation as before."""
+    scheduler = _create_swa_scheduler(async_scheduling=False)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 0
+
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_admission_cap_accounts_for_overlapping_batches():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_num_batched_tokens=1024, max_model_len=16384
+    )
+    # (1024 - 1 + 1024) tokens -> 128 blocks, +1 for window misalignment.
+    assert base == 129
+    overlapped = spec.max_admission_blocks_per_request(
+        max_num_batched_tokens=1024, max_model_len=16384, max_concurrent_batches=2
+    )
+    # One extra in-flight chunk is held back: (1024 - 1 + 2 * 1024) tokens.
+    assert overlapped == 193

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -29,6 +29,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheSpec,
 )
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -58,6 +59,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    kv_cache_spec: KVCacheSpec | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -147,20 +149,17 @@ def create_scheduler(
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
     )
+    if kv_cache_spec is None:
+        kv_cache_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
         kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            )
-        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
     )
     cache_config.num_gpu_blocks = num_blocks
     register_all_kvcache_specs(vllm_config)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -76,6 +76,7 @@ class KVCacheCoordinator(ABC):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -109,6 +110,7 @@ class KVCacheCoordinator(ABC):
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_model_len=max_model_len,
+                max_concurrent_batches=max_concurrent_batches,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
@@ -386,6 +388,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -399,6 +402,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -436,6 +440,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -449,6 +454,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
@@ -522,6 +528,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -535,6 +542,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -783,6 +791,7 @@ def get_kv_cache_coordinator(
     scheduler_block_size: int,
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    max_concurrent_batches: int = 1,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -796,6 +805,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -810,6 +820,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -823,4 +834,5 @@ def get_kv_cache_coordinator(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
+        max_concurrent_batches=max_concurrent_batches,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -123,6 +123,7 @@ class KVCacheManager:
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
         watermark: float = 0.0,
+        max_concurrent_batches: int = 1,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -152,6 +153,7 @@ class KVCacheManager:
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool
@@ -397,8 +399,12 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
+        # Free on the processed-token basis: in-flight steps' attention windows
+        # still read blocks below the optimistic boundary, and rejected spec
+        # tokens can roll it back.
         self.coordinator.remove_skipped_blocks(
-            request.request_id, total_computed_tokens
+            request.request_id,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
         )
 
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -265,6 +265,7 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
@@ -1165,6 +1166,7 @@ class Scheduler(SchedulerInterface):
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
             request.num_computed_tokens += num_scheduled_token
+            request.num_in_flight_tokens += num_scheduled_token
             if self.defer_block_free:
                 # Record the in-flight step, to fence deferred block freeing.
                 request.last_sched_seq = self.sched_step_seq
@@ -1550,10 +1552,12 @@ class Scheduler(SchedulerInterface):
         stopped_preempted_reqs: set[Request] = set()
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # skip failed or rescheduled requests from KV load failure
                 continue
-            request = self.requests.get(req_id)
             if request is None or request.is_finished():
                 # The request is already finished. This can happen if the
                 # request is aborted while the model is executing it (e.g.,
@@ -2338,10 +2342,12 @@ class Scheduler(SchedulerInterface):
             return False, None
 
         # Free any out-of-window prefix blocks before we hand the block table to
-        # the connector.
+        # the connector, on the processed-token basis (see `allocate_slots`).
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
-            total_computed_tokens=request.num_computed_tokens,
+            total_computed_tokens=max(
+                0, request.num_computed_tokens - request.num_in_flight_tokens
+            ),
         )
 
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1075,13 +1075,8 @@ class MambaManager(SingleTypeKVCacheManager):
     def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
-        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
-        # draft tokens from the previous step that may or may not be rejected later.
-        # This can make us think we are further ahead in the sequence than we actually
-        # are, so let's assume that all tokens are rejected so we don't free blocks
-        # that we might actually need.
-        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
-
+        # Spec-rollback safety: callers pass the processed-token basis, which
+        # excludes possibly-rejected in-flight tokens.
         super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
@@ -1381,6 +1376,7 @@ def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
     max_num_batched_tokens: int,
     max_model_len: int,
+    max_concurrent_batches: int = 1,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
     """
@@ -1394,6 +1390,8 @@ def get_manager_for_kv_cache_spec(
         kv_cache_spec: The KVCacheSpec instance
         max_num_batched_tokens: The maximum number of tokens in a batch
         max_model_len: The maximum context length the model could serve
+        max_concurrent_batches: The maximum number of scheduler steps that can
+            overlap on the GPU (async scheduling / pipeline parallelism)
     Returns:
         An instance of the appropriate SingleTypeKVCacheManager subclass
     """
@@ -1409,6 +1407,7 @@ def get_manager_for_kv_cache_spec(
             kv_cache_spec.max_admission_blocks_per_request(
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_model_len=max_model_len,
+                max_concurrent_batches=max_concurrent_batches,
             )
         )
     manager = manager_class(kv_cache_spec, **kwargs)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -442,7 +442,10 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self,
+        max_num_batched_tokens: int,
+        max_model_len: int,
+        max_concurrent_batches: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -450,9 +453,13 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         (`max_memory_usage_bytes`) and the runtime admission gate, so requests
         admitted by startup can also be admitted at runtime.
         """
-        # During chunked prefill, we hold KV for at most one chunk window.
+        # During chunked prefill, we hold KV for at most one chunk window, the
+        # newly scheduled tokens, and — since frees happen on the
+        # processed-token basis — up to `max_concurrent_batches - 1` in-flight
+        # chunks.
         num_tokens = min(
-            self.attention_chunk_size + max_num_batched_tokens, max_model_len
+            self.attention_chunk_size + max_concurrent_batches * max_num_batched_tokens,
+            max_model_len,
         )
         return cdiv(num_tokens, self.block_size)
 
@@ -460,7 +467,9 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         return max_blocks * self.page_size_bytes
 
@@ -504,7 +513,10 @@ class SlidingWindowSpec(AttentionSpec):
         )
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self,
+        max_num_batched_tokens: int,
+        max_model_len: int,
+        max_concurrent_batches: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -515,10 +527,12 @@ class SlidingWindowSpec(AttentionSpec):
         before each chunk's `get_num_blocks_to_allocate`.
         """
         # During chunked prefill, we hold KV for the last `sliding_window-1`
-        # computed tokens plus the newly scheduled tokens, and never more
-        # than `max_model_len`.
+        # computed tokens, the newly scheduled tokens, and — since frees happen
+        # on the processed-token basis — up to `max_concurrent_batches - 1`
+        # in-flight chunks; never more than `max_model_len`.
         num_tokens = min(
-            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
+            self.sliding_window - 1 + max_concurrent_batches * max_num_batched_tokens,
+            max_model_len,
         )
         # +1 because the sliding window may not start from the beginning of
         # the block. E.g. block size 4 and num_token 4 needs two blocks
@@ -532,7 +546,9 @@ class SlidingWindowSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -141,6 +141,11 @@ class Request:
         self.num_output_placeholders = 0
         self.async_tokens_to_discard = 0
 
+        # Tokens of steps whose output is not yet processed (async scheduling
+        # and PP run ahead of the GPU); `num_computed_tokens` counts them
+        # optimistically.
+        self.num_in_flight_tokens = 0
+
         # V2+PP+async: Enforces `pp_size` cadence between same-request decode steps
         # so the worker's broadcast slot ring stays consistent.
         self.next_decode_eligible_step = 0


### PR DESCRIPTION
## Problem

With async scheduling (now default) or PP, the scheduler runs ahead of the GPU: `request.num_computed_tokens` is advanced at schedule time. `remove_skipped_blocks` (SWA / chunked-local / mamba) used this optimistic count as the free boundary, causing two bugs:

1. **vllm-project#47282 (load-WAR):** blocks still covered by an in-flight step's attention window are returned to the pool; a KV-consumer connector reallocates them as load destinations and overwrites them on an unordered stream mid-read.
2. **Spec-rejection misfree (silent):** rejected spec tokens roll the boundary back below already-nulled blocks, so attention reads null KV. Upstream only patched this locally for Mamba (`num_speculative_tokens` subtraction); SWA / chunked-local were exposed.

## Fix

One mechanism fixes both: track `Request.num_in_flight_tokens` (scheduled minus processed, structurally symmetric across preemption / spec rejection / failed-KV-load) and free on the **settled basis** `num_computed_tokens - num_in_flight_tokens`.

Invariant: a block is returned to the pool only when it is outside the attention window of every unprocessed step and no rollback can make it needed again. Sync scheduling has zero in-flight tokens — behavior unchanged, no gating flag.

Consequential (not an independent fix): the SWA / chunked-local per-request admission bound grows to `W - 1 + max_concurrent_batches * max_num_batched_tokens`, applied in the single source of truth used by both startup pool sizing and the runtime gate. MambaManager's local subtraction is removed (subsumed exactly, now also covering prefill chunks and PP depth).

Alternatives considered: vllm-project#47653 (BlockPool fence) and a scheduler-callback defer both fence the free downstream; this PR corrects the lying input instead — no new queues, no BlockPool state, no callbacks. Request-level finish/preempt frees remain behind the vllm-project#45357 fence (write-after-free, unreachable by a lagged basis).

## Tests

- New: `tests/v1/core/test_swa_inflight_window_free.py` — counter symmetry, out-of-window blocks held until the reader step is processed, sync unchanged, admission cap.
- Regression (all pass): `test_deferred_block_free`, `test_single_type_kv_cache_manager`, `test_kv_cache_utils`, `test_async_scheduler`, `test_prefix_caching`, offloading-connector scheduler suite (82), `test_scheduler.py` failure set byte-identical to clean main (35 pre-existing env failures).
- Not yet run: GPU e2e garble repro (async + SWA + SimpleCPUOffload).

AI assistance was used for this change; every line reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)