### PR TITLE
[Core] Fine-grained partial prefix-cache hits for hybrid models (FA/SWA/Mamba) via copy-on-write

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -156,7 +156,8 @@ def test_cache_partial_block_kv_cache_events():
         kv_cache_group_id=kv_cache_group_id,
         block_size=block_size,
     )
-    assert duplicate_entry_hash == partial_entry_hash
+    # Duplicate registration is a no-op and reports no fresh entry.
+    assert duplicate_entry_hash is None
     assert pool.take_events() == []
 
     pool.free_blocks([block])
@@ -368,7 +369,8 @@ def test_cache_partial_block_duplicate_checks_all_blocks_for_hash():
         kv_cache_group_id=kv_cache_group_id,
         block_size=block_size,
     )
-    assert duplicate_entry_hash == second_entry_hash
+    # Re-registering the same (hash, block) pair reports no fresh entry.
+    assert duplicate_entry_hash is None
     assert pool.cached_block_hashes_by_block == {}
 
 

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -2,14 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import pytest
+import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashListWithBlockSize,
@@ -17,6 +20,14 @@ from vllm.v1.core.kv_cache_utils import (
     get_request_block_hasher,
     hash_block_tokens,
     init_none_hash,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    MLAAttentionSpec,
 )
 from vllm.v1.request import Request
 
@@ -460,3 +471,145 @@ def test_partial_block_promotes_to_direct_full_block_hash():
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
     assert pool.get_cached_block(partial_hash_10, [kv_cache_group_id]) is None
+
+
+def _partial_hit_coordinator(groups, scheduler_block_size, hash_block_size):
+    cfg = KVCacheConfig(num_blocks=64, kv_cache_tensors=[], kv_cache_groups=groups)
+    return get_kv_cache_coordinator(
+        cfg,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+    )
+
+
+def _full_spec(block_size: int) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=8, dtype=torch.float32
+    )
+
+
+def _mla_spec(block_size: int) -> MLAAttentionSpec:
+    # Kimi-style MLA: bf16 latent, no fp8/compression.
+    return MLAAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=576, dtype=torch.bfloat16
+    )
+
+
+def _mamba_spec(block_size: int) -> MambaSpec:
+    return MambaSpec(block_size=block_size, shapes=(1, 1), dtypes=(torch.float32,))
+
+
+def test_fine_grained_partial_hits_enabled_for_mla_hybrid():
+    """MLA hybrids (e.g. Kimi-Linear: MLA + KDA) keep fine-grained partial
+    hits. The Kimi-Linear gsm8k regression (0.87 -> 0.68) originally blamed
+    on MLA was really an engine crash caused by unaligned prefill chunk ends
+    after a mid-block resume (see test_mamba_align_split_*): the whole-page
+    CoW copy is layout-agnostic, so MLA needs no exclusion."""
+    # MLA attention + linear (mamba) hybrid, hash granularity finer than block.
+    mla_hybrid = _partial_hit_coordinator(
+        [
+            KVCacheGroupSpec(["attn"], _mla_spec(32)),
+            KVCacheGroupSpec(["lin"], _mamba_spec(32)),
+        ],
+        scheduler_block_size=32,
+        hash_block_size=16,
+    )
+    assert mla_hybrid.enable_partial_hash_hits is True
+
+    # Standard full attention + linear (Qwen3-Next-like) likewise.
+    std_hybrid = _partial_hit_coordinator(
+        [
+            KVCacheGroupSpec(["attn"], _full_spec(32)),
+            KVCacheGroupSpec(["lin"], _mamba_spec(32)),
+        ],
+        scheduler_block_size=32,
+        hash_block_size=16,
+    )
+    assert std_hybrid.enable_partial_hash_hits is True
+
+
+class _SplitSchedulerStub:
+    """Just enough Scheduler state for _mamba_block_aligned_split."""
+
+    def __init__(
+        self,
+        block_size: int,
+        use_eagle: bool = False,
+        hash_block_size: int | None = None,
+    ):
+        self.cache_config = SimpleNamespace(block_size=block_size)
+        self.hash_block_size = (
+            hash_block_size if hash_block_size is not None else block_size
+        )
+        self.use_eagle = use_eagle
+        self.mamba_partial_tail_stop = hash_block_size is not None
+
+
+class _SplitRequestStub:
+    def __init__(self, num_computed_tokens: int, num_prompt_tokens: int):
+        self.num_computed_tokens = num_computed_tokens
+        self.num_prompt_tokens = num_prompt_tokens
+        self.num_tokens = num_prompt_tokens
+
+
+def _split(computed, num_new, prompt, block_size=24, hash_block_size=None):
+    return Scheduler._mamba_block_aligned_split(
+        _SplitSchedulerStub(block_size, hash_block_size=hash_block_size),
+        _SplitRequestStub(computed, prompt),
+        num_new,
+    )
+
+
+def test_mamba_align_split_end_aligned_after_partial_hit():
+    """After a fine-grained partial hit, num_computed_tokens sits mid-block.
+    Align-mode caching requires every mid-prefill chunk to END on a block
+    boundary (frozen state blocks are registered under their block-end hash),
+    and the resumed block must materialize its own boundary state before the
+    request runs past it. Regression: flooring only the chunk LENGTH kept
+    every subsequent step end unaligned, registering mamba state blocks under
+    boundary hashes they never held — later hits then resumed from wrong-length
+    states and crashed the Kimi-Linear KDA/MLA kernels (CUDA illegal memory
+    access, gsm8k 0.87 -> 0.68 from failed requests)."""
+    # Aligned resume: legacy behavior unchanged (floor to block multiples).
+    assert _split(0, 60, 1000) == 48
+    assert _split(48, 60, 1000) == 48
+    # Mid-block resume (partial hit): the first chunk stops exactly at the
+    # next boundary so the resumed (CoW) block freezes its block-end state.
+    assert _split(16, 60, 1000) == 8  # 16 -> 24
+    assert _split(4, 44, 1000) == 20  # 4 -> 24, NOT 4 -> 48
+    # After realignment, chunk ends stay aligned.
+    assert _split(24, 60, 1000) == 48  # 24 -> 72
+    # Not enough budget to reach the next boundary: skip this step.
+    assert _split(16, 4, 1000) == 0
+    # Mid-block resume already inside the final partial block: plain tail
+    # prefill, nothing cacheable ahead, unchanged.
+    assert _split(100, 10, 110) == 10
+    # Mid-block resume with a huge chunk: still stops at the next boundary
+    # first; later chunks then snap to last_cache_position as before.
+    assert _split(16, 500, 100) == 8
+    assert _split(24, 500, 100) == 96 - 24
+
+
+def test_mamba_align_split_partial_tail_stop():
+    """With fine-grained partial hits on, the final prefill chunk stops once
+    more at the prompt's last hash boundary so the mamba partial tail entry
+    (which requires a step ending exactly there) is registered for EVERY
+    prompt, not only hash-aligned ones."""
+    # prompt 110, block 24, hash 4: last_cache_position=96, tail boundary=108.
+    # Final chunk from 96 stops at 108 first, then finishes 108 -> 110.
+    assert _split(96, 500, 110, hash_block_size=4) == 108 - 96
+    assert _split(108, 2, 110, hash_block_size=4) == 2
+    # Hash-aligned prompt: boundary == prompt end, no extra stop needed.
+    assert _split(96, 12, 108, hash_block_size=4) == 12
+    # Without the feature flag, unchanged tail behavior.
+    assert _split(96, 500, 110) == 500
+    # Boundary at/below last_cache_position: already covered by the aligned
+    # stop, no duplicate stop.
+    assert _split(72, 500, 97, hash_block_size=4) == 96 - 72

--- a/tests/v1/core/test_deferred_block_free.py
+++ b/tests/v1/core/test_deferred_block_free.py
@@ -412,3 +412,114 @@ def test_non_async_abort_defers_via_last_sched_seq():
     scheduler.update_from_output(out0, _make_model_runner_output(out0))
     assert not scheduler.deferred_frees
     assert pool.get_num_free_blocks() == num_free_initially
+
+
+def _inject_cow_retentions(scheduler, num_blocks: int = 2):
+    """Simulate a partial-hit CoW from the last scheduled step: the manager
+    holds one retention ref per copy endpoint in `_cow_blocks_to_release`,
+    handed back at the next `new_step_starts`. schedule() records the fence
+    when it emits the copies; mirror that here."""
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    blocks = scheduler.kv_cache_manager.block_pool.get_new_blocks(num_blocks)
+    manager._cow_blocks_to_release.extend(blocks)
+    scheduler.cow_copy_fence_seq = scheduler.sched_step_seq
+    return blocks
+
+
+def test_cow_retention_release_deferred_while_step_inflight():
+    """CoW copy retentions ride the same fence as request-level frees: the
+    step that runs the queued block copy may still be in flight when the next
+    schedule() hands the retentions back, and a consumer connector could
+    otherwise reallocate a copy endpoint as a load destination.
+    """
+    scheduler = _create_deferring_scheduler()
+    pool = scheduler.kv_cache_manager.block_pool
+    request, out0, out1 = _setup_request_with_inflight_step(scheduler)
+
+    _inject_cow_retentions(scheduler)
+    num_free = pool.get_num_free_blocks()
+    scheduler.kv_cache_manager.new_step_starts()
+
+    # Withheld from the pool until the newest in-flight step (which carried
+    # the copies) is processed.
+    assert len(scheduler.deferred_frees) == 1
+    assert scheduler.deferred_frees[0][0] == scheduler.sched_step_seq
+    assert pool.get_num_free_blocks() == num_free
+
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert len(scheduler.deferred_frees) == 1
+    assert pool.get_num_free_blocks() == num_free
+
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert not scheduler.deferred_frees
+    assert pool.get_num_free_blocks() == num_free + 2
+
+
+def test_cow_retention_release_immediate_when_quiescent():
+    # Deferral gate on, but the newest scheduled step has already been
+    # processed: the copies have run, release immediately.
+    scheduler = _create_deferring_scheduler()
+    pool = scheduler.kv_cache_manager.block_pool
+    request = create_requests(
+        num_requests=1,
+        num_tokens=NUM_PROMPT_TOKENS,
+        max_tokens=5,
+        stop_token_ids=[STOP_TOKEN_ID],
+    )[0]
+    scheduler.add_request(request)
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+
+    _inject_cow_retentions(scheduler)
+    num_free = pool.get_num_free_blocks()
+    scheduler.kv_cache_manager.new_step_starts()
+    assert not scheduler.deferred_frees
+    assert pool.get_num_free_blocks() == num_free + 2
+
+
+def test_cow_retention_release_deferred_when_copies_rode_empty_step():
+    """Copies can ride a 0-token step (async KV loads only), which never
+    advances sched_step_seq: the retention fence must point at the next
+    non-empty step instead of the already-satisfied current seq."""
+    scheduler = _create_deferring_scheduler()
+    pool = scheduler.kv_cache_manager.block_pool
+    request = create_requests(
+        num_requests=1,
+        num_tokens=NUM_PROMPT_TOKENS,
+        max_tokens=5,
+        stop_token_ids=[STOP_TOKEN_ID],
+    )[0]
+    scheduler.add_request(request)
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+
+    # Quiescent (sched == processed), then copies emitted by a 0-token step:
+    # schedule() fences them one step ahead.
+    _inject_cow_retentions(scheduler)
+    scheduler.cow_copy_fence_seq = scheduler.sched_step_seq + 1
+    num_free = pool.get_num_free_blocks()
+    scheduler.kv_cache_manager.new_step_starts()
+    assert len(scheduler.deferred_frees) == 1
+    assert pool.get_num_free_blocks() == num_free
+
+    # The next non-empty step completing implies the copies have run.
+    out1 = scheduler.schedule()
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert not scheduler.deferred_frees
+    assert pool.get_num_free_blocks() == num_free + 2
+
+
+def test_cow_retention_release_immediate_when_gate_off():
+    # Without the deferral gate, retention releases stay immediate even with
+    # an in-flight step: GPU-stream writers of a reallocated block are
+    # ordered after the in-flight copy.
+    scheduler = create_scheduler(model=MODEL, async_scheduling=True)
+    assert not scheduler.defer_block_free
+    pool = scheduler.kv_cache_manager.block_pool
+    _setup_request_with_inflight_step(scheduler)
+
+    _inject_cow_retentions(scheduler)
+    num_free = pool.get_num_free_blocks()
+    scheduler.kv_cache_manager.new_step_starts()
+    assert not scheduler.deferred_frees
+    assert pool.get_num_free_blocks() == num_free + 2

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1404,12 +1404,15 @@ def test_get_max_concurrency_for_kv_cache_config():
         enable_chunked_prefill=True,
         max_model_len=model_config.max_model_len,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        # Pin to sync: SWA per-request bounds grow with overlapping batches.
+        async_scheduling=False,
     )
 
     vllm_config = VllmConfig(
         model_config=model_config,
         scheduler_config=scheduler_config,
     )
+    assert vllm_config.max_concurrent_batches == 1
 
     full_attention_spec = FullAttentionSpec(
         block_size=16,

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2509,3 +2509,63 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+def test_resolve_block_hashes_gate():
+    # Resolve symbols through the module so they stay consistent with each other
+    # even after other tests reload ``kv_cache_utils``.
+    resolve_block_hashes = kv_cache_utils.resolve_block_hashes
+    BlockHashListWithBlockSize = kv_cache_utils.BlockHashListWithBlockSize
+    # Raw, hash_block_size-granularity hashes (contents are opaque here).
+    raw = [BlockHash(bytes([i])) for i in range(8)]
+
+    # block_size == hash_block_size: always reuse the raw hashes.
+    assert resolve_block_hashes(raw, 2, 2, alignment_tokens=2) is raw
+    assert (
+        resolve_block_hashes(
+            raw, 2, 2, supports_fine_grained_hash_lookup=True, alignment_tokens=2
+        )
+        is raw
+    )
+
+    # Fine-grained manager, partial hits ON (alignment_tokens == hash_block_size
+    # < block_size): keep raw hashes so the manager can scan at hash granularity.
+    assert (
+        resolve_block_hashes(
+            raw, 2, 4, supports_fine_grained_hash_lookup=True, alignment_tokens=2
+        )
+        is raw
+    )
+
+    # Fine-grained manager, partial hits OFF (alignment_tokens ==
+    # scheduler_block_size >= block_size): must fall back to a block-size view,
+    # exactly like the pre-refactor coordinator did.
+    off = resolve_block_hashes(
+        raw, 2, 4, supports_fine_grained_hash_lookup=True, alignment_tokens=4
+    )
+    assert isinstance(off, BlockHashListWithBlockSize)
+    assert off.scale_factor == 2
+
+    # Non-fine-grained manager (e.g. sliding window): always a block-size view
+    # when block_size != hash_block_size, regardless of alignment_tokens.
+    swa = resolve_block_hashes(
+        raw, 2, 4, supports_fine_grained_hash_lookup=False, alignment_tokens=2
+    )
+    assert isinstance(swa, BlockHashListWithBlockSize)
+    assert swa.scale_factor == 2
+
+
+def test_resolve_block_hashes_rejects_mismatched_view():
+    resolve_block_hashes = kv_cache_utils.resolve_block_hashes
+    BlockHashListWithBlockSize = kv_cache_utils.BlockHashListWithBlockSize
+    raw = [BlockHash(bytes([i])) for i in range(8)]
+
+    # A view built at this block_size is returned as-is (idempotent).
+    view = BlockHashListWithBlockSize(raw, 2, 4)
+    assert resolve_block_hashes(view, 2, 4) is view
+
+    # A view built at a different block_size must fail loudly rather than be
+    # silently reinterpreted at the wrong granularity.
+    mismatched = BlockHashListWithBlockSize(raw, 2, 8)
+    with pytest.raises(AssertionError):
+        resolve_block_hashes(mismatched, 2, 4)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2572,3 +2572,27 @@ def test_resolve_block_hashes_rejects_mismatched_view():
     mismatched = BlockHashListWithBlockSize(raw, 2, 8)
     with pytest.raises(AssertionError):
         resolve_block_hashes(mismatched, 2, 4)
+
+
+def test_resolve_kv_cache_block_sizes_rejects_single_group_hash_override():
+    """A single KV cache group has nothing to gain from a finer hash block
+    size (fine-grained partial hits are hybrid-only), and with context
+    parallelism hashes must be computed at the scaled block size — fail fast
+    instead of silently ignoring the override."""
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    kv_cache_config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer1"], new_kv_cache_spec())],
+    )
+    block_size = vllm_config.cache_config.block_size
+
+    # A matching value is a no-op and passes.
+    vllm_config.cache_config.hash_block_size = block_size
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        kv_cache_config, vllm_config
+    ) == (block_size, block_size)
+
+    vllm_config.cache_config.hash_block_size = block_size // 2
+    with pytest.raises(ValueError, match="single KV cache group"):
+        kv_cache_utils.resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1271,6 +1271,9 @@ def test_hybrid_full_attention_partial_hash_hit_uses_cow():
         )
         in manager.take_kv_cache_block_copies()
     )
+    assert partial_full_block[0].ref_cnt == 1
+    manager.new_step_starts()
+    assert partial_full_block[0].ref_cnt == 0
 
 
 def test_hybrid_partial_hash_truncates_full_attention_hit_length():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1197,6 +1197,10 @@ def test_hybrid_mamba_align_partial_hash_hit():
     assert len(mamba_new_block_ids) == 1
     assert mamba_new_block_ids[0] != partial_mamba_block[0].block_id
     assert manager.get_blocks("1").get_block_ids()[1][1] == mamba_new_block_ids[0]
+    assert partial_mamba_block[0].block_hash is not None
+    assert get_block_hash(partial_mamba_block[0].block_hash) == partial_mamba_hash
+    assert get_group_id(partial_mamba_block[0].block_hash) == 1
+    assert partial_mamba_block[0].block_hash_num_tokens == 6
     assert (
         KVCacheBlockCopy(
             src_block_id=partial_mamba_block[0].block_id,
@@ -1263,6 +1267,13 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     assert len(mamba_new_block_ids) == 1
     assert mamba_new_block_ids[0] != partial_mamba_block_id
     assert manager.get_blocks("0").get_block_ids()[1][1] == mamba_new_block_ids[0]
+    assert partial_mamba_block[0].block_hash is not None
+    assert get_block_hash(partial_mamba_block[0].block_hash) == partial_mamba_hash
+    assert get_group_id(partial_mamba_block[0].block_hash) == 1
+    assert partial_mamba_block[0].block_hash_num_tokens == 6
+    cow_mamba_block = manager.get_blocks("0").blocks[1][1]
+    assert cow_mamba_block.block_hash is None
+    assert cow_mamba_block.block_hash_num_tokens is None
     assert (
         KVCacheBlockCopy(
             src_block_id=partial_mamba_block_id,
@@ -1404,6 +1415,10 @@ def test_hybrid_full_attention_partial_hash_hit_uses_cow():
     full_new_block_ids = new_blocks.get_block_ids()[0]
     assert len(full_new_block_ids) == 1
     assert full_new_block_ids[0] != partial_full_block[0].block_id
+    assert partial_full_block[0].block_hash is not None
+    assert get_block_hash(partial_full_block[0].block_hash) == partial_full_hash
+    assert get_group_id(partial_full_block[0].block_hash) == 0
+    assert partial_full_block[0].block_hash_num_tokens == 6
     assert (
         KVCacheBlockCopy(
             src_block_id=partial_full_block[0].block_id,
@@ -1414,6 +1429,89 @@ def test_hybrid_full_attention_partial_hash_hit_uses_cow():
     assert partial_full_block[0].ref_cnt == 1
     manager.new_step_starts()
     assert partial_full_block[0].ref_cnt == 0
+
+
+def test_hybrid_partial_hit_cow_target_starts_uncached():
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    partial_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_full_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[0]
+    )
+    partial_mamba_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_full_block is not None
+    assert partial_mamba_block is not None
+
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+
+    new_blocks = manager.allocate_slots(
+        req1,
+        2,
+        num_computed,
+        computed_blocks,
+        delay_cache_blocks=True,
+    )
+    assert new_blocks is not None
+
+    full_cow_block = manager.get_blocks("1").blocks[0][1]
+    mamba_cow_block = manager.get_blocks("1").blocks[1][1]
+    assert full_cow_block.block_id != partial_full_block[0].block_id
+    assert mamba_cow_block.block_id != partial_mamba_block[0].block_id
+    assert full_cow_block.block_hash is None
+    assert full_cow_block.block_hash_num_tokens is None
+    assert mamba_cow_block.block_hash is None
+    assert mamba_cow_block.block_hash_num_tokens is None
+
+    assert partial_full_block[0].block_hash is not None
+    assert get_block_hash(partial_full_block[0].block_hash) == partial_hash
+    assert get_group_id(partial_full_block[0].block_hash) == 0
+    assert partial_full_block[0].block_hash_num_tokens == 6
+    assert partial_mamba_block[0].block_hash is not None
+    assert get_block_hash(partial_mamba_block[0].block_hash) == partial_hash
+    assert get_group_id(partial_mamba_block[0].block_hash) == 1
+    assert partial_mamba_block[0].block_hash_num_tokens == 6
 
 
 def test_hybrid_partial_hash_truncates_full_attention_hit_length():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1486,7 +1486,6 @@ def test_hybrid_partial_hash_truncates_full_attention_hit_length():
     computed_blocks, num_computed = manager.get_computed_blocks(req)
     assert num_computed == 6
     assert [len(group) for group in computed_blocks.blocks] == [2, 2]
-    assert computed_blocks.blocks[0].hit_length == 6
 
 
 def test_prefill_plp():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -27,6 +27,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashWithGroupId,
     KVCacheBlock,
+    KVCacheBlockCopy,
     get_block_hash,
     get_group_id,
     get_request_block_hasher,
@@ -1134,6 +1135,219 @@ def test_hybrid_model_mamba_align_with_dynamic_draft_tokens():
     assert blocks is not None and all(len(group) == 0 for group in blocks.blocks)
 
     manager.free(req0)
+
+
+def test_hybrid_mamba_align_partial_hash_hit():
+    hash_block_size = 2
+    mamba_block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=20,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    blocks = manager.allocate_slots(req0, 6, num_computed, computed_blocks)
+    assert blocks is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_mamba_block = manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_mamba_block is not None
+    assert partial_mamba_block[0].block_hash_num_tokens == 6
+
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+    assert [len(group) for group in computed_blocks.blocks] == [3, 2]
+
+    new_blocks = manager.allocate_slots(req1, 2, num_computed, computed_blocks)
+    assert new_blocks is not None
+    mamba_new_block_ids = new_blocks.get_block_ids()[1]
+    assert len(mamba_new_block_ids) == 1
+    assert mamba_new_block_ids[0] != partial_mamba_block[0].block_id
+    assert manager.get_blocks("1").get_block_ids()[1][1] == mamba_new_block_ids[0]
+    assert (
+        KVCacheBlockCopy(
+            kv_cache_group_id=1,
+            src_block_id=partial_mamba_block[0].block_id,
+            dst_block_id=mamba_new_block_ids[0],
+            num_tokens=mamba_block_size,
+        )
+        in manager.take_kv_cache_block_copies()
+    )
+    assert manager.get_blocks("1").blocks[1][1].block_hash_num_tokens == 8
+
+
+def test_hybrid_full_attention_partial_hash_hit_uses_cow():
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    partial_full_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_full_block = manager.block_pool.get_cached_block(
+        partial_full_hash, kv_cache_group_ids=[0]
+    )
+    assert partial_full_block is not None
+
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+    assert [len(group) for group in computed_blocks.blocks] == [2, 2]
+
+    new_blocks = manager.allocate_slots(req1, 2, num_computed, computed_blocks)
+    assert new_blocks is not None
+    full_new_block_ids = new_blocks.get_block_ids()[0]
+    assert len(full_new_block_ids) == 1
+    assert full_new_block_ids[0] != partial_full_block[0].block_id
+    assert (
+        KVCacheBlockCopy(
+            kv_cache_group_id=0,
+            src_block_id=partial_full_block[0].block_id,
+            dst_block_id=full_new_block_ids[0],
+            num_tokens=2,
+        )
+        in manager.take_kv_cache_block_copies()
+    )
+
+
+def test_hybrid_partial_hash_truncates_full_attention_hit_length():
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request(
+        "0",
+        [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+        hash_block_size,
+        sha256,
+    )
+
+    full_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=full_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    pool.cache_partial_block(
+        request=req,
+        block=full_blocks[2],
+        num_tokens=10,
+        kv_cache_group_id=0,
+        block_size=block_size,
+    )
+
+    mamba_block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(
+        request=req,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=1,
+        block_size=block_size,
+    )
+
+    computed_blocks, num_computed = manager.get_computed_blocks(req)
+    assert num_computed == 6
+    assert [len(group) for group in computed_blocks.blocks] == [2, 2]
+    assert computed_blocks.blocks[0].hit_length == 6
 
 
 def test_prefill_plp():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1199,10 +1199,8 @@ def test_hybrid_mamba_align_partial_hash_hit():
     assert manager.get_blocks("1").get_block_ids()[1][1] == mamba_new_block_ids[0]
     assert (
         KVCacheBlockCopy(
-            kv_cache_group_id=1,
             src_block_id=partial_mamba_block[0].block_id,
             dst_block_id=mamba_new_block_ids[0],
-            num_tokens=mamba_block_size,
         )
         in manager.take_kv_cache_block_copies()
     )
@@ -1268,10 +1266,8 @@ def test_hybrid_full_attention_partial_hash_hit_uses_cow():
     assert full_new_block_ids[0] != partial_full_block[0].block_id
     assert (
         KVCacheBlockCopy(
-            kv_cache_group_id=0,
             src_block_id=partial_full_block[0].block_id,
             dst_block_id=full_new_block_ids[0],
-            num_tokens=2,
         )
         in manager.take_kv_cache_block_copies()
     )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1751,6 +1751,147 @@ def test_hybrid_partial_hash_truncates_full_attention_hit_length():
     assert [len(group) for group in computed_blocks.blocks] == [2, 2]
 
 
+def _make_fa_swa_manager():
+    """FA block 4 + two SWA groups (block 4, window 8), hash_block_size 2.
+
+    hash < lcm and every group scans at hash granularity, so partial hash
+    hits are enabled without any mamba group.
+    """
+    kv_cache_config = make_kv_cache_config_hybrid_model(
+        block_size=4, num_blocks=40, sliding_window_blocks=2
+    )
+    return make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=2,
+    )
+
+
+def test_hybrid_swa_partial_hash_hit_uses_cow():
+    manager = _make_fa_swa_manager()
+    assert manager.coordinator.enable_partial_hash_hits
+
+    # 14 tokens: 3 full blocks + a 2-token tail inside block 3.
+    req0 = make_request("0", [i for i in range(7) for _ in range(2)], 2, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 14, num_computed, computed_blocks) is not None
+
+    # The prompt tail at 14 tokens is registered in every group.
+    tail_hash = req0.block_hashes[6]
+    tail_blocks = manager.block_pool.get_cached_block(
+        tail_hash, kv_cache_group_ids=[0, 1, 2]
+    )
+    assert tail_blocks is not None
+    assert all(b.block_hash_num_tokens == 14 for b in tail_blocks)
+
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", [i for i in range(8) for _ in range(2)], 2, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 14
+    assert [len(group) for group in computed_blocks.blocks] == [4, 4, 4]
+    # SWA hits pad blocks before the window with nulls.
+    assert computed_blocks.blocks[1][0] is manager.block_pool.null_block
+    assert all(
+        group[-1].block_id == tail.block_id
+        for group, tail in zip(computed_blocks.blocks, tail_blocks)
+    )
+
+    new_blocks = manager.allocate_slots(req1, 2, num_computed, computed_blocks)
+    assert new_blocks is not None
+    copies = manager.take_kv_cache_block_copies()
+    for group_id, tail in enumerate(tail_blocks):
+        cow_ids = new_blocks.get_block_ids()[group_id]
+        assert len(cow_ids) == 1
+        assert cow_ids[0] != tail.block_id
+        assert (
+            KVCacheBlockCopy(src_block_id=tail.block_id, dst_block_id=cow_ids[0])
+            in copies
+        )
+        assert manager.get_blocks("1").get_block_ids()[group_id][3] == cow_ids[0]
+
+
+def test_hybrid_swa_partial_hit_requires_window_coverage():
+    manager = _make_fa_swa_manager()
+    pool = manager.block_pool
+
+    req0 = make_request("0", [i for i in range(7) for _ in range(2)], 2, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 14, num_computed, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    # Evict SWA block 1 (tokens [4, 8), key = hash at its last boundary) from
+    # both SWA groups: window coverage for the fine hits at 14 and 12 breaks.
+    for group_id in (1, 2):
+        evicted = pool.get_cached_block(req0.block_hashes[3], [group_id])
+        assert evicted is not None
+        pool.cached_block_hash_to_block.pop(
+            make_block_hash_with_group_id(req0.block_hashes[3], group_id),
+            evicted[0].block_id,
+        )
+
+    req1 = make_request("1", [i for i in range(8) for _ in range(2)], 2, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    # The longest SWA hit is now the standalone block-0 entry (4 tokens, the
+    # whole window for the token at position 4); full attention truncates to
+    # the common hit.
+    assert num_computed == 4
+    assert [len(group) for group in computed_blocks.blocks] == [1, 1, 1]
+
+
+def test_partial_hit_shared_source_two_consumers():
+    """Two requests consuming the same partial tail in one step must each get
+    a private CoW block, and the shared source must be fully released after
+    both are freed."""
+    manager = _make_fa_swa_manager()
+    pool = manager.block_pool
+
+    req0 = make_request("0", [i for i in range(7) for _ in range(2)], 2, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 14, num_computed, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    tail_hash = req0.block_hashes[6]
+    src_ids = [
+        b.block_id
+        for b in pool.get_cached_block(tail_hash, kv_cache_group_ids=[0, 1, 2])
+    ]
+
+    tokens = [i for i in range(8) for _ in range(2)]
+    cow_ids_by_req = {}
+    consumers = {}
+    for req_id in ("1", "2"):
+        req = make_request(req_id, tokens, 2, sha256)
+        consumers[req_id] = req
+        computed_blocks, num_computed = manager.get_computed_blocks(req)
+        assert num_computed == 14
+        new_blocks = manager.allocate_slots(req, 2, num_computed, computed_blocks)
+        assert new_blocks is not None
+        cow_ids_by_req[req_id] = [ids[0] for ids in new_blocks.get_block_ids()]
+
+    copies = manager.take_kv_cache_block_copies()
+    for group_id, src_id in enumerate(src_ids):
+        cow1 = cow_ids_by_req["1"][group_id]
+        cow2 = cow_ids_by_req["2"][group_id]
+        assert cow1 != cow2 and src_id not in (cow1, cow2)
+        for cow_id in (cow1, cow2):
+            assert KVCacheBlockCopy(src_block_id=src_id, dst_block_id=cow_id) in copies
+
+    manager.free(consumers["1"])
+    manager.free(consumers["2"])
+    manager.new_step_starts()
+    # The shared sources' hit-refs are released after the copies ran; the
+    # entries stay in the prefix cache as eviction candidates.
+    for src_id in src_ids:
+        assert pool.blocks[src_id].ref_cnt == 0
+    assert pool.get_cached_block(tail_hash, kv_cache_group_ids=[0, 1, 2]) is not None
+
+
 def test_prefill_plp():
     """Test prefill with APC and some prompt logprobs (plp) requests.
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1263,28 +1263,44 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     new_blocks = manager.allocate_slots(req0, 1)
     assert new_blocks is not None
 
-    mamba_new_block_ids = new_blocks.get_block_ids()[1]
-    assert len(mamba_new_block_ids) == 1
-    assert mamba_new_block_ids[0] != partial_mamba_block_id
-    assert manager.get_blocks("0").get_block_ids()[1][1] == mamba_new_block_ids[0]
-    assert partial_mamba_block[0].block_hash is not None
-    assert get_block_hash(partial_mamba_block[0].block_hash) == partial_mamba_hash
-    assert get_group_id(partial_mamba_block[0].block_hash) == 1
-    assert partial_mamba_block[0].block_hash_num_tokens == 6
-    cow_mamba_block = manager.get_blocks("0").blocks[1][1]
-    assert cow_mamba_block.block_hash is None
-    assert cow_mamba_block.block_hash_num_tokens is None
+    # The producer keeps its own block: the worker block-table update protocol
+    # for running requests is append-only, so its table must not change.
+    assert new_blocks.get_block_ids()[1] == []
+    assert manager.get_blocks("0").get_block_ids()[1][1] == partial_mamba_block_id
+    # The prefix-cache entry moved to a private copy of the state.
+    moved = manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    )
+    assert moved is not None
+    cache_block = moved[0]
+    assert cache_block.block_id != partial_mamba_block_id
+    assert cache_block.block_hash is not None
+    assert get_block_hash(cache_block.block_hash) == partial_mamba_hash
+    assert get_group_id(cache_block.block_hash) == 1
+    assert cache_block.block_hash_num_tokens == 6
+    # The producer's own block no longer serves the cache entry.
+    assert partial_mamba_block[0].block_hash is None
     assert (
         KVCacheBlockCopy(
             src_block_id=partial_mamba_block_id,
-            dst_block_id=mamba_new_block_ids[0],
+            dst_block_id=cache_block.block_id,
         )
         in manager.take_kv_cache_block_copies()
     )
-    assert (
-        manager.block_pool.get_cached_block(partial_mamba_hash, kv_cache_group_ids=[1])
-        == partial_mamba_block
-    )
+    # A consumer in the same step must be deferred: the copied state only
+    # exists once this step starts executing.
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 4, 4], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+    assert manager.allocate_slots(req1, 2, num_computed, computed_blocks) is None
+
+    # The copy target is pinned until the copy has run, then becomes evictable.
+    assert cache_block.ref_cnt == 1
+    manager.new_step_starts()
+    assert cache_block.ref_cnt == 0
+    assert manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    ) == [cache_block]
 
 
 def test_hybrid_mamba_partial_tail_owner_continue_preserves_later_hit():
@@ -1337,25 +1353,174 @@ def test_hybrid_mamba_partial_tail_owner_continue_preserves_later_hit():
     req0.append_output_token_ids([3])
     assert manager.allocate_slots(req0, 1) is not None
     manager.take_kv_cache_block_copies()
+    # The entry now points at the producer's private cache copy.
+    moved = manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    )
+    assert moved is not None
+    cache_block_id = moved[0].block_id
+    assert cache_block_id != partial_mamba_block_id
     manager.new_step_starts()
 
     req1 = make_request("1", [0, 0, 1, 1, 2, 2, 4, 4], hash_block_size, sha256)
     computed_blocks, num_computed = manager.get_computed_blocks(req1)
     assert num_computed == 6
-    assert computed_blocks.get_block_ids()[1][1] == partial_mamba_block_id
+    assert computed_blocks.get_block_ids()[1][1] == cache_block_id
 
     new_blocks = manager.allocate_slots(req1, 2, num_computed, computed_blocks)
     assert new_blocks is not None
     mamba_new_block_ids = new_blocks.get_block_ids()[1]
     assert len(mamba_new_block_ids) == 1
-    assert mamba_new_block_ids[0] != partial_mamba_block_id
+    assert mamba_new_block_ids[0] != cache_block_id
     assert (
         KVCacheBlockCopy(
-            src_block_id=partial_mamba_block_id,
+            src_block_id=cache_block_id,
             dst_block_id=mamba_new_block_ids[0],
         )
         in manager.take_kv_cache_block_copies()
     )
+
+
+def test_hybrid_mamba_partial_tail_producer_append_only_worker_table():
+    """The worker updates a RUNNING request's block table append-only
+    (``gpu_model_runner`` extends ``block_ids`` with the newly returned IDs),
+    so the scheduler must never redirect an already-sent, non-null table
+    position. Otherwise the worker keeps writing mamba state into the block
+    the scheduler handed to the prefix cache, corrupting the cached entry.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    # A new request's full block table is sent to the worker.
+    worker_table = [list(ids) for ids in manager.get_blocks("0").get_block_ids()]
+    null_id = manager.block_pool.null_block.block_id
+
+    def check_worker_view():
+        # Every non-null scheduler position must match what the append-only
+        # worker holds at that position (null positions are never read).
+        for group_ids, worker_ids in zip(
+            manager.get_blocks("0").get_block_ids(), worker_table
+        ):
+            for pos, block_id in enumerate(group_ids):
+                if block_id != null_id:
+                    assert worker_ids[pos] == block_id
+
+    # Decode steps; the first one triggers the partial-tail CoW.
+    for num_computed_tokens in (6, 7, 8):
+        req0.num_computed_tokens = num_computed_tokens
+        req0.append_output_token_ids([3])
+        manager.new_step_starts()
+        new_blocks = manager.allocate_slots(req0, 1)
+        assert new_blocks is not None
+        for worker_ids, new_ids in zip(worker_table, new_blocks.get_block_ids()):
+            worker_ids.extend(new_ids)
+        check_worker_view()
+
+
+def test_partial_hit_cow_copy_target_pinned_until_copy_runs():
+    """A consumer freed (aborted/preempted) in the same scheduling step still
+    has a pending CoW copy targeting its private block. That block must not be
+    handed to another request before the copy runs at step start, or the stale
+    copy would overwrite the new owner's freshly zeroed block."""
+    hash_block_size = 2
+    mamba_block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=20,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 3, 3], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+    assert manager.allocate_slots(req1, 2, num_computed, computed_blocks) is not None
+    cow_block = manager.get_blocks("1").blocks[1][1]
+
+    # Same step: the consumer is freed with its copy still pending.
+    manager.free(req1)
+
+    copies = manager.take_kv_cache_block_copies()
+    assert any(c.dst_block_id == cow_block.block_id for c in copies)
+    # Both ends of the pending copy stay pinned: draining the entire free
+    # queue (what same-step allocations under the memory pressure that causes
+    # preemption do) must not hand them out.
+    drained = manager.block_pool.get_new_blocks(
+        manager.block_pool.get_num_free_blocks()
+    )
+    drained_ids = {block.block_id for block in drained}
+    for block_copy in copies:
+        assert block_copy.dst_block_id not in drained_ids
+        assert block_copy.src_block_id not in drained_ids
+
+    # Once the copies have run, the pinned blocks become reusable.
+    manager.new_step_starts()
+    assert cow_block.ref_cnt == 0
+    assert manager.block_pool.get_num_free_blocks() == 2
 
 
 def test_hybrid_full_attention_partial_hash_hit_uses_cow():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1068,7 +1068,9 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
     # Next, validate scheduler logic for num_uncached_common_prefix_tokens > 0
     # Create minimal mock with just the needed attributes
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=block_size), use_eagle=False
+        cache_config=SimpleNamespace(block_size=block_size),
+        use_eagle=False,
+        mamba_partial_tail_stop=False,
     )
     num_new_tokens_adjusted = Scheduler._mamba_block_aligned_split(
         self=mock,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3453,9 +3453,11 @@ def test_different_block_size():
     assert len(computed_blocks.blocks[1]) == 6
     assert num_computed_tokens == 6 * 16
 
-    # Evict some blocks to make sliding window cache hit length 5*16
-    # But should return 4 * 16 because full attention cache hit length must be
-    # a multiple of 32
+    # Evict some blocks to make sliding window cache hit length 5*16.
+    # hash_block_size (16) < lcm (32) enables partial hits for this FA+SWA
+    # config, so the common hit stays at 5*16: full attention serves the
+    # mid-block tail with a copy-on-write of its third block (kept in the
+    # returned blocks), instead of clamping down to a 32-aligned 4*16.
     manager.block_pool.cached_block_hash_to_block.pop(
         make_block_hash_with_group_id(req1.block_hashes[6], 1), 11
     )
@@ -3463,9 +3465,9 @@ def test_different_block_size():
         make_block_hash_with_group_id(req1.block_hashes[5], 1), 10
     )
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
-    assert len(computed_blocks.blocks[0]) == 2
-    assert len(computed_blocks.blocks[1]) == 4
-    assert num_computed_tokens == 4 * 16
+    assert len(computed_blocks.blocks[0]) == 3
+    assert len(computed_blocks.blocks[1]) == 5
+    assert num_computed_tokens == 5 * 16
 
 
 def test_hybrid_cache_blocks_swa_tail_window_only():
@@ -3540,12 +3542,11 @@ def test_hybrid_cache_blocks_swa_tail_window_only():
             )
 
 
-def test_hybrid_cache_blocks_clamped_to_lcm():
-    """HybridKVCacheCoordinator.cache_blocks() clamps to scheduler_block_size.
-    Chunks past the last lcm-aligned boundary can never participate in a
-    cache hit (find_longest_cache_hit always returns lcm-aligned hits), so
-    caching them only pollutes the prefix-cache hash map and keeps blocks
-    on the LRU list that could otherwise return to the free pool."""
+def test_hybrid_cache_blocks_fine_tail_cached():
+    """With hash_block_size < lcm, partial hash hits are enabled for FA+SWA
+    hybrids, so HybridKVCacheCoordinator.cache_blocks() no longer clamps to
+    scheduler_block_size: chunks past the last lcm-aligned boundary are now
+    legitimate fine-grained hit targets and must be cached."""
     block_size = 16
     # Full attn block_size=32, SWA block_size=16 -> lcm=32.
     kv_cache_config = KVCacheConfig(
@@ -3595,16 +3596,14 @@ def test_hybrid_cache_blocks_clamped_to_lcm():
     assert len(req.block_hashes) == 7
 
     pool = manager.block_pool
-    # SWA group_id=1: hashes 0..5 cached (6 blocks * 16 tokens = 96), hash 6
-    # spans tokens [96, 112) past the lcm boundary and must NOT be cached.
-    for i in range(6):
+    # SWA group_id=1: with partial hits enabled, all 7 hashes are cached —
+    # including hash 6 spanning tokens [96, 112) past the lcm boundary, which
+    # a fine-grained lookup can now hit directly.
+    for i in range(7):
         assert (
             pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
             is not None
         ), f"SWA hash {i} should be cached"
-    assert pool.get_cached_block(req.block_hashes[6], kv_cache_group_ids=[1]) is None, (
-        "SWA hash 6 spans tokens past the lcm boundary; should not be cached"
-    )
 
 
 def test_hybrid_local_kv_retention_interval_aligns_in_manager(monkeypatch):

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1207,6 +1207,146 @@ def test_hybrid_mamba_align_partial_hash_hit():
     assert manager.get_blocks("1").blocks[1][1].block_hash_num_tokens == 8
 
 
+def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+
+    partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_mamba_block = manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_mamba_block is not None
+    partial_mamba_block_id = partial_mamba_block[0].block_id
+    assert manager.get_blocks("0").get_block_ids()[1][1] == partial_mamba_block_id
+
+    req0.num_computed_tokens = 6
+    req0.append_output_token_ids([3])
+    new_blocks = manager.allocate_slots(req0, 1)
+    assert new_blocks is not None
+
+    mamba_new_block_ids = new_blocks.get_block_ids()[1]
+    assert len(mamba_new_block_ids) == 1
+    assert mamba_new_block_ids[0] != partial_mamba_block_id
+    assert manager.get_blocks("0").get_block_ids()[1][1] == mamba_new_block_ids[0]
+    assert (
+        KVCacheBlockCopy(
+            src_block_id=partial_mamba_block_id,
+            dst_block_id=mamba_new_block_ids[0],
+        )
+        in manager.take_kv_cache_block_copies()
+    )
+    assert (
+        manager.block_pool.get_cached_block(partial_mamba_hash, kv_cache_group_ids=[1])
+        == partial_mamba_block
+    )
+
+
+def test_hybrid_mamba_partial_tail_owner_continue_preserves_later_hit():
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+
+    partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_mamba_block = manager.block_pool.get_cached_block(
+        partial_mamba_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_mamba_block is not None
+    partial_mamba_block_id = partial_mamba_block[0].block_id
+
+    req0.num_computed_tokens = 6
+    req0.append_output_token_ids([3])
+    assert manager.allocate_slots(req0, 1) is not None
+    manager.take_kv_cache_block_copies()
+    manager.new_step_starts()
+
+    req1 = make_request("1", [0, 0, 1, 1, 2, 2, 4, 4], hash_block_size, sha256)
+    computed_blocks, num_computed = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+    assert computed_blocks.get_block_ids()[1][1] == partial_mamba_block_id
+
+    new_blocks = manager.allocate_slots(req1, 2, num_computed, computed_blocks)
+    assert new_blocks is not None
+    mamba_new_block_ids = new_blocks.get_block_ids()[1]
+    assert len(mamba_new_block_ids) == 1
+    assert mamba_new_block_ids[0] != partial_mamba_block_id
+    assert (
+        KVCacheBlockCopy(
+            src_block_id=partial_mamba_block_id,
+            dst_block_id=mamba_new_block_ids[0],
+        )
+        in manager.take_kv_cache_block_copies()
+    )
+
+
 def test_hybrid_full_attention_partial_hash_hit_uses_cow():
     hash_block_size = 2
     block_size = 2 * hash_block_size

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4059,9 +4059,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
         use_eagle=True,
     )
 
-    # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # 127 tokens with partial hits (hash 8 < lcm 32): the replay boundary is
+    # the last hash boundary, 120. The EAGLE lookup lands on that boundary and
+    # claims one hash unit below (112), so retention keeps the entry block at
+    # 120 plus the window block for the 112-token claim: hashes 13 and 14.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
@@ -4075,7 +4076,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {13, 14}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -4085,10 +4086,13 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
 
     manager.free(req0)
 
+    # Replay: full attention serves its registered partial tail at 120; the
+    # EAGLE SWA group claims 112 via the entry at 120; the common hit is 112
+    # (mid-FA-block, served through copy-on-write of FA block 3).
     req1 = make_request("1", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
-    assert num_computed_tokens == 12 * block_size
-    assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
+    assert num_computed_tokens == 14 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [4, 14]
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -88,7 +88,7 @@ def test_chunked_local_attention_possible_cached_prefix():
             kv_cache_spec=chunked_local_attention_spec,
             drop_eagle_block=False,
             alignment_tokens=block_size,
-        )[0]
+        )[0][0]
         assert len(computed_blocks) == expect_length
 
         assert all(
@@ -159,7 +159,7 @@ def test_sliding_window_possible_cached_prefix():
             kv_cache_spec=sliding_window_spec,
             drop_eagle_block=False,
             alignment_tokens=block_size,
-        )[0]
+        )[0][0]
         assert len(computed_blocks) == expect_length
 
         assert all(
@@ -348,13 +348,13 @@ def test_get_num_blocks_to_allocate():
 
     assert (
         manager.get_num_blocks_to_allocate(
-            "1", 20 * block_size, cached_blocks_1, 0, 20 * block_size
+            "1", 20 * block_size, cached_blocks_1, 0, 0, 20 * block_size
         )
         == 20
     )
     assert (
         manager.get_num_blocks_to_allocate(
-            "2", 20 * block_size, cached_blocks_2, 0, 20 * block_size
+            "2", 20 * block_size, cached_blocks_2, 0, 0, 20 * block_size
         )
         == 15
     )
@@ -384,6 +384,7 @@ def test_evictable_cached_blocks_not_double_allocated():
         num_tokens=2 * block_size,
         new_computed_blocks=[evictable_block],
         total_computed_tokens=block_size,
+        num_local_computed_tokens=block_size,
         num_tokens_main_model=2 * block_size,
     )
     # Free capacity check should count evictable cached blocks, but allocation
@@ -424,13 +425,13 @@ def test_chunked_local_attention_get_num_blocks_to_allocate():
 
     assert (
         manager.get_num_blocks_to_allocate(
-            "1", 20 * block_size, cached_blocks_1, 0, 20 * block_size
+            "1", 20 * block_size, cached_blocks_1, 0, 0, 20 * block_size
         )
         == 20
     )
     assert (
         manager.get_num_blocks_to_allocate(
-            "2", 20 * block_size, cached_blocks_2, 0, 20 * block_size
+            "2", 20 * block_size, cached_blocks_2, 0, 0, 20 * block_size
         )
         == 15
     )
@@ -474,6 +475,7 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             num_tokens=num_tokens,
             new_computed_blocks=[],
             total_computed_tokens=total_computed,
+            num_local_computed_tokens=0,
             num_tokens_main_model=num_tokens,
         )
         new_blocks = manager.allocate_new_blocks(

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -6,17 +6,27 @@ import random
 import pytest
 import torch
 
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    get_request_block_hasher,
+    init_none_hash,
     make_block_hash_with_group_id,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
     SlidingWindowManager,
 )
-from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
 
 pytestmark = pytest.mark.cpu_test
 
@@ -486,3 +496,55 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_full_attention_partial_tail_same_step_guard():
+    """A partial tail entry registered this step covers KV that is only
+    written during this step's execution, while a consumer's CoW copy runs at
+    step start. Consumers hitting the fresh entry must be deferred one step
+    (mirrors the mamba guard in ``MambaManager.get_num_blocks_to_allocate``).
+    """
+    init_none_hash(sha256)
+    hash_block_size = 2
+    block_size = 4
+    block_pool = BlockPool(
+        num_gpu_blocks=20, enable_caching=True, hash_block_size=hash_block_size
+    )
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    manager = FullAttentionManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+
+    sampling_params = SamplingParams(max_tokens=17)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    producer = Request(
+        request_id="producer",
+        prompt_token_ids=[0, 0, 1, 1, 2, 2],
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(hash_block_size, sha256),
+    )
+    blocks = manager.allocate_new_blocks("producer", 6, 6)
+    assert len(blocks) == 2
+    # Caches block 0 as full and freshly registers the partial tail at 6
+    # tokens on block 1.
+    manager.cache_blocks(producer, 6)
+
+    hit_blocks = list(manager.req_to_blocks["producer"])
+    # Same step: a consumer hitting the fresh partial tail must be deferred.
+    num_blocks = manager.get_num_blocks_to_allocate("consumer", 8, hit_blocks, 6, 6, 8)
+    assert num_blocks > block_pool.num_gpu_blocks
+
+    # Next step the entry's KV has been written; the hit is consumable.
+    manager.new_step_starts()
+    num_blocks = manager.get_num_blocks_to_allocate("consumer", 8, hit_blocks, 6, 6, 8)
+    assert num_blocks <= block_pool.num_gpu_blocks

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -394,6 +394,41 @@ def test_sliding_window_fine_grained_cache_hit():
     assert find(15) == ([10], 4)
 
 
+def test_sliding_window_mask_replay_anchor_at_hash_granularity():
+    """With partial hits, the replay boundary sits on a hash boundary that may
+    fall inside a block; the mask must keep that block plus enough full blocks
+    to cover the whole window."""
+    spec = SlidingWindowSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4,  # need = cdiv(3, 4) = 1 contiguous block per hit
+    )
+
+    def mask(num_prompt_tokens: int, partial_anchor_tokens: int | None):
+        return SlidingWindowManager.reachable_block_mask(
+            start_block=0,
+            end_block=4,
+            alignment_tokens=8,  # lcm of a hybrid with a block-8 FA group
+            kv_cache_spec=spec,
+            use_eagle=False,
+            retention_interval=None,
+            num_prompt_tokens=num_prompt_tokens,
+            partial_anchor_tokens=partial_anchor_tokens,
+        )
+
+    # Without partial hits: only the dense segment tails (odd blocks, one
+    # `need`-sized tail per 8-token segment).
+    assert mask(15, None) == [False, True, False, True]
+    # Block-aligned fine anchor (prompt 13 -> latest boundary 12): keep the
+    # `need` blocks before block 3 on top of the segment tails.
+    assert mask(13, 2) == [False, True, True, True]
+    # Mid-block fine anchor (prompt 15 -> latest boundary 14 inside block 3):
+    # keep the partial tail block itself plus a full window before it.
+    assert mask(15, 2) == [False, True, True, True]
+
+
 def test_full_attention_fine_grained_eagle_drop():
     block_size = 4
     hash_block_size = 2

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -337,6 +337,105 @@ def test_sliding_window_remove_skipped_blocks():
     assert_block_id(block_table, [null_block_id] * 4 + original_block_ids[4:])
 
 
+def test_sliding_window_fine_grained_cache_hit():
+    block_size = 4
+    hash_block_size = 2
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=8,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=hash_block_size
+    )
+
+    # 7 hash blocks = 14 tokens. Full-block keys are the hashes at each
+    # block's last hash boundary (indices 1, 3, 5 -> blocks 0, 1, 2); index 6
+    # is a partial prompt tail at 14 tokens inside block 3.
+    hashes = [BlockHash(str(i).encode()) for i in range(7)]
+
+    def insert(hash_idx: int, pool_block_id: int) -> None:
+        block_pool.cached_block_hash_to_block.insert(
+            make_block_hash_with_group_id(hashes[hash_idx], 0),
+            block_pool.blocks[pool_block_id],
+        )
+
+    for hash_idx, pool_block_id in ((1, 10), (3, 11), (5, 12), (6, 13)):
+        insert(hash_idx, pool_block_id)
+
+    def find(max_length: int, drop_eagle_block: bool = False):
+        blocks, hit_length = SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=max_length,
+            kv_cache_group_ids=[0],
+            block_pool=block_pool,
+            kv_cache_spec=sliding_window_spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=hash_block_size,
+        )
+        return [b.block_id for b in blocks[0]], hit_length
+
+    null_id = block_pool.null_block.block_id
+
+    # The partial tail at 14 plus the window blocks before it.
+    assert find(15) == ([null_id, 11, 12, 13], 14)
+    # Eagle drops one hash unit; the tail block no longer serves the claim
+    # but the window at 12 is still covered.
+    assert find(15, drop_eagle_block=True) == ([null_id, 11, 12], 12)
+    # Capped below the tail: falls back to the block-boundary entry at 12.
+    assert find(13) == ([null_id, 11, 12], 12)
+    # Evicting block 1 breaks window coverage for 14 and 12; the longest hit
+    # becomes the standalone block-0 entry (4 tokens cover its own window).
+    block_pool.cached_block_hash_to_block.pop(
+        make_block_hash_with_group_id(hashes[3], 0), 11
+    )
+    assert find(15) == ([10], 4)
+
+
+def test_full_attention_fine_grained_eagle_drop():
+    block_size = 4
+    hash_block_size = 2
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=hash_block_size
+    )
+    hashes = [BlockHash(str(i).encode()) for i in range(7)]
+    for hash_idx, pool_block_id in ((1, 10), (3, 11), (5, 12), (6, 13)):
+        block_pool.cached_block_hash_to_block.insert(
+            make_block_hash_with_group_id(hashes[hash_idx], 0),
+            block_pool.blocks[pool_block_id],
+        )
+
+    def find(drop_eagle_block: bool):
+        blocks, hit_length = FullAttentionManager.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=15,
+            kv_cache_group_ids=[0],
+            block_pool=block_pool,
+            kv_cache_spec=full_spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=hash_block_size,
+        )
+        return [b.block_id for b in blocks[0]], hit_length
+
+    assert find(drop_eagle_block=False) == ([10, 11, 12, 13], 14)
+    # Eagle drops one hash unit (14 -> 12); the partial tail block is trimmed.
+    assert find(drop_eagle_block=True) == ([10, 11, 12], 12)
+    # Without the partial tail the longest hit is 12; the eagle drop lands
+    # mid-block (10) and keeps the last full block as the CoW source.
+    block_pool.cached_block_hash_to_block.pop(
+        make_block_hash_with_group_id(hashes[6], 0), 13
+    )
+    assert find(drop_eagle_block=True) == ([10, 11, 12], 10)
+
+
 def test_get_num_blocks_to_allocate():
     block_size = 2
     sliding_window_spec = SlidingWindowSpec(

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -682,3 +682,226 @@ def test_full_attention_partial_tail_same_step_guard():
     manager.new_step_starts()
     num_blocks = manager.get_num_blocks_to_allocate("consumer", 8, hit_blocks, 6, 6, 8)
     assert num_blocks <= block_pool.num_gpu_blocks
+
+
+@pytest.mark.parametrize(
+    "pool_hash_size,alignment_tokens",
+    [
+        (2, 2),  # fine-grained partial hits
+        (2, 4),  # coarse via a block-size view (alignment == block_size)
+        (4, 4),  # coarse on raw hashes (hash_block_size == block_size)
+        (2, 8),  # coarse, alignment > block_size (hybrid page sizes)
+        (4, 8),
+    ],
+)
+@pytest.mark.parametrize("sliding_window", [3, 5, 8, 13])
+@pytest.mark.parametrize("drop_eagle_block", [False, True])
+def test_sliding_window_cache_hit_matches_naive_oracle(
+    pool_hash_size, alignment_tokens, sliding_window, drop_eagle_block
+):
+    """Randomized parity: the optimized claim walk (memoized block lookups,
+    jump-ahead on coverage failure) must match a naive walk that re-checks
+    every aligned claim from scratch."""
+    block_size = 4
+    num_hashes = 40
+    fine = alignment_tokens < block_size
+    lookup_unit = alignment_tokens if fine else block_size
+    drop_tokens = lookup_unit if drop_eagle_block else 0
+    resolved_len = (
+        num_hashes
+        if pool_hash_size == lookup_unit
+        else num_hashes * pool_hash_size // block_size
+    )
+
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=sliding_window,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=200, enable_caching=True, hash_block_size=pool_hash_size
+    )
+    null_id = block_pool.null_block.block_id
+    rng = random.Random(
+        f"{pool_hash_size}-{alignment_tokens}-{sliding_window}-{drop_eagle_block}"
+    )
+
+    for trial in range(150):
+        block_pool.cached_block_hash_to_block._cache.clear()
+        hashes = [BlockHash(f"{trial}-{i}".encode()) for i in range(num_hashes)]
+        cached: dict[int, int] = {}
+        for i in range(num_hashes):
+            if rng.random() < 0.55:
+                cached[i] = 10 + i
+                block_pool.cached_block_hash_to_block.insert(
+                    make_block_hash_with_group_id(hashes[i], 0),
+                    block_pool.blocks[10 + i],
+                )
+        max_length = rng.randrange(0, num_hashes * pool_hash_size + 5)
+
+        def entry_id(u: int, cached=cached) -> int | None:
+            # Visible entries sit on lookup_unit boundaries; the key at
+            # boundary u is the raw hash ending there.
+            if u <= 0 or u % lookup_unit != 0 or u // pool_hash_size > num_hashes:
+                return None
+            return cached.get(u // pool_hash_size - 1)
+
+        def naive(max_length=max_length, entry_id=entry_id) -> tuple[list[int], int]:
+            max_tokens = min(max_length, resolved_len * lookup_unit)
+            max_claim = (
+                (max_tokens - drop_tokens) // alignment_tokens * alignment_tokens
+            )
+            for claim in range(max_claim, 0, -alignment_tokens):
+                u = claim + drop_tokens
+                eid = entry_id(u)
+                if eid is None:
+                    continue
+                entry_block_idx = (u - 1) // block_size
+                last_block_idx = (claim - 1) // block_size
+                first_block_idx = max(claim - sliding_window + 1, 0) // block_size
+                ids = []
+                for j in range(first_block_idx, last_block_idx + 1):
+                    bid = (
+                        eid if j == entry_block_idx else entry_id((j + 1) * block_size)
+                    )
+                    if bid is None:
+                        break
+                    ids.append(bid)
+                else:
+                    return [null_id] * first_block_idx + ids, claim
+            return [], 0
+
+        blocks, hit_length = SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=max_length,
+            kv_cache_group_ids=[0],
+            block_pool=block_pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=alignment_tokens,
+        )
+        exp_ids, exp_hit = naive()
+        assert ([b.block_id for b in blocks[0]], hit_length) == (exp_ids, exp_hit), (
+            f"trial={trial} max_length={max_length} cached={sorted(cached)}"
+        )
+
+
+@pytest.mark.parametrize(
+    "pool_hash_size,alignment_tokens",
+    [(2, 2), (2, 4), (4, 4), (2, 8), (4, 8)],
+)
+@pytest.mark.parametrize("drop_eagle_block", [False, True])
+def test_full_attention_cache_hit_matches_naive_oracle(
+    pool_hash_size, alignment_tokens, drop_eagle_block
+):
+    """Randomized parity for the unified full-attention lookup: full-block
+    prefix scan, fine-grained tail probe, eagle drop, and alignment trim."""
+    block_size = 4
+    num_hashes = 40
+    fine = alignment_tokens < block_size
+    resolved_len_blocks = num_hashes * pool_hash_size // block_size
+
+    spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=200, enable_caching=True, hash_block_size=pool_hash_size
+    )
+    rng = random.Random(f"{pool_hash_size}-{alignment_tokens}-{drop_eagle_block}")
+
+    for trial in range(150):
+        block_pool.cached_block_hash_to_block._cache.clear()
+        hashes = [BlockHash(f"{trial}-{i}".encode()) for i in range(num_hashes)]
+        cached: dict[int, int] = {}
+        for i in range(num_hashes):
+            if rng.random() < 0.55:
+                cached[i] = 10 + i
+                block_pool.cached_block_hash_to_block.insert(
+                    make_block_hash_with_group_id(hashes[i], 0),
+                    block_pool.blocks[10 + i],
+                )
+        max_length = rng.randrange(0, num_hashes * pool_hash_size + 5)
+
+        def naive(max_length=max_length, cached=cached) -> tuple[list[int], int]:
+            # Longest cached full-block prefix.
+            num_full = 0
+            while (
+                num_full < min(max_length // block_size, resolved_len_blocks)
+                and ((num_full + 1) * block_size // pool_hash_size - 1) in cached
+            ):
+                num_full += 1
+            hit = num_full * block_size
+            full_ids = [
+                cached[(j + 1) * block_size // pool_hash_size - 1]
+                for j in range(num_full)
+            ]
+            # Fine-grained: highest cached interior boundary of the first
+            # non-full block.
+            tail_id = None
+            if fine:
+                lo = num_full * block_size
+                hi = min(
+                    lo + block_size - alignment_tokens,
+                    max_length // alignment_tokens * alignment_tokens,
+                    num_hashes * alignment_tokens,
+                )
+                for u in range(hi, lo, -alignment_tokens):
+                    if (tail_id := cached.get(u // pool_hash_size - 1)) is not None:
+                        hit = u
+                        break
+            if drop_eagle_block and hit > 0:
+                hit -= min(alignment_tokens, block_size)
+            hit -= hit % alignment_tokens
+            num_blocks = -(-hit // block_size)
+            if tail_id is not None and num_blocks > num_full:
+                return full_ids + [tail_id], hit
+            return full_ids[:num_blocks], hit
+
+        blocks, hit_length = FullAttentionManager.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_length=max_length,
+            kv_cache_group_ids=[0],
+            block_pool=block_pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=alignment_tokens,
+        )
+        exp_ids, exp_hit = naive()
+        assert ([b.block_id for b in blocks[0]], hit_length) == (exp_ids, exp_hit), (
+            f"trial={trial} max_length={max_length} cached={sorted(cached)}"
+        )
+
+
+def test_full_attention_cache_hit_with_dcp():
+    """With DCP, block hashes are computed at block_size * dcp_world_size
+    granularity; the lookup must resolve the hash view at that scaled size
+    (regression: resolving at the unscaled size tripped an assert)."""
+    block_size, dcp_world_size = 4, 2
+    scaled = block_size * dcp_world_size
+    spec = FullAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=scaled
+    )
+    hashes = [BlockHash(str(i).encode()) for i in range(4)]
+    for hash_idx, pool_block_id in ((0, 10), (1, 11)):
+        block_pool.cached_block_hash_to_block.insert(
+            make_block_hash_with_group_id(hashes[hash_idx], 0),
+            block_pool.blocks[pool_block_id],
+        )
+
+    blocks, hit_length = FullAttentionManager.find_longest_cache_hit(
+        block_hashes=hashes,
+        max_length=30,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        drop_eagle_block=False,
+        alignment_tokens=scaled,
+        dcp_world_size=dcp_world_size,
+    )
+    # Each hash covers 8 tokens; two cached scaled blocks -> 16 tokens.
+    assert ([b.block_id for b in blocks[0]], hit_length) == ([10, 11], 16)

--- a/tests/v1/core/test_swa_inflight_window_free.py
+++ b/tests/v1/core/test_swa_inflight_window_free.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Out-of-window block frees vs in-flight GPU steps.
+
+With async scheduling / PP, `num_computed_tokens` optimistically includes
+tokens of unprocessed steps whose attention windows still read the blocks
+just below the optimistic boundary (and rejected spec tokens can roll it
+back), so `allocate_slots` frees on the processed-token basis:
+`num_computed_tokens - num_in_flight_tokens`.
+"""
+
+import torch
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler
+
+NUM_PROMPT_TOKENS = 100
+BLOCK_SIZE = 16
+SLIDING_WINDOW = 16
+# Tokens 0..84 are outside the window of the next token to compute
+# (100 - 16 + 1 = 85), i.e. 5 full blocks.
+NUM_OUT_OF_WINDOW_BLOCKS = 85 // BLOCK_SIZE
+
+
+def _make_model_runner_output(
+    scheduler_output: SchedulerOutput,
+    token_id: int = 0,
+) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens.keys())
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[token_id] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def _create_swa_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _num_null_blocks(scheduler, request_id: str) -> int:
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    null_block = manager._null_block
+    return sum(1 for b in manager.req_to_blocks[request_id] if b is null_block)
+
+
+def test_num_in_flight_tokens_accounting():
+    scheduler = create_scheduler(async_scheduling=True)
+    request = create_requests(num_requests=1, num_tokens=NUM_PROMPT_TOKENS)[0]
+    scheduler.add_request(request)
+
+    out0 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS
+    # Async: decode scheduled before the prefill output is processed.
+    out1 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS + 1
+
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 1
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert request.num_in_flight_tokens == 0
+
+
+def test_swa_free_waits_for_in_flight_step():
+    """Async: out-of-window blocks stay allocated until the step that still
+    reads them has been processed."""
+    scheduler = _create_swa_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-window blocks:
+    # they must not be freed yet.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-window
+    # blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks()
+        == free_after_prefill + NUM_OUT_OF_WINDOW_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_free_immediate_when_sync():
+    """Sync: no in-flight step at schedule time, frees happen at the first
+    decode allocation as before."""
+    scheduler = _create_swa_scheduler(async_scheduling=False)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 0
+
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_admission_cap_accounts_for_overlapping_batches():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_num_batched_tokens=1024, max_model_len=16384
+    )
+    # (1024 - 1 + 1024) tokens -> 128 blocks, +1 for window misalignment.
+    assert base == 129
+    overlapped = spec.max_admission_blocks_per_request(
+        max_num_batched_tokens=1024, max_model_len=16384, max_concurrent_batches=2
+    )
+    # One extra in-flight chunk is held back: (1024 - 1 + 2 * 1024) tokens.
+    assert overlapped == 193

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -29,6 +29,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheSpec,
 )
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -58,6 +59,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    kv_cache_spec: KVCacheSpec | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -147,20 +149,17 @@ def create_scheduler(
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
     )
+    if kv_cache_spec is None:
+        kv_cache_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
         kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            )
-        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
     )
     cache_config.num_gpu_blocks = num_blocks
     register_all_kvcache_specs(vllm_config)

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -37,7 +37,7 @@ def _make_coord(groups, hash_block_size, use_eagle=False, retention_interval=Non
 
 
 def test_external_cached_block_pool_tautological_returns_present_for_any_hash():
-    cmap = ExternalCachedBlockPool()
+    cmap = ExternalCachedBlockPool(hash_block_size=16)
     h = BlockHash(b"\xaa" * 4)
     res = cmap.get_cached_block(h, [0, 1])
     assert res is not None
@@ -48,7 +48,7 @@ def test_external_cached_block_pool_tautological_returns_present_for_any_hash():
 
 def test_external_cached_block_pool_hit_all_groups():
     h = BlockHash(b"\x11\x22\x33\x44")
-    cmap = ExternalCachedBlockPool({(0, bytes(h)), (1, bytes(h))})
+    cmap = ExternalCachedBlockPool({(0, bytes(h)), (1, bytes(h))}, hash_block_size=16)
     res = cmap.get_cached_block(h, [0, 1])
     assert res is not None
     assert len(res) == 2
@@ -58,14 +58,14 @@ def test_external_cached_block_pool_hit_all_groups():
 
 def test_external_cached_block_pool_miss_one_group():
     h = BlockHash(b"\x11\x22\x33\x44")
-    cmap = ExternalCachedBlockPool({(0, bytes(h))})
+    cmap = ExternalCachedBlockPool({(0, bytes(h))}, hash_block_size=16)
     assert cmap.get_cached_block(h, [0, 1]) is None
 
 
 def test_external_cached_block_pool_unknown_hash():
     h_known = BlockHash(b"\x01" * 4)
     h_unknown = BlockHash(b"\x02" * 4)
-    cmap = ExternalCachedBlockPool({(0, bytes(h_known))})
+    cmap = ExternalCachedBlockPool({(0, bytes(h_known))}, hash_block_size=16)
     assert cmap.get_cached_block(h_unknown, [0]) is None
 
 
@@ -103,7 +103,7 @@ def test_coordinator_single_full_attention_all_hits():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs})
+    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs}, hash_block_size=16)
     masks, hit = coord.find_longest_cache_hit(hs, max_length=64, cached_block_pool=cmap)
     assert hit == 64
     assert masks[0] == [True, True, True, True]
@@ -113,7 +113,9 @@ def test_coordinator_single_full_attention_partial_prefix():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(0, bytes(hs[0])), (0, bytes(hs[1]))})
+    cmap = ExternalCachedBlockPool(
+        {(0, bytes(hs[0])), (0, bytes(hs[1]))}, hash_block_size=16
+    )
     masks, hit = coord.find_longest_cache_hit(hs, max_length=64, cached_block_pool=cmap)
     assert hit == 32
     assert masks[0] == [True, True]
@@ -123,7 +125,7 @@ def test_coordinator_single_full_attention_no_hits():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool(set())
+    cmap = ExternalCachedBlockPool(set(), hash_block_size=16)
     masks, hit = coord.find_longest_cache_hit(hs, max_length=64, cached_block_pool=cmap)
     assert hit == 0
     assert masks[0] == []
@@ -135,7 +137,7 @@ def test_coordinator_single_swa_tautological_pool_masks_pre_window():
     groups = [KVCacheGroupSpec(["L0"], _swa(block_size=16, sliding_window=32))]
     coord = _make_coord(groups, hash_block_size=16)
     hs = _hashes(4)  # 4 chunks * 16 tokens
-    cmap = ExternalCachedBlockPool()
+    cmap = ExternalCachedBlockPool(hash_block_size=16)
     masks, hit = coord.find_longest_cache_hit(hs, max_length=64, cached_block_pool=cmap)
     assert hit == 64
     # ceil((sw-1)/block_size) = ceil(31/16) = 2 tail blocks.
@@ -153,7 +155,9 @@ def test_coordinator_hybrid_full_plus_swa_all_hit():
     ]
     coord = _make_coord(groups, hash_block_size=16)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(g, bytes(h)) for g in (0, 1) for h in hs})
+    cmap = ExternalCachedBlockPool(
+        {(g, bytes(h)) for g in (0, 1) for h in hs}, hash_block_size=16
+    )
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -169,7 +173,7 @@ def test_coordinator_hybrid_hole_in_full_clips_both():
     hs = _hashes(4)
     exists = {(0, bytes(hs[0])), (0, bytes(hs[2])), (0, bytes(hs[3]))}
     exists |= {(1, bytes(h)) for h in hs}
-    cmap = ExternalCachedBlockPool(exists)
+    cmap = ExternalCachedBlockPool(exists, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -188,7 +192,7 @@ def test_coordinator_group_block_size_double_hash():
     big_hashes = list(chunk_hashes_for_block_size(hs, 16, 32))
     exists = {(0, bytes(h)) for h in hs}
     exists |= {(1, bytes(bh)) for bh in big_hashes}
-    cmap = ExternalCachedBlockPool(exists)
+    cmap = ExternalCachedBlockPool(exists, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -364,7 +368,7 @@ def test_lookup_with_eagle_pops_last_full_attention_block():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16, use_eagle=True)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs})
+    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs}, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -385,7 +389,7 @@ def test_load_mask_with_eagle_does_not_double_prune_full_attention():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16, use_eagle=True)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs})
+    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs}, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -409,7 +413,7 @@ def test_load_mask_with_eagle_hybrid_full_plus_swa():
     coord = _make_coord(groups, hash_block_size=16, use_eagle=True)
     hs = _hashes(4)
     exists = {(g, bytes(h)) for g in (0, 1) for h in hs}
-    cmap = ExternalCachedBlockPool(exists)
+    cmap = ExternalCachedBlockPool(exists, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )
@@ -428,7 +432,7 @@ def test_load_mask_without_eagle_unchanged():
     groups = [KVCacheGroupSpec(["L0"], _full(16))]
     coord = _make_coord(groups, hash_block_size=16, use_eagle=False)
     hs = _hashes(4)
-    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs})
+    cmap = ExternalCachedBlockPool({(0, bytes(h)) for h in hs}, hash_block_size=16)
     _masks, hit = coord.find_longest_cache_hit(
         hs, max_length=64, cached_block_pool=cmap
     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -28,10 +28,16 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 class ExternalCachedBlockPool:
     """Duck-typed BlockPool backed by a ``(group_id, hash)`` exists set."""
 
-    def __init__(self, exists: set[tuple[int, bytes]] | None = None) -> None:
+    def __init__(
+        self,
+        exists: set[tuple[int, bytes]] | None = None,
+        *,
+        hash_block_size: int,
+    ) -> None:
         # ``exists=None`` is used on the recv side where hit_length is already
         # determined and we just want each spec's manager to apply its own mask.
         self._exists = exists
+        self.hash_block_size = hash_block_size
         self.null_block = KVCacheBlock(block_id=0)
         # Dummy ID 1 for present block for duck-typing.
         self._present_block = KVCacheBlock(block_id=1)
@@ -165,7 +171,7 @@ class MooncakeStoreCoordinator:
         masks, _ = self.find_longest_cache_hit(
             block_hashes,
             token_len,
-            ExternalCachedBlockPool(),
+            ExternalCachedBlockPool(hash_block_size=self.hash_block_size),
             apply_eagle=False,
         )
         return masks
@@ -263,7 +269,7 @@ class MooncakeStoreCoordinator:
         if len(self.attention_groups) == 1:
             spec, group_ids, manager_cls = self.attention_groups[0]
             hashes = self.block_hashes_for_spec(block_hashes, spec)
-            hit_blocks = manager_cls.find_longest_cache_hit(
+            hit_blocks, hit_length = manager_cls.find_longest_cache_hit(
                 block_hashes=hashes,  # type: ignore[arg-type]
                 max_length=max_length,
                 kv_cache_group_ids=group_ids,
@@ -276,11 +282,12 @@ class MooncakeStoreCoordinator:
             blocks_by_group: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
             for gid, blks in zip(group_ids, hit_blocks, strict=True):
                 blocks_by_group[gid] = blks
-            return tuple(blocks_by_group), len(hit_blocks[0]) * spec.block_size
+            return tuple(blocks_by_group), hit_length
 
         num_groups = len(self.kv_cache_groups)
         hit_length = max_length
         hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
+        hit_length_by_group: list[int] = [0] * num_groups
 
         is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
             self.attention_groups[0][0], FullAttentionSpec
@@ -293,8 +300,9 @@ class MooncakeStoreCoordinator:
             for idx, (spec, group_ids, manager_cls) in enumerate(self.attention_groups):
                 cached = hit_blocks_by_group[group_ids[0]]
                 if isinstance(spec, FullAttentionSpec) and cached is not None:
-                    curr_hit_length = (
-                        curr_hit_length // spec.block_size * spec.block_size
+                    curr_hit_length = min(
+                        curr_hit_length,
+                        hit_length_by_group[group_ids[0]],
                     )
                     continue
 
@@ -303,7 +311,7 @@ class MooncakeStoreCoordinator:
                 if drop_eagle_block:
                     _max_length = min(curr_hit_length + spec.block_size, max_length)
                 hashes = self.block_hashes_for_spec(block_hashes, spec)
-                hit_blocks = manager_cls.find_longest_cache_hit(
+                hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=hashes,  # type: ignore[arg-type]
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
@@ -312,7 +320,6 @@ class MooncakeStoreCoordinator:
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self.lcm_block_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -320,6 +327,7 @@ class MooncakeStoreCoordinator:
                 curr_hit_length = _new_hit_length
                 for gid, blocks in zip(group_ids, hit_blocks, strict=True):
                     hit_blocks_by_group[gid] = blocks
+                    hit_length_by_group[gid] = _new_hit_length
 
             if curr_hit_length >= hit_length:
                 break
@@ -336,6 +344,7 @@ class MooncakeStoreCoordinator:
                 full_blks = hit_blocks_by_group[gid]
                 assert full_blks is not None
                 del full_blks[num_blocks:]
+                hit_length_by_group[gid] = hit_length
 
         return (
             tuple(blks if blks is not None else [] for blks in hit_blocks_by_group),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1109,6 +1109,18 @@ class MooncakeStoreWorker:
             use_eagle=use_eagle,
             retention_interval=envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL,
         )
+        # Mirrors HybridKVCacheCoordinator.enable_partial_hash_hits: the
+        # engine then reports mid-block local hit lengths, which this
+        # connector cannot consume yet (support lands in a follow-up PR).
+        if self.hash_block_size < self.block_size and all(
+            manager_cls.supports_fine_grained_hash_lookup
+            or spec.block_size == self.hash_block_size
+            for spec, _, manager_cls in self.coord.attention_groups
+        ):
+            raise NotImplementedError(
+                "MooncakeStoreConnector does not support fine-grained partial "
+                "prefix-cache hits yet. Unset --hash-block-size to disable them."
+            )
         # One ChunkedTokenDatabase per group; addresses populated in
         # register_kv_caches once the kv-cache layout is known.
         self.token_dbs: list[ChunkedTokenDatabase] = [
@@ -1442,7 +1454,9 @@ class MooncakeStoreWorker:
         exists_set = {gh for gh, c in present_count.items() if c >= expected_per_key}
 
         _masks, hit_length = self.coord.find_longest_cache_hit(
-            block_hashes, token_len, ExternalCachedBlockPool(exists_set)
+            block_hashes,
+            token_len,
+            ExternalCachedBlockPool(exists_set, hash_block_size=self.hash_block_size),
         )
         return hit_length
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -684,6 +684,7 @@ class EngineArgs:
     mamba_cache_dtype: MambaDType = CacheConfig.mamba_cache_dtype
     mamba_ssm_cache_dtype: MambaDType = CacheConfig.mamba_ssm_cache_dtype
     mamba_block_size: int | None = get_field(CacheConfig, "mamba_block_size")
+    hash_block_size: int | None = get_field(CacheConfig, "hash_block_size")
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
@@ -1182,6 +1183,7 @@ class EngineArgs:
         cache_group.add_argument(
             "--mamba-block-size", **cache_kwargs["mamba_block_size"]
         )
+        cache_group.add_argument("--hash-block-size", **cache_kwargs["hash_block_size"])
         cache_group.add_argument(
             "--mamba-cache-mode", **cache_kwargs["mamba_cache_mode"]
         )
@@ -1854,6 +1856,7 @@ class EngineArgs:
             mamba_cache_dtype=self.mamba_cache_dtype,
             mamba_ssm_cache_dtype=self.mamba_ssm_cache_dtype,
             mamba_block_size=self.mamba_block_size,
+            hash_block_size=self.hash_block_size,
             mamba_cache_mode=self.mamba_cache_mode,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -391,8 +391,9 @@ class BlockPool:
                 entry is partial within the owning cache block.
 
         Returns:
-            The hash key with group ID if a partial entry can be registered;
-            otherwise ``None`` for null blocks.
+            The hash key with group ID if a new partial entry was registered;
+            ``None`` for null blocks or when the entry already pointed to
+            ``block`` (so callers can tell freshly registered entries apart).
         """
         if block.is_null:
             return None
@@ -410,9 +411,10 @@ class BlockPool:
                 block_hash_with_group_id, block.block_id
             )
         )
+        if already_cached:
+            return None
         if (
-            not already_cached
-            and block.block_hash is not None
+            block.block_hash is not None
             and block.block_hash_num_tokens is not None
             and block.block_hash_num_tokens < num_hash_blocks * self.hash_block_size
         ):
@@ -423,7 +425,7 @@ class BlockPool:
             block,
             num_tokens=num_hash_blocks * self.hash_block_size,
         )
-        if self.enable_kv_cache_events and not already_cached:
+        if self.enable_kv_cache_events:
             parent_hash, block_start = self._get_partial_block_parent_hash_and_start(
                 request, num_tokens
             )
@@ -455,6 +457,26 @@ class BlockPool:
                 )
             )
         return block_hash_with_group_id
+
+    def move_block_hashes(
+        self,
+        src_block: KVCacheBlock,
+        dst_block: KVCacheBlock,
+    ) -> None:
+        """Re-point every prefix-cache entry of ``src_block`` to ``dst_block``.
+
+        Used when the owner of a partially-hit block keeps writing into it:
+        the prefix cache keeps a private copy (``dst_block``) of the content
+        instead, so all hash keys that resolved to ``src_block`` must resolve
+        to ``dst_block``. No KV cache events are emitted; the entries stay
+        live under the same hashes.
+        """
+        assert dst_block.block_hash is None
+        assert dst_block.block_id not in self.cached_block_hashes_by_block
+        num_tokens = src_block.block_hash_num_tokens
+        for block_hash in self._remove_cached_block_hashes(src_block):
+            # `num_tokens` only applies to the first (primary) insertion.
+            self._insert_block_hash(block_hash, dst_block, num_tokens=num_tokens)
 
     def _get_partial_block_hash(
         self,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -11,8 +11,6 @@ from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
-    KVCacheBlockListWithHitLength,
-    get_cache_hit_length,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -135,6 +133,7 @@ class KVCacheCoordinator(ABC):
         new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
         num_encoder_tokens: int,
         total_computed_tokens: int,
+        num_local_computed_tokens: int,
         num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
@@ -150,6 +149,8 @@ class KVCacheCoordinator(ABC):
             num_encoder_tokens: The number of encoder tokens for allocating
                 blocks for cross-attention.
             total_computed_tokens: Include both local and external tokens.
+            num_local_computed_tokens: The number of local prefix-cache computed
+                tokens.
             num_tokens_main_model: The number of tokens for the main model (aka target
                 model in spec decode). w/o spec decode, it is num_tokens;
                 with spec decode, it is num_tokens - num_lookahead_tokens.
@@ -171,6 +172,7 @@ class KVCacheCoordinator(ABC):
                     num_encoder_tokens,
                     [],
                     0,
+                    0,
                     num_encoder_tokens,
                     apply_admission_cap=apply_admission_cap,
                 )
@@ -180,6 +182,7 @@ class KVCacheCoordinator(ABC):
                     num_tokens,
                     new_computed_blocks[i],
                     total_computed_tokens,
+                    num_local_computed_tokens,
                     num_tokens_main_model,
                     apply_admission_cap=apply_admission_cap,
                 )
@@ -475,7 +478,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
-        hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
+        hit_blocks, hit_length = self.single_type_managers[0].find_longest_cache_hit(
             block_hashes=block_hashes,
             max_length=max_cache_hit_length,
             kv_cache_group_ids=[0],
@@ -486,7 +489,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             dcp_world_size=self.dcp_world_size,
             pcp_world_size=self.pcp_world_size,
         )
-        return hit_blocks, len(hit_blocks[0]) * self.block_size
+        return hit_blocks, hit_length
 
 
 class SpecGroup(NamedTuple):
@@ -668,6 +671,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_length = max_cache_hit_length
         longest_hit_length = 0
         hit_blocks_by_group: list[list[KVCacheBlock] | None] = [None] * num_groups
+        hit_length_by_group: list[int] = [0] * num_groups
 
         # Simple hybrid (1 full attn + 1 other): one iteration suffices.
         # Full attn is always first if it exists.
@@ -693,7 +697,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     # to the (reduced) current hit length.
                     curr_hit_length = min(
                         curr_hit_length,
-                        get_cache_hit_length(cached_blocks, spec.block_size),
+                        hit_length_by_group[group_ids[0]],
                     )
                     continue
 
@@ -705,7 +709,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     _max_length = min(
                         curr_hit_length + spec.block_size, max_cache_hit_length
                     )
-                hit_blocks = manager_cls.find_longest_cache_hit(
+                hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=block_hashes,
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
@@ -714,7 +718,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self._cache_hit_alignment_tokens,
                 )
-                _new_hit_length = get_cache_hit_length(hit_blocks[0], spec.block_size)
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -723,6 +726,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 curr_hit_length = _new_hit_length
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
+                    hit_length_by_group[group_id] = _new_hit_length
 
                 longest_hit_length = max(longest_hit_length, curr_hit_length)
 
@@ -738,17 +742,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             num_blocks = cdiv(hit_length, first_group.spec.block_size)
             for group_id in first_group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
-                    # Full attention always returns a hit-length-carrying list.
-                    assert isinstance(blks, KVCacheBlockListWithHitLength)
                     del blks[num_blocks:]
-                    blks.hit_length = hit_length
+                    hit_length_by_group[group_id] = hit_length
 
         # Uncached shared prefix detection: If any attn. group cached a longer prefix
         # than the current prefix, it is an uncached common prefix across requests:
         self.num_uncached_common_prefix_tokens = longest_hit_length - hit_length
         return tuple(
-            blocks if blocks is not None else KVCacheBlockListWithHitLength()
-            for blocks in hit_blocks_by_group
+            blocks if blocks is not None else [] for blocks in hit_blocks_by_group
         ), hit_length
 
     def find_longest_cache_hit_per_group(
@@ -767,7 +768,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_lengths: list[int] = [0] * num_groups
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
-            blocks = manager_cls.find_longest_cache_hit(
+            blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_cache_hit_length,
                 kv_cache_group_ids=group_ids,
@@ -776,7 +777,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self._cache_hit_alignment_tokens,
             )
-            group_hit = get_cache_hit_length(blocks[0], spec.block_size)
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks
                 hit_lengths[gid] = group_hit

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -558,6 +558,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         self.verify_and_split_kv_cache_groups()
 
+    @property
+    def _cache_hit_alignment_tokens(self) -> int:
+        # Fine-grained partial hits may return hash-block-aligned lengths;
+        # otherwise it must stay scheduler-block-aligned.
+        return (
+            self.hash_block_size
+            if self.enable_partial_hash_hits
+            else self.scheduler_block_size
+        )
+
     def verify_and_split_kv_cache_groups(self) -> None:
         """
         Groups KV cache groups by their spec type for efficient batch processing
@@ -686,11 +696,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # ``curr_hit_length``. Each eagle group applies the drop at most once
         # per candidate length (see issue #32802).
         eagle_verified: set[int] = set()
-        alignment_tokens = (
-            self.hash_block_size
-            if self.enable_partial_hash_hits
-            else self.scheduler_block_size
-        )
 
         while True:
             curr_hit_length = hit_length
@@ -724,7 +729,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
-                    alignment_tokens=alignment_tokens,
+                    alignment_tokens=self._cache_hit_alignment_tokens,
                 )
                 _new_hit_length = get_cache_hit_length(hit_blocks[0], spec.block_size)
                 if drop_eagle_block:
@@ -790,11 +795,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
-        alignment_tokens = (
-            self.hash_block_size
-            if self.enable_partial_hash_hits
-            else self.scheduler_block_size
-        )
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
             blocks = manager_cls.find_longest_cache_hit(
@@ -804,7 +804,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 block_pool=self.block_pool,
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
-                alignment_tokens=alignment_tokens,
+                alignment_tokens=self._cache_hit_alignment_tokens,
             )
             group_hit = get_cache_hit_length(blocks[0], spec.block_size)
             for gid, blks in zip(group_ids, blocks):

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from vllm import envs
+from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
@@ -12,6 +13,8 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     BlockHashListWithBlockSize,
     KVCacheBlock,
+    KVCacheBlockListWithHitLength,
+    get_cache_hit_length,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -22,6 +25,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
@@ -546,6 +550,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         ), "block_size must be divisible by hash_block_size"
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
+        self.enable_partial_hash_hits = any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            and g.kv_cache_spec.mamba_cache_mode == "align"
+            and g.kv_cache_spec.block_size > hash_block_size
+            for g in kv_cache_config.kv_cache_groups
+        )
         self.verify_and_split_kv_cache_groups()
 
     def verify_and_split_kv_cache_groups(self) -> None:
@@ -591,14 +601,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     self.single_type_managers[gid].use_eagle = True
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
-        # Cache hits in this coordinator are always a multiple of
-        # ``scheduler_block_size`` tokens (see ``find_longest_cache_hit``).
-        # Within an aligned region, SWA groups may only consult a subset of blocks
-        # per ``scheduler_block_size``-segment so the unused blocks also stay
-        # out of the prefix-cache hash map.
-        aligned_num_computed_tokens = (
-            num_computed_tokens // self.scheduler_block_size * self.scheduler_block_size
-        )
+        if self.enable_partial_hash_hits:
+            aligned_num_computed_tokens = num_computed_tokens
+        else:
+            # Cache hits in this coordinator are always a multiple of
+            # ``scheduler_block_size`` tokens (see ``find_longest_cache_hit``).
+            # Within an aligned region, SWA groups may only consult a subset of
+            # blocks per ``scheduler_block_size``-segment so the unused blocks
+            # also stay out of the prefix-cache hash map.
+            aligned_num_computed_tokens = (
+                num_computed_tokens
+                // self.scheduler_block_size
+                * self.scheduler_block_size
+            )
         for manager in self.single_type_managers:
             num_tokens_to_cache = aligned_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
@@ -641,8 +656,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 - The number of tokens of the longest cache hit.
         """
 
-        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+        def _get_block_hashes(
+            kv_cache_spec: KVCacheSpec,
+            manager_cls: type[SingleTypeKVCacheManager],
+        ) -> BlockHashList:
             if kv_cache_spec.block_size == self.hash_block_size:
+                return block_hashes
+            if (
+                self.enable_partial_hash_hits
+                and manager_cls.supports_fine_grained_hash_lookup
+            ):
                 return block_hashes
             return BlockHashListWithBlockSize(
                 block_hashes, self.hash_block_size, kv_cache_spec.block_size
@@ -663,6 +686,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # ``curr_hit_length``. Each eagle group applies the drop at most once
         # per candidate length (see issue #32802).
         eagle_verified: set[int] = set()
+        alignment_tokens = (
+            self.hash_block_size
+            if self.enable_partial_hash_hits
+            else self.scheduler_block_size
+        )
 
         while True:
             curr_hit_length = hit_length
@@ -675,8 +703,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     # Full attention is downward-closed: we only need to look
                     # up cached blocks once; on subsequent iterations just trim
                     # to the (reduced) current hit length.
-                    curr_hit_length = (
-                        curr_hit_length // spec.block_size * spec.block_size
+                    curr_hit_length = min(
+                        curr_hit_length,
+                        get_cache_hit_length(cached_blocks, spec.block_size),
                     )
                     continue
 
@@ -689,15 +718,15 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         curr_hit_length + spec.block_size, max_cache_hit_length
                     )
                 hit_blocks = manager_cls.find_longest_cache_hit(
-                    block_hashes=_get_block_hashes(spec),
+                    block_hashes=_get_block_hashes(spec, manager_cls),
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
-                    alignment_tokens=self.scheduler_block_size,
+                    alignment_tokens=alignment_tokens,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                _new_hit_length = get_cache_hit_length(hit_blocks[0], spec.block_size)
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -718,10 +747,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         first_group = self.attention_groups[0]
         if isinstance(first_group.spec, FullAttentionSpec):
-            num_blocks = hit_length // first_group.spec.block_size
+            num_blocks = cdiv(hit_length, first_group.spec.block_size)
             for group_id in first_group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
+                    if isinstance(blks, KVCacheBlockListWithHitLength):
+                        blks.hit_length = hit_length
 
         # Uncached shared prefix detection: If any attn. group cached a longer prefix
         # than the current prefix, it is an uncached common prefix across requests:
@@ -741,8 +772,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             (blocks_per_group, hit_lengths_per_group)
         """
 
-        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
+        def _get_block_hashes(
+            kv_cache_spec: KVCacheSpec,
+            manager_cls: type[SingleTypeKVCacheManager],
+        ) -> BlockHashList:
             if kv_cache_spec.block_size == self.hash_block_size:
+                return block_hashes
+            if (
+                self.enable_partial_hash_hits
+                and manager_cls.supports_fine_grained_hash_lookup
+            ):
                 return block_hashes
             return BlockHashListWithBlockSize(
                 block_hashes, self.hash_block_size, kv_cache_spec.block_size
@@ -751,18 +790,23 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
+        alignment_tokens = (
+            self.hash_block_size
+            if self.enable_partial_hash_hits
+            else self.scheduler_block_size
+        )
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
             blocks = manager_cls.find_longest_cache_hit(
-                block_hashes=_get_block_hashes(spec),
+                block_hashes=_get_block_hashes(spec, manager_cls),
                 max_length=max_cache_hit_length,
                 kv_cache_group_ids=group_ids,
                 block_pool=self.block_pool,
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
-                alignment_tokens=self.scheduler_block_size,
+                alignment_tokens=alignment_tokens,
             )
-            group_hit = len(blocks[0]) * spec.block_size
+            group_hit = get_cache_hit_length(blocks[0], spec.block_size)
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks
                 hit_lengths[gid] = group_hit

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -365,10 +365,13 @@ class KVCacheCoordinator(ABC):
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         pass
 
-    def new_step_starts(self) -> None:
-        """Called when a new step is started."""
+    def new_step_starts(self) -> list[KVCacheBlock]:
+        """Called when a new step is started. Returns the blocks whose CoW
+        retention ended; the caller must release them."""
+        blocks_to_release: list[KVCacheBlock] = []
         for manager in self.single_type_managers:
-            manager.new_step_starts()
+            blocks_to_release.extend(manager.new_step_starts())
+        return blocks_to_release
 
 
 class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -74,6 +74,7 @@ class KVCacheCoordinator(ABC):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -107,6 +108,7 @@ class KVCacheCoordinator(ABC):
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_model_len=max_model_len,
+                max_concurrent_batches=max_concurrent_batches,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
@@ -389,6 +391,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -402,6 +405,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -439,6 +443,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -452,6 +457,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
@@ -525,6 +531,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_concurrent_batches: int = 1,
     ):
         super().__init__(
             kv_cache_config,
@@ -538,6 +545,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -808,6 +816,7 @@ def get_kv_cache_coordinator(
     scheduler_block_size: int,
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    max_concurrent_batches: int = 1,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -821,6 +830,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -835,6 +845,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -848,4 +859,5 @@ def get_kv_cache_coordinator(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
+        max_concurrent_batches=max_concurrent_batches,
     )

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -10,8 +10,6 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
-    BlockHashList,
-    BlockHashListWithBlockSize,
     KVCacheBlock,
     KVCacheBlockListWithHitLength,
     get_cache_hit_length,
@@ -666,21 +664,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 - The number of tokens of the longest cache hit.
         """
 
-        def _get_block_hashes(
-            kv_cache_spec: KVCacheSpec,
-            manager_cls: type[SingleTypeKVCacheManager],
-        ) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
-                return block_hashes
-            if (
-                self.enable_partial_hash_hits
-                and manager_cls.supports_fine_grained_hash_lookup
-            ):
-                return block_hashes
-            return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, kv_cache_spec.block_size
-            )
-
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_length = max_cache_hit_length
         longest_hit_length = 0
@@ -723,7 +706,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         curr_hit_length + spec.block_size, max_cache_hit_length
                     )
                 hit_blocks = manager_cls.find_longest_cache_hit(
-                    block_hashes=_get_block_hashes(spec, manager_cls),
+                    block_hashes=block_hashes,
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
@@ -755,15 +738,17 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             num_blocks = cdiv(hit_length, first_group.spec.block_size)
             for group_id in first_group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
+                    # Full attention always returns a hit-length-carrying list.
+                    assert isinstance(blks, KVCacheBlockListWithHitLength)
                     del blks[num_blocks:]
-                    if isinstance(blks, KVCacheBlockListWithHitLength):
-                        blks.hit_length = hit_length
+                    blks.hit_length = hit_length
 
         # Uncached shared prefix detection: If any attn. group cached a longer prefix
         # than the current prefix, it is an uncached common prefix across requests:
         self.num_uncached_common_prefix_tokens = longest_hit_length - hit_length
         return tuple(
-            blocks if blocks is not None else [] for blocks in hit_blocks_by_group
+            blocks if blocks is not None else KVCacheBlockListWithHitLength()
+            for blocks in hit_blocks_by_group
         ), hit_length
 
     def find_longest_cache_hit_per_group(
@@ -777,28 +762,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             (blocks_per_group, hit_lengths_per_group)
         """
 
-        def _get_block_hashes(
-            kv_cache_spec: KVCacheSpec,
-            manager_cls: type[SingleTypeKVCacheManager],
-        ) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
-                return block_hashes
-            if (
-                self.enable_partial_hash_hits
-                and manager_cls.supports_fine_grained_hash_lookup
-            ):
-                return block_hashes
-            return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, kv_cache_spec.block_size
-            )
-
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
             blocks = manager_cls.find_longest_cache_hit(
-                block_hashes=_get_block_hashes(spec, manager_cls),
+                block_hashes=block_hashes,
                 max_length=max_cache_hit_length,
                 kv_cache_group_ids=group_ids,
                 block_pool=self.block_pool,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -21,7 +21,6 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
-    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
@@ -551,13 +550,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         ), "block_size must be divisible by hash_block_size"
         assert dcp_world_size == 1, "DCP not support hybrid attn now."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
-        self.enable_partial_hash_hits = any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            and g.kv_cache_spec.mamba_cache_mode == "align"
-            and g.kv_cache_spec.block_size > hash_block_size
-            for g in kv_cache_config.kv_cache_groups
-        )
         self.verify_and_split_kv_cache_groups()
+        # Fine-grained partial hits need every group to either scan at hash
+        # granularity or have nothing to gain from it (block_size ==
+        # hash_block_size, where the coarse path is already exact). Groups
+        # that support neither (chunked local attention) disable them.
+        self.enable_partial_hash_hits = hash_block_size < scheduler_block_size and all(
+            group.manager_cls.supports_fine_grained_hash_lookup
+            or group.spec.block_size == hash_block_size
+            for group in self.attention_groups
+        )
 
     @property
     def _cache_hit_alignment_tokens(self) -> int:
@@ -705,9 +707,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
                 _max_length = curr_hit_length
                 if drop_eagle_block:
-                    # Eagle needs to match one more block and then pop the last.
+                    # Eagle matches one more drop unit and then drops it: one
+                    # hash block for fine-grained managers, else one cache
+                    # block. The margin must equal the drop so the post-drop
+                    # length cannot exceed `curr_hit_length`.
+                    eagle_margin = (
+                        self.hash_block_size
+                        if self.enable_partial_hash_hits
+                        and manager_cls.supports_fine_grained_hash_lookup
+                        and spec.block_size > self.hash_block_size
+                        else spec.block_size
+                    )
                     _max_length = min(
-                        curr_hit_length + spec.block_size, max_cache_hit_length
+                        curr_hit_length + eagle_margin, max_cache_hit_length
                     )
                 hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=block_hashes,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -379,6 +379,7 @@ class KVCacheManager:
                 new_computed_blocks=new_computed_block_list,
                 num_encoder_tokens=num_encoder_tokens,
                 total_computed_tokens=total_computed_tokens,
+                num_local_computed_tokens=num_local_computed_tokens,
                 num_tokens_main_model=full_num_tokens,
                 apply_admission_cap=True,
             )
@@ -408,6 +409,7 @@ class KVCacheManager:
             num_encoder_tokens=num_encoder_tokens,
             total_computed_tokens=num_local_computed_tokens
             + num_external_computed_tokens,
+            num_local_computed_tokens=num_local_computed_tokens,
             num_tokens_main_model=num_tokens_main_model,
         )
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -10,7 +10,7 @@ from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     get_kv_cache_spec_kind,
@@ -608,6 +608,13 @@ class KVCacheManager:
         for mgr in self.coordinator.single_type_managers:
             ids.extend(mgr.take_new_block_ids())
         return ids
+
+    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
+        """Drain and return pending KV cache block copies."""
+        copies: list[KVCacheBlockCopy] = []
+        for mgr in self.coordinator.single_type_managers:
+            copies.extend(mgr.take_kv_cache_block_copies())
+        return copies
 
     def new_step_starts(self) -> None:
         """Called when a new step is started."""

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -201,7 +201,6 @@ class KVCacheManager:
 
     def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int]:
         """Get the computed (cached) blocks for the request.
-        Note that the computed blocks must be full.
 
         Args:
             request: The request to get the computed blocks.

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -123,6 +123,7 @@ class KVCacheManager:
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
         watermark: float = 0.0,
+        max_concurrent_batches: int = 1,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -152,6 +153,7 @@ class KVCacheManager:
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
+            max_concurrent_batches=max_concurrent_batches,
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool
@@ -397,8 +399,12 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
+        # Free on the processed-token basis: in-flight steps' attention windows
+        # still read blocks below the optimistic boundary, and rejected spec
+        # tokens can roll it back.
         self.coordinator.remove_skipped_blocks(
-            request.request_id, total_computed_tokens
+            request.request_id,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
         )
 
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Literal, overload
 
@@ -179,6 +179,15 @@ class KVCacheManager:
         self.empty_kv_cache_blocks = KVCacheBlocks(
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
+
+        # Optional hook for the CoW copy retentions handed back by
+        # `new_step_starts`. The scheduler installs it to defer the free
+        # while the step that runs the queued copy may still be in flight
+        # (see Scheduler._free_cow_retained_blocks). When unset, the
+        # retained blocks are freed immediately.
+        self.cow_retained_block_free_handler: (
+            Callable[[list[KVCacheBlock]], None] | None
+        ) = None
 
     @property
     def usage(self) -> float:
@@ -624,5 +633,17 @@ class KVCacheManager:
         return copies
 
     def new_step_starts(self) -> None:
-        """Called when a new step is started."""
-        self.coordinator.new_step_starts()
+        """Called when a new step is started.
+
+        CoW copy retentions from the previous step are handed to
+        `cow_retained_block_free_handler` when the scheduler installed one
+        (to fence the free against the copy's step still being in flight);
+        otherwise they are released immediately.
+        """
+        retained_blocks = self.coordinator.new_step_starts()
+        if not retained_blocks:
+            return
+        if self.cow_retained_block_free_handler is not None:
+            self.cow_retained_block_free_handler(retained_blocks)
+        else:
+            self.block_pool.free_blocks(retained_blocks)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -176,36 +176,6 @@ class KVCacheBlock:
         )
 
 
-class KVCacheBlockListWithHitLength(list[KVCacheBlock]):
-    """A block list carrying the exact token length it represents."""
-
-    def __init__(
-        self,
-        blocks: Sequence[KVCacheBlock] = (),
-        hit_length: int | None = None,
-    ) -> None:
-        super().__init__(blocks)
-        self.hit_length = hit_length
-
-
-def get_cache_hit_length(
-    blocks: Sequence[KVCacheBlock],
-    block_size: int,
-) -> int:
-    hit_length = getattr(blocks, "hit_length", None)
-    if hit_length is not None:
-        return hit_length
-    return len(blocks) * block_size
-
-
-def has_partial_cache_hit(
-    blocks: Sequence[KVCacheBlock],
-    block_size: int,
-) -> bool:
-    hit_length = get_cache_hit_length(blocks, block_size)
-    return hit_length > 0 and hit_length % block_size != 0
-
-
 class KVCacheBlockCopy(NamedTuple):
     src_block_id: int
     dst_block_id: int

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from functools import partial
-from typing import Any, NewType, TypeAlias, cast, overload
+from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 
 from vllm import envs
 from vllm.config import VllmConfig
@@ -126,7 +126,7 @@ class KVCacheBlock:
     # when the block is full and cached.
     _block_hash: BlockHashWithGroupId | None = None
     # Number of prefix tokens covered by _block_hash. For full blocks this is
-    # the full block boundary; partial aliases can end inside a cache block.
+    # the full block boundary; partial entries can end inside a cache block.
     _block_hash_num_tokens: int | None = None
 
     # Used to construct a doubly linked list for free blocks.
@@ -174,6 +174,45 @@ class KVCacheBlock:
             f"prev_free_block={prev_block_id}, "
             f"next_free_block={next_block_id})"
         )
+
+
+class KVCacheBlockListWithHitLength(list[KVCacheBlock]):
+    """A block list carrying the exact token length it represents."""
+
+    def __init__(
+        self,
+        blocks: Sequence[KVCacheBlock] = (),
+        hit_length: int | None = None,
+    ) -> None:
+        super().__init__(blocks)
+        self.hit_length = hit_length
+
+
+def get_cache_hit_length(
+    blocks: Sequence[KVCacheBlock],
+    block_size: int,
+) -> int:
+    hit_length = getattr(blocks, "hit_length", None)
+    if hit_length is not None:
+        return hit_length
+    return len(blocks) * block_size
+
+
+def has_partial_cache_hit(
+    blocks: Sequence[KVCacheBlock],
+    block_size: int,
+) -> bool:
+    hit_length = get_cache_hit_length(blocks, block_size)
+    return hit_length > 0 and hit_length % block_size != 0
+
+
+class KVCacheBlockCopy(NamedTuple):
+    """A pending copy between two KV cache blocks in one cache group."""
+
+    kv_cache_group_id: int
+    src_block_id: int
+    dst_block_id: int
+    num_tokens: int
 
 
 class FreeKVCacheBlockQueue:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -207,12 +207,8 @@ def has_partial_cache_hit(
 
 
 class KVCacheBlockCopy(NamedTuple):
-    """A pending copy between two KV cache blocks in one cache group."""
-
-    kv_cache_group_id: int
     src_block_id: int
     dst_block_id: int
-    num_tokens: int
 
 
 class FreeKVCacheBlockQueue:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -634,6 +634,14 @@ def resolve_kv_cache_block_sizes(
 
     if len(groups) <= 1:  # Single group: block_size * dcp * pcp
         bs = cache_config.block_size * dcp * pcp
+        if cache_config.hash_block_size not in (None, bs):
+            raise ValueError(
+                f"hash_block_size={cache_config.hash_block_size} is not "
+                f"supported for models with a single KV cache group: block "
+                f"hashes must be computed at block_size * dcp * pcp = {bs} "
+                f"tokens. Fine-grained partial prefix-cache hits require "
+                f"multiple KV cache groups and no context parallelism."
+            )
         return bs, bs
 
     if dcp != 1 or pcp != 1:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2251,3 +2251,36 @@ class BlockHashListWithBlockSize:
 
 
 BlockHashList = list[BlockHash] | BlockHashListWithBlockSize
+
+
+def resolve_block_hashes(
+    block_hashes: BlockHashList,
+    hash_block_size: int,
+    block_size: int,
+    *,
+    supports_fine_grained_hash_lookup: bool = False,
+    alignment_tokens: int | None = None,
+) -> BlockHashList:
+    """Resolve the block-hash view at ``block_size``.
+
+    When ``block_size`` equals ``hash_block_size``, reuse the precomputed block
+    hashes directly; otherwise view them at ``block_size`` granularity.
+    Fine-grained lookup keeps the original hashes for partial cache hits.
+    """
+    if block_size == hash_block_size:
+        return block_hashes
+    if isinstance(block_hashes, BlockHashListWithBlockSize):
+        # Already a block-size view
+        assert block_hashes.scale_factor == block_size // hash_block_size
+        return block_hashes
+    # Fine-grained partial hits keep the raw hashes. The caller passes
+    # alignment_tokens = hash_block_size to enable them, else >= block_size.
+    if (
+        supports_fine_grained_hash_lookup
+        and alignment_tokens is not None
+        and alignment_tokens < block_size
+        and block_size % alignment_tokens == 0
+    ):
+        return block_hashes
+    assert block_size % hash_block_size == 0
+    return BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -16,10 +16,12 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalFeatureSpec
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
+    from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
     from vllm.v1.request import Request
 else:
     ECConnectorMetadata = object
     KVConnectorMetadata = object
+    KVCacheBlockCopy = object
     LoRARequest = object
     MultiModalFeatureSpec = object
     PoolingParams = object
@@ -239,6 +241,9 @@ class SchedulerOutput:
     # The worker zeros the corresponding GPU memory before the blocks are used,
     # preventing stale NaN/data from corrupting attention or SSM computation.
     new_block_ids_to_zero: list[int] | None = None
+
+    # CoW copies to apply after zeroing new blocks and before forward.
+    kv_cache_block_copies: list[KVCacheBlockCopy] | None = None
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2341,6 +2341,7 @@ class Scheduler(SchedulerInterface):
             new_computed_blocks=self.kv_cache_manager.empty_kv_cache_blocks.blocks,
             num_encoder_tokens=0,
             total_computed_tokens=request.num_computed_tokens,
+            num_local_computed_tokens=request.num_computed_tokens,
             num_tokens_main_model=full_num_tokens,
             apply_admission_cap=True,
         )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1048,6 +1048,9 @@ class Scheduler(SchedulerInterface):
             if self.needs_kv_cache_zeroing
             else None
         )
+        kv_cache_block_copies = (
+            self.kv_cache_manager.take_kv_cache_block_copies() or None
+        )
 
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
@@ -1072,6 +1075,7 @@ class Scheduler(SchedulerInterface):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            kv_cache_block_copies=kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
         )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -310,6 +310,21 @@ class Scheduler(SchedulerInterface):
         # FIFO of (fence_seq, blocks): blocks become safe to free once
         # processed_step_seq >= fence_seq.
         self.deferred_frees: deque[tuple[int, list[KVCacheBlock]]] = deque()
+        # Fence for the most recently emitted KV block copies: the seq of the
+        # first non-empty step whose completion implies the copies have run
+        # (same-stream ordering). Copies riding a 0-token step (async KV
+        # loads only) never advance sched_step_seq themselves, so this can
+        # point one step past it.
+        self.cow_copy_fence_seq = 0
+        # Fence partial-hit CoW retention releases like request-level frees: the step
+        # that runs the queued block copy may still be in flight when the
+        # next schedule() releases the retentions, and a KV-consumer
+        # connector could otherwise reallocate a copy endpoint as a load
+        # destination and overwrite it via a transfer that is not ordered
+        # against the copy.
+        self.kv_cache_manager.cow_retained_block_free_handler = (
+            self._free_cow_retained_blocks
+        )
 
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
@@ -1099,6 +1114,12 @@ class Scheduler(SchedulerInterface):
         kv_cache_block_copies = (
             self.kv_cache_manager.take_kv_cache_block_copies() or None
         )
+        if kv_cache_block_copies:
+            # The copies are dispatched with this step; the first non-empty
+            # step at or after it gets seq `sched_step_seq + 1` (0-token
+            # steps do not advance the seq), and its completion implies the
+            # copies have run.
+            self.cow_copy_fence_seq = self.sched_step_seq + 1
 
         # Dynamic speculative decoding: compute optimal K
         num_spec_tokens_to_schedule = self.num_spec_tokens
@@ -2145,11 +2166,28 @@ class Scheduler(SchedulerInterface):
         if blocks:
             self.deferred_frees.append((self.sched_step_seq, blocks))
 
+    def _free_cow_retained_blocks(self, blocks: list[KVCacheBlock]):
+        """Release the previous step's CoW copy retentions
+        (`new_step_starts`), deferring the return to the block pool while the
+        step that runs the queued copy may still be in flight on the GPU.
+        """
+        if not blocks:
+            return
+        # `cow_copy_fence_seq` was recorded when the copies were emitted; it
+        # is the seq of the first non-empty step ordered after them.
+        if not self.defer_block_free or (
+            self.cow_copy_fence_seq <= self.processed_step_seq
+        ):
+            self.kv_cache_manager.block_pool.free_blocks(blocks)
+            return
+        self.deferred_frees.append((self.cow_copy_fence_seq, blocks[::-1]))
+
     def _drain_deferred_frees(self):
         """Return deferred blocks whose fence step has completed.
 
-        Entries are appended with monotonically non-decreasing fences, so
-        stop at the first one that is still pending.
+        Fences are appended in near-monotonic order (a CoW retention fence
+        can lead request-free fences by one step), so stop at the first
+        pending one; any satisfied entry behind it is merely freed later.
         """
         while self.deferred_frees:
             fence, _ = self.deferred_frees[0]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -265,6 +265,7 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
@@ -1145,6 +1146,7 @@ class Scheduler(SchedulerInterface):
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
             request.num_computed_tokens += num_scheduled_token
+            request.num_in_flight_tokens += num_scheduled_token
             if self.defer_block_free:
                 # Record the in-flight step, to fence deferred block freeing.
                 request.last_sched_seq = self.sched_step_seq
@@ -1530,10 +1532,12 @@ class Scheduler(SchedulerInterface):
         stopped_preempted_reqs: set[Request] = set()
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # skip failed or rescheduled requests from KV load failure
                 continue
-            request = self.requests.get(req_id)
             if request is None or request.is_finished():
                 # The request is already finished. This can happen if the
                 # request is aborted while the model is executing it (e.g.,
@@ -2314,10 +2318,12 @@ class Scheduler(SchedulerInterface):
             return False, None
 
         # Free any out-of-window prefix blocks before we hand the block table to
-        # the connector.
+        # the connector, on the processed-token basis (see `allocate_slots`).
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
-            total_computed_tokens=request.num_computed_tokens,
+            total_computed_tokens=max(
+                0, request.num_computed_tokens - request.num_in_flight_tokens
+            ),
         )
 
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -251,6 +251,7 @@ class Scheduler(SchedulerInterface):
         # Create the KV cache manager.
         if hash_block_size is None:
             hash_block_size = block_size
+        self.hash_block_size = hash_block_size
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
@@ -289,6 +290,17 @@ class Scheduler(SchedulerInterface):
         self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
+        )
+        # Fine-grained partial prefix-cache entries for mamba can only be
+        # registered by a step that ends EXACTLY at the prompt's last hash
+        # boundary (the state block is rewritten in place afterwards). When
+        # partial hits are on, the split adds that stop so every prompt gets
+        # a partial tail entry, not just prompts that are hash-aligned.
+        self.mamba_partial_tail_stop = bool(
+            self.need_mamba_block_aligned_split
+            and getattr(
+                self.kv_cache_manager.coordinator, "enable_partial_hash_hits", False
+            )
         )
 
         # Counts of non-empty steps scheduled / processed. update_from_output
@@ -361,9 +373,29 @@ class Scheduler(SchedulerInterface):
             if self.use_eagle:
                 last_cache_position = max(last_cache_position - block_size, 0)
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
-            if num_computed_tokens_after_sched < last_cache_position:
-                # align to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
+            next_boundary = (num_computed_tokens // block_size + 1) * block_size
+            if (
+                num_computed_tokens % block_size != 0
+                and next_boundary <= last_cache_position
+                and num_computed_tokens_after_sched > next_boundary
+            ):
+                # Resumed mid-block (fine-grained partial prefix-cache hit):
+                # the resumed block's boundary state must be materialized
+                # before running past it — align-mode caching registers that
+                # block under its block-end hash, and the state is only
+                # written when a step ends exactly at the boundary. Stop the
+                # first chunk there; subsequent chunks are aligned again.
+                num_new_tokens = next_boundary - num_computed_tokens
+            elif num_computed_tokens_after_sched < last_cache_position:
+                # Align the chunk END (not its length) to block_size:
+                # num_computed_tokens can sit mid-block after a fine-grained
+                # partial hit, and flooring only the length would keep every
+                # subsequent step end unaligned. Identical to the previous
+                # behavior when num_computed_tokens is aligned. May yield 0
+                # (insufficient budget to reach the next boundary); the
+                # caller then skips the request for this step.
+                aligned_end = num_computed_tokens_after_sched // block_size * block_size
+                num_new_tokens = max(aligned_end - num_computed_tokens, 0)
             elif (
                 num_computed_tokens
                 < last_cache_position
@@ -372,8 +404,23 @@ class Scheduler(SchedulerInterface):
                 # force to cache the last chunk
                 num_new_tokens = last_cache_position - num_computed_tokens
             else:
-                # prefill the last few tokens
-                pass
+                # Prefill of the final partial block. When fine-grained
+                # partial hits are on, stop once more at the prompt's last
+                # hash boundary: the mamba partial tail entry can only be
+                # registered by a step ending exactly there (the state block
+                # is rewritten in place afterwards). Without this stop only
+                # hash-aligned prompts ever produce a mamba partial entry.
+                if self.mamba_partial_tail_stop:
+                    hash_bs = self.hash_block_size
+                    tail_boundary = request.num_prompt_tokens // hash_bs * hash_bs
+                    if (
+                        num_computed_tokens
+                        < tail_boundary
+                        < num_computed_tokens_after_sched
+                        and tail_boundary < request.num_prompt_tokens
+                        and tail_boundary > last_cache_position
+                    ):
+                        num_new_tokens = tail_boundary - num_computed_tokens
 
             # Marconi cache admission optimization:
             # cache common prefixes by scheduling num_new_tokens = common prefix length

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -604,7 +604,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             pcp_world_size=pcp_world_size,
             max_admission_blocks_per_request=max_admission_blocks_per_request,
         )
-        self.num_cached_hash_block: dict[str, int] = {}
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._retained_cow_source_blocks: list[KVCacheBlock] = []
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
@@ -856,24 +855,17 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         if boundary_tokens % self.block_size == 0:
             return
 
-        hash_idx = boundary_tokens // hash_block_size - 1
-        num_cached_hash_blocks = self.num_cached_hash_block.get(request.request_id, 0)
-        if num_cached_hash_blocks > hash_idx:
-            return
-
         blocks = self.req_to_blocks[request.request_id]
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        partial_hash = self.block_pool.cache_partial_block(
+        self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
-        if partial_hash is not None:
-            self.num_cached_hash_block[request.request_id] = hash_idx + 1
 
     def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
         copies = self._kv_cache_block_copies
@@ -881,7 +873,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         return copies
 
     def free(self, request_id: str) -> None:
-        self.num_cached_hash_block.pop(request_id, None)
         self._partial_hit_reqs.pop(request_id, None)
         super().free(request_id)
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -347,13 +347,6 @@ class SingleTypeKVCacheManager(ABC):
         self._kv_cache_block_copies = []
         return copies
 
-    def _retain_block(self, block: KVCacheBlock) -> None:
-        if block.is_null:
-            return
-        if block.ref_cnt == 0:
-            self.block_pool.free_block_queue.remove(block)
-        block.ref_cnt += 1
-
     def _free_retained_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
         freed_blocks: list[KVCacheBlock] = []
         ref_counts_by_id = Counter(block.block_id for block in blocks)
@@ -376,15 +369,17 @@ class SingleTypeKVCacheManager(ABC):
         """Redirect ``req_blocks[block_idx]`` from a shared, partially-hit
         ``source_block`` to a private ``cow_block``.
 
-        Records the block copy for the worker and defers releasing the source's
-        hit-ref to the next step (``new_step_starts``), after the copy has run.
+        The request already holds a ref on ``source_block`` (from the
+        prefix-cache touch, or from allocation for the mamba producer). We keep
+        that ref and release it next step (``new_step_starts``), after the
+        worker copy has run, rather than freeing it now -- this keeps the block
+        alive and out of the free queue across the step without a retain/free
+        round-trip.
         """
         req_blocks = self.req_to_blocks[request_id]
         assert block_idx < len(req_blocks)
         assert req_blocks[block_idx] is source_block
-        self._retain_block(source_block)
         req_blocks[block_idx] = cow_block
-        self.block_pool.free_blocks([source_block])
         self._kv_cache_block_copies.append(
             KVCacheBlockCopy(
                 src_block_id=source_block.block_id,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -111,6 +111,16 @@ class SingleTypeKVCacheManager(ABC):
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
         return sum(blk.ref_cnt == 0 and not blk.is_null for blk in blocks)
 
+    def _has_partial_local_hit(
+        self,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+    ) -> bool:
+        return (
+            len(new_computed_blocks) > 0
+            and num_local_computed_tokens % self.block_size != 0
+        )
+
     def get_num_blocks_to_allocate(
         self,
         request_id: str,
@@ -712,10 +722,10 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 for computed in computed_blocks:
                     computed.pop()
                 hit_length = len(computed_blocks[0]) * block_size
-            while block_size != alignment_tokens and hit_length % alignment_tokens != 0:
-                for computed in computed_blocks:
-                    computed.pop()
-                hit_length = len(computed_blocks[0]) * block_size
+            # Fine-grained hits land on a hash-block boundary (== alignment_tokens)
+            # by construction, and the eagle pop drops to a full-block boundary, so
+            # the result is always alignment-aligned; no extra trim needed here
+            # (unlike the coarse branch below, which handles alignment > block_size).
             return computed_blocks, hit_length
 
         max_num_blocks = max_length // block_size
@@ -765,10 +775,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             num_tokens_main_model,
             apply_admission_cap=apply_admission_cap,
         )
-        if (
-            request_id not in self.num_cached_block
-            and len(new_computed_blocks) > 0
-            and num_local_computed_tokens % self.block_size != 0
+        if request_id not in self.num_cached_block and self._has_partial_local_hit(
+            new_computed_blocks, num_local_computed_tokens
         ):
             num_blocks += 1
         return num_blocks
@@ -786,18 +794,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             num_local_computed_tokens,
             num_external_computed_tokens,
         )
-        hit_length = num_local_computed_tokens
-        if (
-            len(new_computed_blocks) > 0
-            and hit_length > 0
-            and hit_length % self.block_size != 0
-        ):
-            block_idx = hit_length // self.block_size
-            source_block = new_computed_blocks[-1]
-            self._partial_hit_reqs[request_id] = (
-                block_idx,
-                source_block,
-            )
+        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
+            block_idx = num_local_computed_tokens // self.block_size
+            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
             self.num_cached_block[request_id] = block_idx
 
     def allocate_new_blocks(
@@ -1428,12 +1427,11 @@ class MambaManager(SingleTypeKVCacheManager):
                 - len(new_computed_blocks)
                 - len(self.req_to_blocks[request_id])
             )
-            has_partial_local_hit = (
-                len(new_computed_blocks) > 0
-                and num_local_computed_tokens % self.block_size != 0
-            )
             has_partial_hit = (
-                has_partial_local_hit or request_id in self._partial_hit_reqs
+                self._has_partial_local_hit(
+                    new_computed_blocks, num_local_computed_tokens
+                )
+                or request_id in self._partial_hit_reqs
             )
             if has_partial_hit:
                 num_new_blocks = max(num_new_blocks, 0) + 1
@@ -1637,10 +1635,8 @@ class MambaManager(SingleTypeKVCacheManager):
             num_local_computed_tokens,
             num_external_computed_tokens,
         )
-        if (
-            self.mamba_cache_mode == "align"
-            and len(new_computed_blocks) > 0
-            and num_local_computed_tokens % self.block_size != 0
+        if self.mamba_cache_mode == "align" and self._has_partial_local_hit(
+            new_computed_blocks, num_local_computed_tokens
         ):
             block_idx = num_local_computed_tokens // self.block_size
             self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -336,6 +336,27 @@ class SingleTypeKVCacheManager(ABC):
         """Drain and return pending KV cache block copies."""
         return []
 
+    def _retain_block(self, block: KVCacheBlock) -> None:
+        if block.is_null:
+            return
+        if block.ref_cnt == 0:
+            self.block_pool.free_block_queue.remove(block)
+        block.ref_cnt += 1
+
+    def _free_retained_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
+        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
+        for block in blocks:
+            _, count = block_ref_counts.get(block.block_id, (block, 0))
+            block_ref_counts[block.block_id] = (block, count + 1)
+
+        freed_blocks: list[KVCacheBlock] = []
+        for block, count in block_ref_counts.values():
+            assert block.ref_cnt >= count
+            block.ref_cnt -= count
+            if block.ref_cnt == 0 and not block.is_null:
+                freed_blocks.append(block)
+        self.block_pool.free_block_queue.append_n(freed_blocks)
+
     def cache_blocks(
         self,
         request: Request,
@@ -806,7 +827,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 )
             )
             if not release_source_ref:
-                self._retain_cow_source_block(source_block)
+                self._retain_block(source_block)
             self._pending_cow_source_blocks.append(source_block)
             new_blocks.append(cow_block)
 
@@ -814,16 +835,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             super().allocate_new_blocks(request_id, num_tokens, num_tokens_main_model)
         )
         return new_blocks
-
-    def _retain_cow_source_block(self, block: KVCacheBlock) -> None:
-        if (
-            block.ref_cnt == 0
-            and not block.is_null
-            and block.prev_free_block is not None
-            and block.next_free_block is not None
-        ):
-            self.block_pool.free_block_queue.remove(block)
-        block.ref_cnt += 1
 
     def cache_blocks(
         self,
@@ -880,22 +891,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         if self._pending_cow_source_blocks:
-            self._free_pending_cow_source_blocks()
+            self._free_retained_blocks(self._pending_cow_source_blocks)
             self._pending_cow_source_blocks = []
-
-    def _free_pending_cow_source_blocks(self) -> None:
-        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
-        for block in self._pending_cow_source_blocks:
-            _, count = block_ref_counts.get(block.block_id, (block, 0))
-            block_ref_counts[block.block_id] = (block, count + 1)
-
-        freed_blocks: list[KVCacheBlock] = []
-        for block, count in block_ref_counts.values():
-            assert block.ref_cnt >= count
-            block.ref_cnt -= count
-            if block.ref_cnt == 0 and not block.is_null:
-                freed_blocks.append(block)
-        self.block_pool.free_block_queue.append_n(freed_blocks)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1690,27 +1687,6 @@ class MambaManager(SingleTypeKVCacheManager):
         copies = self._kv_cache_block_copies
         self._kv_cache_block_copies = []
         return copies
-
-    def _free_retained_blocks(self, blocks: list[KVCacheBlock]) -> None:
-        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
-        for block in blocks:
-            _, count = block_ref_counts.get(block.block_id, (block, 0))
-            block_ref_counts[block.block_id] = (block, count + 1)
-
-        freed_blocks: list[KVCacheBlock] = []
-        for block, count in block_ref_counts.values():
-            assert block.ref_cnt >= count
-            block.ref_cnt -= count
-            if block.ref_cnt == 0 and not block.is_null:
-                freed_blocks.append(block)
-        self.block_pool.free_block_queue.append_n(freed_blocks)
-
-    def _retain_block(self, block: KVCacheBlock) -> None:
-        if block.is_null:
-            return
-        if block.ref_cnt == 0:
-            self.block_pool.free_block_queue.remove(block)
-        block.ref_cnt += 1
 
     def add_local_computed_blocks(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -16,9 +16,6 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashWithGroupId,
     KVCacheBlock,
     KVCacheBlockCopy,
-    KVCacheBlockListWithHitLength,
-    get_cache_hit_length,
-    has_partial_cache_hit,
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -121,6 +118,7 @@ class SingleTypeKVCacheManager(ABC):
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
+        num_local_computed_tokens: int,
         num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
@@ -134,6 +132,8 @@ class SingleTypeKVCacheManager(ABC):
             new_computed_blocks: The new computed blocks just hitting the
                 prefix caching.
             total_computed_tokens: Include both local and external computed
+                tokens.
+            num_local_computed_tokens: The number of local prefix-cache computed
                 tokens.
             num_tokens_main_model: The number of tokens for the main model (aka target
                 model in spec decode). w/o spec decode, it is num_tokens;
@@ -485,7 +485,7 @@ class SingleTypeKVCacheManager(ABC):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         """
         Get the longest cache hit prefix of the blocks that is not longer than
         `max_length`. The prefix should be a common prefix hit for all the
@@ -512,11 +512,9 @@ class SingleTypeKVCacheManager(ABC):
             pcp_world_size: The world size of prefill context parallelism.
 
         Returns:
-            A list of cached blocks with skipped blocks replaced by null block
-            for each kv cache group in `kv_cache_group_ids`.
-            Return a list of length `len(kv_cache_group_ids)`, where the i-th
-            element is a list of cached blocks for the i-th kv cache group
-            in `kv_cache_group_ids`.
+            A tuple containing cached blocks and the exact cache-hit length in
+            tokens. The cached block tuple has skipped blocks replaced by null
+            blocks for each kv cache group in `kv_cache_group_ids`.
             For example, sliding window manager should return a list like
             ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
             and sliding window 8 and len(kv_cache_group_ids) = 1.
@@ -622,7 +620,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_pool: BlockPool,
         block_size: int,
         hash_block_size: int,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert block_size % hash_block_size == 0
         scale_factor = block_size // hash_block_size
         full_block_hashes = BlockHashListWithBlockSize(
@@ -633,8 +631,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             len(block_hashes),
         )
 
-        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
-            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
         )
         max_num_full_blocks = max_length // block_size
         num_full_blocks = 0
@@ -667,10 +665,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             hit_length = num_tokens
             break
 
-        for computed in computed_blocks:
-            assert isinstance(computed, KVCacheBlockListWithHitLength)
-            computed.hit_length = hit_length
-        return computed_blocks
+        return computed_blocks, hit_length
 
     @classmethod
     def find_longest_cache_hit(
@@ -684,7 +679,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(
             kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
         ), (
@@ -698,15 +693,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
-        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
-            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
         if alignment_tokens < block_size and block_size % alignment_tokens == 0:
             assert isinstance(block_hashes, list)
-            computed_blocks = cls._find_fine_grained_cache_hit(
+            computed_blocks, hit_length = cls._find_fine_grained_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_length,
                 kv_cache_group_ids=kv_cache_group_ids,
@@ -717,19 +712,12 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             if drop_eagle_block and computed_blocks[0]:
                 for computed in computed_blocks:
                     computed.pop()
-                    assert isinstance(computed, KVCacheBlockListWithHitLength)
-                    computed.hit_length = len(computed) * block_size
-            while (
-                block_size != alignment_tokens
-                and get_cache_hit_length(computed_blocks[0], block_size)
-                % alignment_tokens
-                != 0
-            ):
+                hit_length = len(computed_blocks[0]) * block_size
+            while block_size != alignment_tokens and hit_length % alignment_tokens != 0:
                 for computed in computed_blocks:
                     computed.pop()
-                    assert isinstance(computed, KVCacheBlockListWithHitLength)
-                    computed.hit_length = len(computed) * block_size
-            return computed_blocks
+                hit_length = len(computed_blocks[0]) * block_size
+            return computed_blocks, hit_length
 
         max_num_blocks = max_length // block_size
         hit_length = 0
@@ -757,10 +745,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             for computed in computed_blocks:
                 computed.pop()
             hit_length -= block_size
-        for computed in computed_blocks:
-            assert isinstance(computed, KVCacheBlockListWithHitLength)
-            computed.hit_length = hit_length
-        return computed_blocks
+        return computed_blocks, hit_length
 
     def get_num_blocks_to_allocate(
         self,
@@ -768,6 +753,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
+        num_local_computed_tokens: int,
         num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
@@ -776,11 +762,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             num_tokens,
             new_computed_blocks,
             total_computed_tokens,
+            num_local_computed_tokens,
             num_tokens_main_model,
             apply_admission_cap=apply_admission_cap,
         )
-        if request_id not in self.num_cached_block and has_partial_cache_hit(
-            new_computed_blocks, self.block_size
+        if (
+            request_id not in self.num_cached_block
+            and len(new_computed_blocks) > 0
+            and num_local_computed_tokens % self.block_size != 0
         ):
             num_blocks += 1
         return num_blocks
@@ -798,8 +787,12 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             num_local_computed_tokens,
             num_external_computed_tokens,
         )
-        hit_length = get_cache_hit_length(new_computed_blocks, self.block_size)
-        if hit_length > 0 and hit_length % self.block_size != 0:
+        hit_length = num_local_computed_tokens
+        if (
+            len(new_computed_blocks) > 0
+            and hit_length > 0
+            and hit_length % self.block_size != 0
+        ):
             block_idx = hit_length // self.block_size
             source_block = new_computed_blocks[-1]
             self._partial_hit_reqs[request_id] = (
@@ -936,7 +929,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(kv_cache_spec, SlidingWindowSpec), (
             "SlidingWindowManager can only be used for sliding window groups"
         )
@@ -961,8 +954,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # sliding_window_contiguous_blocks),
         # which is good for low cache hit rate scenarios.
         max_num_blocks = max_length // kv_cache_spec.block_size
-        computed_blocks = tuple(
-            KVCacheBlockListWithHitLength([block_pool.null_block] * max_num_blocks)
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
@@ -1016,9 +1009,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             ):
                 for computed in computed_blocks:
                     computed.pop()
-        for computed in computed_blocks:
-            computed.hit_length = len(computed) * block_size
-        return computed_blocks
+        hit_length = len(computed_blocks[0]) * block_size
+        return computed_blocks, hit_length
 
     @classmethod
     def reachable_block_mask(
@@ -1139,7 +1131,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         """
         For chunked local attention, we need to find the longest cache hit
         prefix of the blocks that is not longer than `max_length`. The prefix
@@ -1211,10 +1203,8 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         local_attention_start_block_idx = (
             local_attention_start_idx // kv_cache_spec.block_size
         )
-        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
-            KVCacheBlockListWithHitLength(
-                [block_pool.null_block] * local_attention_start_block_idx
-            )
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [block_pool.null_block] * local_attention_start_block_idx
             for _ in range(len(kv_cache_group_ids))
         )
         for i in range(local_attention_start_block_idx, max_num_blocks):
@@ -1226,9 +1216,8 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
                     computed.append(cached)
             else:
                 break
-        for computed in computed_blocks:
-            computed.hit_length = len(computed) * kv_cache_spec.block_size
-        return computed_blocks
+        hit_length = len(computed_blocks[0]) * kv_cache_spec.block_size
+        return computed_blocks, hit_length
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -1315,7 +1304,7 @@ class MambaManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
         )
@@ -1328,9 +1317,10 @@ class MambaManager(SingleTypeKVCacheManager):
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
-        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
-            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
         )
+        hit_length = 0
 
         block_size = kv_cache_spec.block_size
         if alignment_tokens < block_size and block_size % alignment_tokens == 0:
@@ -1351,10 +1341,9 @@ class MambaManager(SingleTypeKVCacheManager):
                     for computed, cached in zip(computed_blocks, cached_block):
                         computed.extend([block_pool.null_block] * block_idx)
                         computed.append(cached)
-                        assert isinstance(computed, KVCacheBlockListWithHitLength)
-                        computed.hit_length = num_tokens
+                    hit_length = num_tokens
                     break
-            return computed_blocks
+            return computed_blocks, hit_length
 
         max_num_blocks = max_length // block_size
         # Search from right to left and early stop when a match is found.
@@ -1377,11 +1366,10 @@ class MambaManager(SingleTypeKVCacheManager):
                     # so we insert dummy blocks at the beginning:
                     computed.extend([block_pool.null_block] * i)
                     computed.append(cached)
-                    assert isinstance(computed, KVCacheBlockListWithHitLength)
-                    computed.hit_length = (i + 1) * block_size
+                hit_length = (i + 1) * block_size
                 break  # we just need the last match - early stopping
 
-        return computed_blocks
+        return computed_blocks, hit_length
 
     def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
@@ -1425,6 +1413,7 @@ class MambaManager(SingleTypeKVCacheManager):
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
+        num_local_computed_tokens: int,
         num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
@@ -1450,6 +1439,7 @@ class MambaManager(SingleTypeKVCacheManager):
                 num_tokens,
                 new_computed_blocks,
                 total_computed_tokens,
+                num_local_computed_tokens,
                 num_tokens_main_model,
                 apply_admission_cap=apply_admission_cap,
             )
@@ -1471,9 +1461,12 @@ class MambaManager(SingleTypeKVCacheManager):
                 - len(new_computed_blocks)
                 - len(self.req_to_blocks[request_id])
             )
+            has_partial_local_hit = (
+                len(new_computed_blocks) > 0
+                and num_local_computed_tokens % self.block_size != 0
+            )
             has_partial_hit = (
-                has_partial_cache_hit(new_computed_blocks, self.block_size)
-                or request_id in self._partial_hit_reqs
+                has_partial_local_hit or request_id in self._partial_hit_reqs
             )
             if has_partial_hit:
                 num_new_blocks = max(num_new_blocks, 0) + 1
@@ -1700,11 +1693,12 @@ class MambaManager(SingleTypeKVCacheManager):
             num_local_computed_tokens,
             num_external_computed_tokens,
         )
-        if self.mamba_cache_mode == "align" and has_partial_cache_hit(
-            new_computed_blocks, self.block_size
+        if (
+            self.mamba_cache_mode == "align"
+            and len(new_computed_blocks) > 0
+            and num_local_computed_tokens % self.block_size != 0
         ):
-            hit_length = get_cache_hit_length(new_computed_blocks, self.block_size)
-            block_idx = hit_length // self.block_size
+            block_idx = num_local_computed_tokens // self.block_size
             self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
             self.num_cached_block[request_id] = block_idx
 
@@ -1759,7 +1753,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
         assert isinstance(kv_cache_spec, CrossAttentionSpec), (
             "CrossAttentionManager can only be used for cross-attention groups"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -42,6 +42,10 @@ class SingleTypeKVCacheManager(ABC):
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
+    # Whether newly allocated block IDs are reported via `take_new_block_ids`
+    # (feeds `new_block_ids_to_zero` for worker-side zeroing).
+    tracks_new_block_ids: ClassVar[bool] = False
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -293,12 +297,7 @@ class SingleTypeKVCacheManager(ABC):
             cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
         )
         req_blocks.extend(allocated_blocks)
-        if type(self.kv_cache_spec) in (
-            FullAttentionSpec,
-            TQFullAttentionSpec,
-            MLAAttentionSpec,
-            HiddenStateCacheSpec,
-        ):
+        if self.tracks_new_block_ids:
             self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
@@ -326,12 +325,7 @@ class SingleTypeKVCacheManager(ABC):
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
-            if type(self.kv_cache_spec) in (
-                FullAttentionSpec,
-                TQFullAttentionSpec,
-                MLAAttentionSpec,
-                HiddenStateCacheSpec,
-            ):
+            if self.tracks_new_block_ids:
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 
@@ -614,6 +608,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    tracks_new_block_ids: ClassVar[bool] = True
 
     @classmethod
     def _find_fine_grained_cache_hit(
@@ -1702,6 +1697,10 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
 
 
 class SinkFullAttentionManager(FullAttentionManager):
+    # SinkFullAttentionSpec was never in the spec-type allowlist this flag
+    # replaced, so its new blocks stay unreported for zeroing.
+    tracks_new_block_ids: ClassVar[bool] = False
+
     def __init__(
         self,
         kv_cache_spec: SinkFullAttentionSpec,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import ClassVar
@@ -41,7 +41,6 @@ from vllm.v1.request import Request
 @dataclass
 class _RetainedKVCacheBlockCopy:
     source_block: KVCacheBlock
-    dst_block: KVCacheBlock
     copy: KVCacheBlockCopy
 
 
@@ -345,18 +344,24 @@ class SingleTypeKVCacheManager(ABC):
         block.ref_cnt += 1
 
     def _free_retained_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
-        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
-        for block in blocks:
-            _, count = block_ref_counts.get(block.block_id, (block, 0))
-            block_ref_counts[block.block_id] = (block, count + 1)
-
         freed_blocks: list[KVCacheBlock] = []
-        for block, count in block_ref_counts.values():
+        ref_counts_by_id = Counter(block.block_id for block in blocks)
+        blocks_by_id = {block.block_id: block for block in blocks}
+        for block_id, count in ref_counts_by_id.items():
+            block = blocks_by_id[block_id]
             assert block.ref_cnt >= count
             block.ref_cnt -= count
             if block.ref_cnt == 0 and not block.is_null:
                 freed_blocks.append(block)
         self.block_pool.free_block_queue.append_n(freed_blocks)
+
+    def _free_retained_copies(
+        self,
+        copies: list[_RetainedKVCacheBlockCopy],
+    ) -> None:
+        if not copies:
+            return
+        self._free_retained_blocks([copy.source_block for copy in copies])
 
     def cache_blocks(
         self,
@@ -605,8 +610,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             max_admission_blocks_per_request=max_admission_blocks_per_request,
         )
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
-        self._retained_cow_source_blocks: list[KVCacheBlock] = []
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
+        self._copy_refs_to_release: list[_RetainedKVCacheBlockCopy] = []
 
     @classmethod
     def _find_fine_grained_cache_hit(
@@ -817,13 +822,17 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             req_blocks[block_idx] = cow_block
             self.block_pool.free_blocks([source_block])
             self.new_block_ids.append(cow_block.block_id)
-            self._kv_cache_block_copies.append(
-                KVCacheBlockCopy(
-                    src_block_id=source_block.block_id,
-                    dst_block_id=cow_block.block_id,
+            block_copy = KVCacheBlockCopy(
+                src_block_id=source_block.block_id,
+                dst_block_id=cow_block.block_id,
+            )
+            self._kv_cache_block_copies.append(block_copy)
+            self._copy_refs_to_release.append(
+                _RetainedKVCacheBlockCopy(
+                    source_block=source_block,
+                    copy=block_copy,
                 )
             )
-            self._retained_cow_source_blocks.append(source_block)
             new_blocks.append(cow_block)
 
         new_blocks.extend(
@@ -841,13 +850,19 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
-        self._cache_final_prompt_hash_tail_only(request, num_tokens)
+        self._cache_partial_tail_block(request, num_tokens)
 
-    def _cache_final_prompt_hash_tail_only(
+    def _cache_partial_tail_block(
         self,
         request: Request,
         num_tokens: int,
     ) -> None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped.
+        """
         hash_block_size = self.block_pool.hash_block_size
         boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
         if boundary_tokens == 0 or boundary_tokens > num_tokens:
@@ -877,9 +892,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         super().free(request_id)
 
     def new_step_starts(self) -> None:
-        if self._retained_cow_source_blocks:
-            self._free_retained_blocks(self._retained_cow_source_blocks)
-            self._retained_cow_source_blocks = []
+        self._free_retained_copies(self._copy_refs_to_release)
+        self._copy_refs_to_release = []
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1286,10 +1300,8 @@ class MambaManager(SingleTypeKVCacheManager):
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
             self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
-            self._retained_cow_source_blocks: list[KVCacheBlock] = []
             self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
-            self._active_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
-            self._delayed_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
+            self._copy_refs_to_release: list[_RetainedKVCacheBlockCopy] = []
 
     @classmethod
     def find_longest_cache_hit(
@@ -1570,13 +1582,17 @@ class MambaManager(SingleTypeKVCacheManager):
                     self._retain_block(source_block)
                     req_blocks[block_idx] = cow_block
                     self.block_pool.free_blocks([source_block])
-                    self._kv_cache_block_copies.append(
-                        KVCacheBlockCopy(
-                            src_block_id=source_block.block_id,
-                            dst_block_id=cow_block.block_id,
+                    block_copy = KVCacheBlockCopy(
+                        src_block_id=source_block.block_id,
+                        dst_block_id=cow_block.block_id,
+                    )
+                    self._kv_cache_block_copies.append(block_copy)
+                    self._copy_refs_to_release.append(
+                        _RetainedKVCacheBlockCopy(
+                            source_block=source_block,
+                            copy=block_copy,
                         )
                     )
-                    self._retained_cow_source_blocks.append(source_block)
                     returned_blocks = [cow_block] + returned_blocks
                     new_blocks = new_blocks[1:]
                 req_blocks.extend(new_blocks)
@@ -1610,7 +1626,7 @@ class MambaManager(SingleTypeKVCacheManager):
         super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
-            partial_hash = self._cache_partial_snapshot(request, num_tokens)
+            partial_hash = self._cache_partial_tail_block(request, num_tokens)
             if partial_hash is not None:
                 self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
@@ -1624,18 +1640,11 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         if self.mamba_cache_mode == "align":
-            if self._retained_cow_source_blocks:
-                self._free_retained_blocks(self._retained_cow_source_blocks)
-                self._retained_cow_source_blocks = []
-            self._free_snapshot_copies(self._active_snapshot_copies)
-            self._active_snapshot_copies = self._delayed_snapshot_copies
-            self._delayed_snapshot_copies = []
-            self._kv_cache_block_copies = [
-                snapshot.copy for snapshot in self._active_snapshot_copies
-            ]
+            self._free_retained_copies(self._copy_refs_to_release)
+            self._copy_refs_to_release = []
         self.cached_blocks_this_step.clear()
 
-    def _cache_partial_snapshot(
+    def _cache_partial_tail_block(
         self,
         request: Request,
         num_tokens: int,
@@ -1661,39 +1670,13 @@ class MambaManager(SingleTypeKVCacheManager):
         if source_block.is_null:
             return None
 
-        snapshot_block = self.block_pool.get_new_blocks(1)[0]
-        partial_hash = self.block_pool.cache_partial_block(
+        return self.block_pool.cache_partial_block(
             request=request,
-            block=snapshot_block,
+            block=source_block,
             num_tokens=num_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
-        if partial_hash is None:
-            self.block_pool.free_blocks([snapshot_block])
-            return None
-
-        self._retain_block(source_block)
-        self._delayed_snapshot_copies.append(
-            _RetainedKVCacheBlockCopy(
-                source_block=source_block,
-                dst_block=snapshot_block,
-                copy=KVCacheBlockCopy(
-                    src_block_id=source_block.block_id,
-                    dst_block_id=snapshot_block.block_id,
-                ),
-            )
-        )
-        return partial_hash
-
-    def _free_snapshot_copies(
-        self,
-        snapshots: list[_RetainedKVCacheBlockCopy],
-    ) -> None:
-        if not snapshots:
-            return
-        self._free_retained_blocks([snapshot.source_block for snapshot in snapshots])
-        self.block_pool.free_blocks([snapshot.dst_block for snapshot in snapshots])
 
     def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
         copies = self._kv_cache_block_copies

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -19,6 +19,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlockListWithHitLength,
     get_cache_hit_length,
     has_partial_cache_hit,
+    resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
@@ -479,7 +480,7 @@ class SingleTypeKVCacheManager(ABC):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         """
         Get the longest cache hit prefix of the blocks that is not longer than
         `max_length`. The prefix should be a common prefix hit for all the
@@ -617,7 +618,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_pool: BlockPool,
         block_size: int,
         hash_block_size: int,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         assert block_size % hash_block_size == 0
         scale_factor = block_size // hash_block_size
         full_block_hashes = BlockHashListWithBlockSize(
@@ -628,7 +629,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             len(block_hashes),
         )
 
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
             KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
         max_num_full_blocks = max_length // block_size
@@ -679,14 +680,21 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         assert isinstance(
             kv_cache_spec, FullAttentionSpec | ChunkedLocalAttentionSpec
         ), (
             "FullAttentionManager can only be used for full attention "
             "and chunked local attention groups"
         )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
             KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
@@ -932,12 +940,19 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         assert isinstance(kv_cache_spec, SlidingWindowSpec), (
             "SlidingWindowManager can only be used for sliding window groups"
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
@@ -951,7 +966,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # which is good for low cache hit rate scenarios.
         max_num_blocks = max_length // kv_cache_spec.block_size
         computed_blocks = tuple(
-            [block_pool.null_block] * max_num_blocks
+            KVCacheBlockListWithHitLength([block_pool.null_block] * max_num_blocks)
             for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
@@ -1005,6 +1020,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             ):
                 for computed in computed_blocks:
                     computed.pop()
+        for computed in computed_blocks:
+            computed.hit_length = len(computed) * block_size
         return computed_blocks
 
     @classmethod
@@ -1126,7 +1143,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         """
         For chunked local attention, we need to find the longest cache hit
         prefix of the blocks that is not longer than `max_length`. The prefix
@@ -1175,6 +1192,13 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
             "KV cache groups with different block sizes are not compatible with "
             "chunked local attention now"
         )
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
         max_num_blocks = max_length // kv_cache_spec.block_size
         if max_length > 0:
             local_attention_start_idx = (
@@ -1191,8 +1215,10 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         local_attention_start_block_idx = (
             local_attention_start_idx // kv_cache_spec.block_size
         )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [block_pool.null_block] * local_attention_start_block_idx
+        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
+            KVCacheBlockListWithHitLength(
+                [block_pool.null_block] * local_attention_start_block_idx
+            )
             for _ in range(len(kv_cache_group_ids))
         )
         for i in range(local_attention_start_block_idx, max_num_blocks):
@@ -1204,6 +1230,8 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
                     computed.append(cached)
             else:
                 break
+        for computed in computed_blocks:
+            computed.hit_length = len(computed) * kv_cache_spec.block_size
         return computed_blocks
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
@@ -1293,13 +1321,20 @@ class MambaManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
         )
         assert dcp_world_size == 1, "DCP not support mamba now."
         assert pcp_world_size == 1, "PCP not support mamba now."
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            kv_cache_spec.block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        computed_blocks: tuple[KVCacheBlockListWithHitLength, ...] = tuple(
             KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
 
@@ -1753,7 +1788,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
-    ) -> tuple[list[KVCacheBlock], ...]:
+    ) -> tuple[KVCacheBlockListWithHitLength, ...]:
         assert isinstance(kv_cache_spec, CrossAttentionSpec), (
             "CrossAttentionManager can only be used for cross-attention groups"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1670,13 +1670,17 @@ class MambaManager(SingleTypeKVCacheManager):
         if source_block.is_null:
             return None
 
-        return self.block_pool.cache_partial_block(
+        partial_hash = self.block_pool.cache_partial_block(
             request=request,
             block=source_block,
             num_tokens=num_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
+        if partial_hash is not None:
+            self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
+            self.num_cached_block[request.request_id] = block_idx
+        return partial_hash
 
     def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
         copies = self._kv_cache_block_copies

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -9,7 +9,6 @@ from typing import ClassVar
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
-    BlockHash,
     BlockHashList,
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
@@ -812,82 +811,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     tracks_new_block_ids: ClassVar[bool] = True
 
     @classmethod
-    def _find_fine_grained_cache_hit(
-        cls,
-        block_hashes: list[BlockHash],
-        max_length: int,
-        kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
-        block_size: int,
-        hash_block_size: int,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
-        # Two-phase scan. Example with block_size 4, hash_block_size 2 and a
-        # cached 6-token prefix: raw hashes [h0(2) h1(4) h2(6)], full-block
-        # keys are the view [h1] (a block's key is the chained hash at its
-        # LAST hash boundary, so h1 covers tokens 0..3).
-        #   Phase 1 matches full blocks left-to-right via the block-size view
-        #     -> 1 full block, hit 4.
-        #   Phase 2 probes the hash boundaries INSIDE the next block, right
-        #     to left (h2 first) -> partial entry at 6 -> hit 6, and the tail
-        #     block is appended after the full blocks.
-        assert block_size % hash_block_size == 0
-        scale_factor = block_size // hash_block_size
-        full_block_hashes = BlockHashListWithBlockSize(
-            block_hashes, hash_block_size, block_size
-        )
-        max_num_hash_blocks = min(
-            max_length // hash_block_size,
-            len(block_hashes),
-        )
-
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [] for _ in range(len(kv_cache_group_ids))
-        )
-        # Phase 1: longest run of cached FULL blocks from the start. The
-        # chained-hash property makes this sound: a missing block implies
-        # every later block is missing too.
-        max_num_full_blocks = max_length // block_size
-        num_full_blocks = 0
-        for block_hash in itertools.islice(full_block_hashes, max_num_full_blocks):
-            cached_full_block = block_pool.get_cached_block(
-                block_hash, kv_cache_group_ids
-            )
-            if not cached_full_block:
-                break
-            for computed, cached in zip(computed_blocks, cached_full_block):
-                computed.append(cached)
-            num_full_blocks += 1
-
-        # Phase 2: try to extend the hit into the first non-full block by
-        # probing its interior hash boundaries from the highest one down
-        # (longest extension first). Only the final prompt tail is ever
-        # registered (see _cache_partial_tail_block), so typically at most
-        # one of these probes can succeed; `continue` (not `break`) because
-        # partial entries are point registrations, not a chain.
-        hit_length = num_full_blocks * block_size
-        first_partial_idx = num_full_blocks * scale_factor
-        max_partial_idx = min(
-            # scale_factor - 1: the block's LAST boundary is the full-block
-            # key itself, already known to miss from phase 1.
-            first_partial_idx + scale_factor - 1,
-            max_num_hash_blocks,
-        )
-        for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
-            num_tokens = (fine_idx + 1) * hash_block_size
-            cached_tail = block_pool.get_cached_block(
-                block_hashes[fine_idx], kv_cache_group_ids
-            )
-            if not cached_tail:
-                continue
-
-            for computed, cached in zip(computed_blocks, cached_tail):
-                computed.append(cached)
-            hit_length = num_tokens
-            break
-
-        return computed_blocks, hit_length
-
-    @classmethod
     def find_longest_cache_hit(
         cls,
         block_hashes: BlockHashList,
@@ -906,83 +829,91 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "FullAttentionManager can only be used for full attention "
             "and chunked local attention groups"
         )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size * pcp_world_size > 1:
+            # Each block spans block_size * world_size tokens; block hashes
+            # are computed at that scaled granularity.
+            block_size *= dcp_world_size * pcp_world_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
-            kv_cache_spec.block_size,
+            block_size,
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [] for _ in range(len(kv_cache_group_ids))
-        )
-        block_size = kv_cache_spec.block_size
-        if dcp_world_size * pcp_world_size > 1:
-            block_size *= dcp_world_size * pcp_world_size
         # Fine-grained mode: the coordinator passes alignment_tokens ==
         # hash_block_size (< block_size) when partial hits are enabled;
         # resolve_block_hashes then kept the raw hash-granularity list.
-        # Otherwise alignment_tokens >= block_size and we take the coarse
-        # path below on a block-size view.
-        if alignment_tokens < block_size and block_size % alignment_tokens == 0:
+        # Otherwise alignment_tokens is a multiple of block_size and lookups
+        # run on a block-size view.
+        fine_grained = (
+            alignment_tokens < block_size and block_size % alignment_tokens == 0
+        )
+        if fine_grained:
             assert isinstance(block_hashes, list)
-            computed_blocks, hit_length = cls._find_fine_grained_cache_hit(
-                block_hashes=block_hashes,
-                max_length=max_length,
-                kv_cache_group_ids=kv_cache_group_ids,
-                block_pool=block_pool,
-                block_size=block_size,
-                hash_block_size=alignment_tokens,
+            full_block_hashes: BlockHashList = BlockHashListWithBlockSize(
+                block_hashes, alignment_tokens, block_size
             )
-            if drop_eagle_block and hit_length > 0:
-                # Eagle only needs the tokens right before the generation
-                # point recomputed, so drop one hash unit rather than a whole
-                # cache block. The tail block's KV is append-only, so it still
-                # covers the reduced length; trim blocks past the new tail.
-                # Three shapes (block 4, hash 2):
-                #   hit 6 (partial tail) -> claim 4: cdiv(4,4)=1, tail entry
-                #     dropped, ends on a clean block boundary;
-                #   hit 8 (2 full)       -> claim 6: cdiv(6,4)=2, both blocks
-                #     kept, block 1 becomes the CoW source for the mid-block
-                #     claim;
-                #   hit 10 (tail at 10)  -> claim 8: cdiv(8,4)=2, tail
-                #     dropped, full blocks serve exactly.
-                hit_length -= alignment_tokens
-                num_blocks = cdiv(hit_length, block_size)
-                for computed in computed_blocks:
-                    del computed[num_blocks:]
-            # Fine-grained hits land on a hash-block boundary
-            # (== alignment_tokens) by construction; no extra trim needed here
-            # (unlike the coarse branch below, which handles
-            # alignment > block_size).
-            return computed_blocks, hit_length
+        else:
+            assert alignment_tokens % block_size == 0
+            full_block_hashes = block_hashes
 
-        max_num_blocks = max_length // block_size
-        hit_length = 0
-        for block_hash in itertools.islice(block_hashes, max_num_blocks):
-            # block_hashes is a chain of block hashes. If a block hash is not
-            # in the cached_block_hash_to_id, the following block hashes are
-            # not computed yet for sure.
-            if cached_block := block_pool.get_cached_block(
-                block_hash, kv_cache_group_ids
-            ):
-                for computed, cached in zip(computed_blocks, cached_block):
-                    computed.append(cached)
-                hit_length += block_size
-            else:
+        # Phase 1: longest run of cached FULL blocks from the start. The
+        # chained-hash property makes this sound: a missing block implies
+        # every later block is missing too.
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        num_full_blocks = 0
+        for block_hash in itertools.islice(full_block_hashes, max_length // block_size):
+            cached_block = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached_block:
                 break
-        if drop_eagle_block and computed_blocks[0]:
-            # Need to drop the last matched block if eagle is enabled.
-            for computed in computed_blocks:
-                computed.pop()
-            hit_length -= block_size
-        while (
-            block_size != alignment_tokens  # Faster for common case.
-            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
-        ):
-            for computed in computed_blocks:
-                computed.pop()
-            hit_length -= block_size
+            for computed, cached in zip(computed_blocks, cached_block):
+                computed.append(cached)
+            num_full_blocks += 1
+        hit_length = num_full_blocks * block_size
+
+        # Phase 2 (fine-grained only): extend the hit into the first non-full
+        # block by probing its interior hash boundaries from the highest one
+        # down (longest extension first). Only the final prompt tail is ever
+        # registered (see _cache_partial_tail_block), so typically at most
+        # one of these probes can succeed; `continue` (not `break`) because
+        # partial entries are point registrations, not a chain.
+        if fine_grained:
+            scale_factor = block_size // alignment_tokens
+            first_partial_idx = num_full_blocks * scale_factor
+            max_partial_idx = min(
+                # scale_factor - 1: the block's LAST boundary is the
+                # full-block key itself, already known to miss from phase 1.
+                first_partial_idx + scale_factor - 1,
+                max_length // alignment_tokens,
+                len(block_hashes),
+            )
+            for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+                cached_tail = block_pool.get_cached_block(
+                    block_hashes[fine_idx], kv_cache_group_ids
+                )
+                if not cached_tail:
+                    continue
+                for computed, cached in zip(computed_blocks, cached_tail):
+                    computed.append(cached)
+                hit_length = (fine_idx + 1) * alignment_tokens
+                break
+
+        # Eagle only needs the tokens right before the generation point
+        # recomputed: drop one hash unit when fine-grained (the tail block's
+        # KV is append-only, so it still covers the reduced length), else one
+        # cache block.
+        if drop_eagle_block and hit_length > 0:
+            hit_length -= min(alignment_tokens, block_size)
+        # Round down to the alignment; a no-op when fine-grained (hits land
+        # on hash boundaries by construction) and when alignment_tokens ==
+        # block_size. Then trim blocks past the new tail.
+        hit_length -= hit_length % alignment_tokens
+        num_blocks = cdiv(hit_length, block_size)
+        for computed in computed_blocks:
+            del computed[num_blocks:]
         return computed_blocks, hit_length
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -1017,31 +948,65 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         return blocks
 
     @classmethod
-    def _find_fine_grained_cache_hit(
+    def find_longest_cache_hit(
         cls,
-        block_hashes: list[BlockHash],
+        block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
-        sliding_window: int,
+        kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
-        block_size: int,
-        hash_block_size: int,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
-        """Longest hit at hash-block granularity.
+        """Longest hit as a right-to-left walk over aligned claim boundaries.
 
-        Candidate lookup boundaries walk right-to-left over hash boundaries
-        ``u``; a single lookup at ``u`` finds both full blocks (whose cache key
-        is the hash at their last hash boundary) and partial prompt tails. The
-        claimed hit is ``u`` minus the eagle drop, and the window ending at
-        the claim must be covered by cached full blocks (the entry's own block
-        covers itself: its KV is valid up to ``u`` >= claim).
+        Unlike full attention, an SWA hit at ``claim`` tokens is valid only
+        if the whole attention window ending there is present: the next token
+        (position ``claim``) attends to [claim - window + 1, claim - 1], and
+        those tokens' KV must all be in cached blocks. Claims walk multiples
+        of ``alignment_tokens`` right-to-left, so the first covered claim is
+        the longest hit. Fine-grained partial hits (``alignment_tokens <
+        block_size``) walk hash-block boundaries, where a single lookup finds
+        both full blocks and partial prompt tails; otherwise claims sit on
+        cache-block boundaries.
         """
-        assert block_size % hash_block_size == 0
-        drop_tokens = hash_block_size if drop_eagle_block else 0
-        full_view = BlockHashListWithBlockSize(
-            block_hashes, hash_block_size, block_size
+        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
+            "SlidingWindowManager can only be used for sliding window groups"
         )
+        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        block_size = kv_cache_spec.block_size
+        sliding_window = kv_cache_spec.sliding_window
+        block_hashes = resolve_block_hashes(
+            block_hashes,
+            block_pool.hash_block_size,
+            block_size,
+            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
+            alignment_tokens=alignment_tokens,
+        )
+        fine_grained = (
+            alignment_tokens < block_size and block_size % alignment_tokens == 0
+        )
+        # Granularity of the resolved hash list: raw hash blocks when
+        # fine-grained, else one hash per cache block.
+        if fine_grained:
+            assert isinstance(block_hashes, list)
+            lookup_unit = alignment_tokens
+            full_view: BlockHashList = BlockHashListWithBlockSize(
+                block_hashes, alignment_tokens, block_size
+            )
+        else:
+            assert alignment_tokens % block_size == 0
+            lookup_unit = block_size
+            full_view = block_hashes
+
+        # With eagle, the lookup boundary sits one unit past the claim: the
+        # entry at ``u = claim + drop_tokens`` proves KV coverage up to ``u``,
+        # and the dropped unit [claim, u) is recomputed for the drafting head.
+        drop_tokens = lookup_unit if drop_eagle_block else 0
+
         # Memoize full-block lookups: each block is checked at most once
         # across all candidates.
         full_block_cache: dict[int, list[KVCacheBlock] | None] = {}
@@ -1053,30 +1018,26 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                 )
             return full_block_cache[block_idx]
 
-        # Walk candidate lookup boundaries u = k * hash right-to-left so the
-        # first success is the LONGEST hit. A single get_cached_block at the
-        # raw hash h[k-1] finds either kind of entry, because a full block's
-        # key IS the raw hash at its last boundary and a partial tail's key
-        # is the raw hash at its registration boundary.
-        max_num_units = min(max_length // hash_block_size, len(block_hashes))
-        for k in range(max_num_units, 0, -1):
-            lookup_tokens = k * hash_block_size
-            # With eagle, the claim is one hash unit below the lookup: the
-            # entry at u proves KV coverage up to u, and the dropped unit
-            # [claim, u) gets recomputed for the drafting head.
-            claim = lookup_tokens - drop_tokens
-            if claim <= 0:
-                break
-            entry = block_pool.get_cached_block(block_hashes[k - 1], kv_cache_group_ids)
+        max_tokens = min(max_length, len(block_hashes) * lookup_unit)
+        claim = (max_tokens - drop_tokens) // alignment_tokens * alignment_tokens
+        while claim > 0:
+            lookup_tokens = claim + drop_tokens
+            # A single lookup at the boundary hash finds either entry kind: a
+            # full block's key IS the hash at its last boundary and a partial
+            # tail's key is the hash at its registration boundary.
+            if lookup_tokens % block_size == 0:
+                entry = _lookup_full_block(lookup_tokens // block_size - 1)
+            else:
+                entry = block_pool.get_cached_block(
+                    block_hashes[lookup_tokens // lookup_unit - 1],
+                    kv_cache_group_ids,
+                )
             if not entry:
+                claim -= alignment_tokens
                 continue
-            # Unlike full attention, an SWA hit at `claim` is only valid if
-            # the whole attention window ending there is present: the next
-            # token (position `claim`) attends to [claim - window + 1,
-            # claim - 1], and those tokens' KV must all be in cached blocks.
             # The entry's own block covers itself (its KV is valid up to
-            # u >= claim); every other block in that range needs its own
-            # full-block entry.
+            # ``lookup_tokens`` >= claim); every other block in the window
+            # needs its own full-block entry.
             entry_block_idx = (lookup_tokens - 1) // block_size
             last_block_idx = (claim - 1) // block_size
             first_block_idx = max(claim - sliding_window + 1, 0) // block_size
@@ -1084,16 +1045,25 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # (claim rounded down to the previous block); the entry then only
             # serves as evidence and is not part of the returned blocks.
             window_blocks: dict[int, list[KVCacheBlock]] = {}
-            covered = True
+            miss_idx = -1
             for j in range(last_block_idx, first_block_idx - 1, -1):
                 cached = entry if j == entry_block_idx else _lookup_full_block(j)
                 if not cached:
-                    covered = False
+                    miss_idx = j
                     break
                 window_blocks[j] = cached
-            if not covered:
-                # This candidate fails, but a shorter boundary may still have
-                # a fully covered (smaller) window — keep scanning.
+            if miss_idx >= 0:
+                # Every smaller claim whose window still contains the missing
+                # block fails too, unless its own entry lands inside that
+                # block (a partial tail can cover it). Jump straight to the
+                # largest claim that is not ruled out; this keeps the walk
+                # linear in the number of blocks.
+                claim = min(
+                    claim - alignment_tokens,
+                    ((miss_idx + 1) * block_size - drop_tokens)
+                    // alignment_tokens
+                    * alignment_tokens,
+                )
                 continue
             # Blocks before the window are unreachable for SWA: pad with
             # nulls so list positions still line up with block indices.
@@ -1107,116 +1077,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             )
             return computed_blocks, claim
         return tuple([] for _ in range(len(kv_cache_group_ids))), 0
-
-    @classmethod
-    def find_longest_cache_hit(
-        cls,
-        block_hashes: BlockHashList,
-        max_length: int,
-        kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
-        kv_cache_spec: KVCacheSpec,
-        drop_eagle_block: bool,
-        alignment_tokens: int,
-        dcp_world_size: int = 1,
-        pcp_world_size: int = 1,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
-        assert isinstance(kv_cache_spec, SlidingWindowSpec), (
-            "SlidingWindowManager can only be used for sliding window groups"
-        )
-        assert dcp_world_size == 1, "DCP not support sliding window attn now."
-        assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        block_hashes = resolve_block_hashes(
-            block_hashes,
-            block_pool.hash_block_size,
-            kv_cache_spec.block_size,
-            supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
-            alignment_tokens=alignment_tokens,
-        )
-        if (
-            alignment_tokens < kv_cache_spec.block_size
-            and kv_cache_spec.block_size % alignment_tokens == 0
-        ):
-            assert isinstance(block_hashes, list)
-            return cls._find_fine_grained_cache_hit(
-                block_hashes=block_hashes,
-                max_length=max_length,
-                kv_cache_group_ids=kv_cache_group_ids,
-                block_pool=block_pool,
-                sliding_window=kv_cache_spec.sliding_window,
-                drop_eagle_block=drop_eagle_block,
-                block_size=kv_cache_spec.block_size,
-                hash_block_size=alignment_tokens,
-            )
-
-        # The number of contiguous blocks needed for a prefix cache hit.
-        sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
-            kv_cache_spec.sliding_window, kv_cache_spec.block_size, drop_eagle_block
-        )
-
-        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
-        # optimize the time complexity from O(max_num_blocks) to
-        # O(max_num_blocks / sliding_window_contiguous_blocks +
-        # sliding_window_contiguous_blocks),
-        # which is good for low cache hit rate scenarios.
-        max_num_blocks = max_length // kv_cache_spec.block_size
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [block_pool.null_block] * max_num_blocks
-            for _ in range(len(kv_cache_group_ids))
-        )
-        block_size = kv_cache_spec.block_size
-        num_contiguous_blocks = 0
-        match_found = False
-        # Search from right to left and early stop when a match is found.
-        for i in range(max_num_blocks - 1, -1, -1):
-            if cached_block := block_pool.get_cached_block(
-                block_hashes[i], kv_cache_group_ids
-            ):
-                # Skip prefix matching check if the block is not aligned with
-                # `alignment_tokens`.
-                if num_contiguous_blocks == 0 and block_size != alignment_tokens:
-                    post_pop_blocks = i if drop_eagle_block else i + 1
-                    if (post_pop_blocks * block_size) % alignment_tokens != 0:
-                        continue
-                # Add the cached block to the computed blocks.
-                for computed, cached in zip(computed_blocks, cached_block):
-                    computed[i] = cached
-                num_contiguous_blocks += 1
-                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
-                    # Trim the trailing blocks.
-                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
-                    # when sliding_window_contiguous_blocks=2.
-                    for computed in computed_blocks:
-                        del computed[i + num_contiguous_blocks :]
-                    match_found = True
-                    break
-            else:
-                num_contiguous_blocks = 0
-        if not match_found:
-            # The first `num_contiguous_blocks` is a cache hit even if
-            # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
-            for computed in computed_blocks:
-                del computed[num_contiguous_blocks:]
-            while (
-                block_size != alignment_tokens  # Faster for common case.
-                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
-            ):
-                for computed in computed_blocks:
-                    computed.pop()
-        if drop_eagle_block and computed_blocks[0]:
-            for computed in computed_blocks:
-                computed.pop()
-            # Re-align after eagle pop: the pop may break the alignment
-            # when block_size != alignment_tokens (hybrid models with
-            # different page sizes, e.g. Gemma4).
-            while (
-                block_size != alignment_tokens
-                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
-            ):
-                for computed in computed_blocks:
-                    computed.pop()
-        hit_length = len(computed_blocks[0]) * block_size
-        return computed_blocks, hit_length
 
     @classmethod
     def reachable_block_mask(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -604,7 +604,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             max_admission_blocks_per_request=max_admission_blocks_per_request,
         )
         self.num_cached_hash_block: dict[str, int] = {}
-        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock, int, bool]] = {}
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock, bool]] = {}
         self._pending_cow_source_blocks: list[KVCacheBlock] = []
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
 
@@ -797,7 +797,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             self._partial_hit_reqs[request_id] = (
                 block_idx,
                 source_block,
-                hit_length % self.block_size,
                 release_req_ref,
             )
             self.num_cached_block[request_id] = block_idx
@@ -807,8 +806,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     ) -> list[KVCacheBlock]:
         new_blocks: list[KVCacheBlock] = []
         if request_id in self._partial_hit_reqs:
-            block_idx, source_block, copy_tokens, release_source_ref = (
-                self._partial_hit_reqs.pop(request_id)
+            block_idx, source_block, release_source_ref = self._partial_hit_reqs.pop(
+                request_id
             )
             cow_block = self.block_pool.get_new_blocks(1)[0]
             req_blocks = self.req_to_blocks[request_id]
@@ -820,10 +819,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             self.new_block_ids.append(cow_block.block_id)
             self._kv_cache_block_copies.append(
                 KVCacheBlockCopy(
-                    kv_cache_group_id=self.kv_cache_group_id,
                     src_block_id=source_block.block_id,
                     dst_block_id=cow_block.block_id,
-                    num_tokens=copy_tokens,
                 )
             )
             if not release_source_ref:
@@ -1556,10 +1553,8 @@ class MambaManager(SingleTypeKVCacheManager):
                     req_blocks[block_idx] = cow_block
                     self._kv_cache_block_copies.append(
                         KVCacheBlockCopy(
-                            kv_cache_group_id=self.kv_cache_group_id,
                             src_block_id=source_block.block_id,
                             dst_block_id=cow_block.block_id,
-                            num_tokens=self.block_size,
                         )
                     )
                     self._pending_cow_source_blocks.append(source_block)
@@ -1665,10 +1660,8 @@ class MambaManager(SingleTypeKVCacheManager):
                 source_block=source_block,
                 dst_block=snapshot_block,
                 copy=KVCacheBlockCopy(
-                    kv_cache_group_id=self.kv_cache_group_id,
                     src_block_id=source_block.block_id,
                     dst_block_id=snapshot_block.block_id,
-                    num_tokens=self.block_size,
                 ),
             )
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,13 +4,20 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import ClassVar
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
     BlockHashList,
+    BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    KVCacheBlockCopy,
+    KVCacheBlockListWithHitLength,
+    get_cache_hit_length,
+    has_partial_cache_hit,
 )
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
@@ -34,6 +41,8 @@ class SingleTypeKVCacheManager(ABC):
     An abstract base class for a manager that handle the kv cache management
     logic of one specific type of attention layer.
     """
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -315,6 +324,10 @@ class SingleTypeKVCacheManager(ABC):
         self.new_block_ids = []
         return ids
 
+    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
+        """Drain and return pending KV cache block copies."""
+        return []
+
     def cache_blocks(
         self,
         request: Request,
@@ -538,6 +551,91 @@ class SingleTypeKVCacheManager(ABC):
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        kv_cache_spec: KVCacheSpec,
+        block_pool: BlockPool,
+        enable_caching: bool,
+        kv_cache_group_id: int,
+        scheduler_block_size: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+        max_admission_blocks_per_request: int | None = None,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec=kv_cache_spec,
+            block_pool=block_pool,
+            enable_caching=enable_caching,
+            kv_cache_group_id=kv_cache_group_id,
+            scheduler_block_size=scheduler_block_size,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
+            max_admission_blocks_per_request=max_admission_blocks_per_request,
+        )
+        self.num_cached_hash_block: dict[str, int] = {}
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock, int, bool]] = {}
+        self._pending_cow_source_blocks: list[KVCacheBlock] = []
+        self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
+
+    @classmethod
+    def _find_fine_grained_cache_hit(
+        cls,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        block_size: int,
+        hash_block_size: int,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        assert block_size % hash_block_size == 0
+        scale_factor = block_size // hash_block_size
+        full_block_hashes = BlockHashListWithBlockSize(
+            block_hashes, hash_block_size, block_size
+        )
+        max_num_partial_units = min(
+            max_length // hash_block_size,
+            len(block_hashes),
+        )
+
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
+        )
+        for fine_idx in range(max_num_partial_units - 1, -1, -1):
+            num_tokens = (fine_idx + 1) * hash_block_size
+            block_hash = block_hashes[fine_idx]
+            last_block_idx = fine_idx // scale_factor
+
+            cached_tail = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+            if not cached_tail:
+                continue
+
+            prefix_blocks: list[list[KVCacheBlock]] = [[] for _ in kv_cache_group_ids]
+            prefix_ok = True
+            for block_idx in range(last_block_idx):
+                cached_prefix = block_pool.get_cached_block(
+                    full_block_hashes[block_idx], kv_cache_group_ids
+                )
+                if not cached_prefix:
+                    prefix_ok = False
+                    break
+                for blocks, cached in zip(prefix_blocks, cached_prefix):
+                    blocks.append(cached)
+            if not prefix_ok:
+                continue
+
+            for computed, prefix, cached in zip(
+                computed_blocks, prefix_blocks, cached_tail
+            ):
+                computed.extend(prefix)
+                computed.append(cached)
+                assert isinstance(computed, KVCacheBlockListWithHitLength)
+                computed.hit_length = num_tokens
+            break
+
+        return computed_blocks
+
     @classmethod
     def find_longest_cache_hit(
         cls,
@@ -558,12 +656,40 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "and chunked local attention groups"
         )
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [] for _ in range(len(kv_cache_group_ids))
+            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
+        if alignment_tokens < block_size and block_size % alignment_tokens == 0:
+            assert isinstance(block_hashes, list)
+            computed_blocks = cls._find_fine_grained_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_length,
+                kv_cache_group_ids=kv_cache_group_ids,
+                block_pool=block_pool,
+                block_size=block_size,
+                hash_block_size=alignment_tokens,
+            )
+            if drop_eagle_block and computed_blocks[0]:
+                for computed in computed_blocks:
+                    computed.pop()
+                    assert isinstance(computed, KVCacheBlockListWithHitLength)
+                    computed.hit_length = len(computed) * block_size
+            while (
+                block_size != alignment_tokens
+                and get_cache_hit_length(computed_blocks[0], block_size)
+                % alignment_tokens
+                != 0
+            ):
+                for computed in computed_blocks:
+                    computed.pop()
+                    assert isinstance(computed, KVCacheBlockListWithHitLength)
+                    computed.hit_length = len(computed) * block_size
+            return computed_blocks
+
         max_num_blocks = max_length // block_size
+        hit_length = 0
         for block_hash in itertools.islice(block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
@@ -573,19 +699,193 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             ):
                 for computed, cached in zip(computed_blocks, cached_block):
                     computed.append(cached)
+                hit_length += block_size
             else:
                 break
         if drop_eagle_block and computed_blocks[0]:
             # Need to drop the last matched block if eagle is enabled.
             for computed in computed_blocks:
                 computed.pop()
+            hit_length -= block_size
         while (
             block_size != alignment_tokens  # Faster for common case.
             and len(computed_blocks[0]) * block_size % alignment_tokens != 0
         ):
             for computed in computed_blocks:
                 computed.pop()
+            hit_length -= block_size
+        for computed in computed_blocks:
+            assert isinstance(computed, KVCacheBlockListWithHitLength)
+            computed.hit_length = hit_length
         return computed_blocks
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        num_blocks = super().get_num_blocks_to_allocate(
+            request_id,
+            num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_tokens_main_model,
+            apply_admission_cap=apply_admission_cap,
+        )
+        if request_id not in self.num_cached_block and has_partial_cache_hit(
+            new_computed_blocks, self.block_size
+        ):
+            num_blocks += 1
+        return num_blocks
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        super().add_local_computed_blocks(
+            request_id,
+            new_computed_blocks,
+            num_local_computed_tokens,
+            num_external_computed_tokens,
+        )
+        hit_length = get_cache_hit_length(new_computed_blocks, self.block_size)
+        if hit_length > 0 and hit_length % self.block_size != 0:
+            block_idx = hit_length // self.block_size
+            source_block = new_computed_blocks[-1]
+            req_blocks = self.req_to_blocks[request_id]
+            release_req_ref = (
+                block_idx < len(req_blocks) and req_blocks[block_idx] is source_block
+            )
+            self._partial_hit_reqs[request_id] = (
+                block_idx,
+                source_block,
+                hit_length % self.block_size,
+                release_req_ref,
+            )
+            self.num_cached_block[request_id] = block_idx
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        new_blocks: list[KVCacheBlock] = []
+        if request_id in self._partial_hit_reqs:
+            block_idx, source_block, copy_tokens, release_source_ref = (
+                self._partial_hit_reqs.pop(request_id)
+            )
+            cow_block = self.block_pool.get_new_blocks(1)[0]
+            req_blocks = self.req_to_blocks[request_id]
+            if block_idx < len(req_blocks):
+                req_blocks[block_idx] = cow_block
+            else:
+                assert block_idx == len(req_blocks)
+                req_blocks.append(cow_block)
+            self.new_block_ids.append(cow_block.block_id)
+            self._kv_cache_block_copies.append(
+                KVCacheBlockCopy(
+                    kv_cache_group_id=self.kv_cache_group_id,
+                    src_block_id=source_block.block_id,
+                    dst_block_id=cow_block.block_id,
+                    num_tokens=copy_tokens,
+                )
+            )
+            if not release_source_ref:
+                self._retain_cow_source_block(source_block)
+            self._pending_cow_source_blocks.append(source_block)
+            new_blocks.append(cow_block)
+
+        new_blocks.extend(
+            super().allocate_new_blocks(request_id, num_tokens, num_tokens_main_model)
+        )
+        return new_blocks
+
+    def _retain_cow_source_block(self, block: KVCacheBlock) -> None:
+        if (
+            block.ref_cnt == 0
+            and not block.is_null
+            and block.prev_free_block is not None
+            and block.next_free_block is not None
+        ):
+            self.block_pool.free_block_queue.remove(block)
+        block.ref_cnt += 1
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return
+        self._cache_final_prompt_hash_tail_only(request, num_tokens)
+
+    def _cache_final_prompt_hash_tail_only(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> None:
+        hash_block_size = self.block_pool.hash_block_size
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return
+        if boundary_tokens % self.block_size == 0:
+            return
+
+        hash_idx = boundary_tokens // hash_block_size - 1
+        num_cached_hash_blocks = self.num_cached_hash_block.get(request.request_id, 0)
+        if num_cached_hash_blocks > hash_idx:
+            return
+
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return
+        partial_hash = self.block_pool.cache_partial_block(
+            request=request,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+        if partial_hash is not None:
+            self.num_cached_hash_block[request.request_id] = hash_idx + 1
+
+    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
+        copies = self._kv_cache_block_copies
+        self._kv_cache_block_copies = []
+        return copies
+
+    def free(self, request_id: str) -> None:
+        self.num_cached_hash_block.pop(request_id, None)
+        self._partial_hit_reqs.pop(request_id, None)
+        super().free(request_id)
+
+    def new_step_starts(self) -> None:
+        if self._pending_cow_source_blocks:
+            self._free_pending_cow_source_blocks()
+            self._pending_cow_source_blocks = []
+
+    def _free_pending_cow_source_blocks(self) -> None:
+        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
+        for block in self._pending_cow_source_blocks:
+            _, count = block_ref_counts.get(block.block_id, (block, 0))
+            block_ref_counts[block.block_id] = (block, count + 1)
+
+        freed_blocks: list[KVCacheBlock] = []
+        for block, count in block_ref_counts.values():
+            assert block.ref_cnt >= count
+            block.ref_cnt -= count
+            if block.ref_cnt == 0 and not block.is_null:
+                freed_blocks.append(block)
+        self.block_pool.free_block_queue.append_n(freed_blocks)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -956,6 +1256,8 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 
 class MambaManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
     def __init__(
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
     ) -> None:
@@ -969,6 +1271,14 @@ class MambaManager(SingleTypeKVCacheManager):
             self.last_state_block_idx: dict[str, int] = {}
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
+            self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+            self._pending_cow_source_blocks: list[KVCacheBlock] = []
+            self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
+            self._active_snapshot_blocks: list[KVCacheBlock] = []
+            self._delayed_snapshot_blocks: list[KVCacheBlock] = []
+            self._active_snapshot_source_blocks: list[KVCacheBlock] = []
+            self._delayed_snapshot_source_blocks: list[KVCacheBlock] = []
+            self._delayed_kv_cache_block_copies: list[KVCacheBlockCopy] = []
 
     @classmethod
     def find_longest_cache_hit(
@@ -989,10 +1299,33 @@ class MambaManager(SingleTypeKVCacheManager):
         assert dcp_world_size == 1, "DCP not support mamba now."
         assert pcp_world_size == 1, "PCP not support mamba now."
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [] for _ in range(len(kv_cache_group_ids))
+            KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
 
         block_size = kv_cache_spec.block_size
+        if alignment_tokens < block_size and block_size % alignment_tokens == 0:
+            assert isinstance(block_hashes, list)
+            hash_block_size = alignment_tokens
+            scale_factor = block_size // hash_block_size
+            max_num_partial_units = min(
+                max_length // hash_block_size,
+                len(block_hashes),
+            )
+            for fine_idx in range(max_num_partial_units - 1, -1, -1):
+                num_tokens = (fine_idx + 1) * hash_block_size
+                block_hash = block_hashes[fine_idx]
+                if cached_block := block_pool.get_cached_block(
+                    block_hash, kv_cache_group_ids
+                ):
+                    block_idx = fine_idx // scale_factor
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed.extend([block_pool.null_block] * block_idx)
+                        computed.append(cached)
+                        assert isinstance(computed, KVCacheBlockListWithHitLength)
+                        computed.hit_length = num_tokens
+                    break
+            return computed_blocks
+
         max_num_blocks = max_length // block_size
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
@@ -1014,6 +1347,8 @@ class MambaManager(SingleTypeKVCacheManager):
                     # so we insert dummy blocks at the beginning:
                     computed.extend([block_pool.null_block] * i)
                     computed.append(cached)
+                    assert isinstance(computed, KVCacheBlockListWithHitLength)
+                    computed.hit_length = (i + 1) * block_size
                 break  # we just need the last match - early stopping
 
         return computed_blocks
@@ -1106,15 +1441,24 @@ class MambaManager(SingleTypeKVCacheManager):
                 - len(new_computed_blocks)
                 - len(self.req_to_blocks[request_id])
             )
+            has_partial_hit = (
+                has_partial_cache_hit(new_computed_blocks, self.block_size)
+                or request_id in self._partial_hit_reqs
+            )
+            if has_partial_hit:
+                num_new_blocks = max(num_new_blocks, 0) + 1
             if num_new_blocks > 0:
                 if request_id in self._allocated_block_reqs:
                     # Old request. Needs at most 1 more blocks as we can reuse the
                     # speculative blocks in previous step.
-                    num_new_blocks = 1
+                    num_new_blocks = 1 + int(has_partial_hit)
                 else:
-                    # First prefill. Allocate 1 block for running state and the
-                    # speculative blocks.
-                    num_new_blocks = 1 + self.num_speculative_blocks
+                    # First prefill. Allocate 1 block for running state, the
+                    # speculative blocks, and one extra block if a partial cache
+                    # hit must be copy-on-written before the new tokens run.
+                    num_new_blocks = (
+                        1 + self.num_speculative_blocks + int(has_partial_hit)
+                    )
 
             num_evictable_computed_blocks = self._get_num_evictable_blocks(
                 new_computed_blocks
@@ -1146,9 +1490,11 @@ class MambaManager(SingleTypeKVCacheManager):
             num_required_blocks = (
                 cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
             )
+            partial_hit = self._partial_hit_reqs.get(request_id)
+            has_partial_hit = partial_hit is not None
             # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
             # over-allocated at last round.
-            if num_required_blocks <= len(req_blocks):
+            if num_required_blocks <= len(req_blocks) and not has_partial_hit:
                 return []
             else:
                 prev_block_len = len(req_blocks)
@@ -1188,19 +1534,44 @@ class MambaManager(SingleTypeKVCacheManager):
                         else:
                             break
                 num_new_blocks = num_required_blocks - len(req_blocks)
+                if has_partial_hit:
+                    num_new_blocks = max(num_new_blocks, 0) + 1
                 if blocks_allocated:
-                    assert num_new_blocks <= 1
+                    assert num_new_blocks <= 1 + int(has_partial_hit)
                 else:
-                    assert num_new_blocks <= self.num_speculative_blocks + 1
+                    assert num_new_blocks <= self.num_speculative_blocks + 1 + int(
+                        has_partial_hit
+                    )
                 new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                returned_blocks = req_blocks[prev_block_len:]
+                if partial_hit is not None:
+                    block_idx, source_block = partial_hit
+                    cow_block = new_blocks[0]
+                    assert block_idx < len(req_blocks)
+                    assert req_blocks[block_idx] is source_block
+                    req_blocks[block_idx] = cow_block
+                    self._kv_cache_block_copies.append(
+                        KVCacheBlockCopy(
+                            kv_cache_group_id=self.kv_cache_group_id,
+                            src_block_id=source_block.block_id,
+                            dst_block_id=cow_block.block_id,
+                            num_tokens=self.block_size,
+                        )
+                    )
+                    self._pending_cow_source_blocks.append(source_block)
+                    returned_blocks = [cow_block] + returned_blocks
+                    new_blocks = new_blocks[1:]
                 req_blocks.extend(new_blocks)
                 self._allocated_block_reqs.add(request_id)
-                return req_blocks[prev_block_len:]
+                self._partial_hit_reqs.pop(request_id, None)
+                returned_blocks.extend(new_blocks)
+                return returned_blocks
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
+            self._partial_hit_reqs.pop(request_id, None)
         return super().pop_blocks_for_free(request_id)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
@@ -1220,6 +1591,10 @@ class MambaManager(SingleTypeKVCacheManager):
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
         super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if self.mamba_cache_mode == "align":
+            partial_hash = self._cache_partial_snapshot(request, num_tokens)
+            if partial_hash is not None:
+                self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
             for block in self.req_to_blocks[request.request_id][
                 num_cached_blocks_before:num_cached_blocks_after
@@ -1230,7 +1605,121 @@ class MambaManager(SingleTypeKVCacheManager):
                 self.cached_blocks_this_step.add(block.block_hash)
 
     def new_step_starts(self) -> None:
+        if self.mamba_cache_mode == "align":
+            if self._pending_cow_source_blocks:
+                self._free_retained_blocks(self._pending_cow_source_blocks)
+                self._pending_cow_source_blocks = []
+            if self._active_snapshot_source_blocks:
+                self._free_retained_blocks(self._active_snapshot_source_blocks)
+                self._active_snapshot_source_blocks = []
+            if self._active_snapshot_blocks:
+                self.block_pool.free_blocks(self._active_snapshot_blocks)
+                self._active_snapshot_blocks = []
+            self._active_snapshot_blocks = self._delayed_snapshot_blocks
+            self._delayed_snapshot_blocks = []
+            self._active_snapshot_source_blocks = self._delayed_snapshot_source_blocks
+            self._delayed_snapshot_source_blocks = []
+            self._kv_cache_block_copies = self._delayed_kv_cache_block_copies
+            self._delayed_kv_cache_block_copies = []
         self.cached_blocks_this_step.clear()
+
+    def _cache_partial_snapshot(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> BlockHashWithGroupId | None:
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return None
+        if num_tokens % self.block_size == 0:
+            return None
+        if num_tokens % hash_block_size != 0:
+            return None
+        latest_prompt_hash_boundary = (
+            request.num_prompt_tokens // hash_block_size
+        ) * hash_block_size
+        if num_tokens != latest_prompt_hash_boundary:
+            return None
+
+        block_idx = num_tokens // self.block_size
+        blocks = self.req_to_blocks[request.request_id]
+        if block_idx >= len(blocks):
+            return None
+        source_block = blocks[block_idx]
+        if source_block.is_null:
+            return None
+
+        snapshot_block = self.block_pool.get_new_blocks(1)[0]
+        partial_hash = self.block_pool.cache_partial_block(
+            request=request,
+            block=snapshot_block,
+            num_tokens=num_tokens,
+            kv_cache_group_id=self.kv_cache_group_id,
+            block_size=self.block_size,
+        )
+        if partial_hash is None:
+            self.block_pool.free_blocks([snapshot_block])
+            return None
+
+        self._delayed_snapshot_blocks.append(snapshot_block)
+        self._retain_block(source_block)
+        self._delayed_snapshot_source_blocks.append(source_block)
+        self._delayed_kv_cache_block_copies.append(
+            KVCacheBlockCopy(
+                kv_cache_group_id=self.kv_cache_group_id,
+                src_block_id=source_block.block_id,
+                dst_block_id=snapshot_block.block_id,
+                num_tokens=self.block_size,
+            )
+        )
+        return partial_hash
+
+    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
+        copies = self._kv_cache_block_copies
+        self._kv_cache_block_copies = []
+        return copies
+
+    def _free_retained_blocks(self, blocks: list[KVCacheBlock]) -> None:
+        block_ref_counts: dict[int, tuple[KVCacheBlock, int]] = {}
+        for block in blocks:
+            _, count = block_ref_counts.get(block.block_id, (block, 0))
+            block_ref_counts[block.block_id] = (block, count + 1)
+
+        freed_blocks: list[KVCacheBlock] = []
+        for block, count in block_ref_counts.values():
+            assert block.ref_cnt >= count
+            block.ref_cnt -= count
+            if block.ref_cnt == 0 and not block.is_null:
+                freed_blocks.append(block)
+        self.block_pool.free_block_queue.append_n(freed_blocks)
+
+    def _retain_block(self, block: KVCacheBlock) -> None:
+        if block.is_null:
+            return
+        if block.ref_cnt == 0:
+            self.block_pool.free_block_queue.remove(block)
+        block.ref_cnt += 1
+
+    def add_local_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        super().add_local_computed_blocks(
+            request_id,
+            new_computed_blocks,
+            num_local_computed_tokens,
+            num_external_computed_tokens,
+        )
+        if self.mamba_cache_mode == "align" and has_partial_cache_hit(
+            new_computed_blocks, self.block_size
+        ):
+            hit_length = get_cache_hit_length(new_computed_blocks, self.block_size)
+            block_idx = hit_length // self.block_size
+            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
+            self.num_cached_block[request_id] = block_idx
 
 
 class CrossAttentionManager(SingleTypeKVCacheManager):
@@ -1303,16 +1792,18 @@ class SinkFullAttentionManager(FullAttentionManager):
         block_pool: BlockPool,
         enable_caching: bool,
         kv_cache_group_id: int,
+        scheduler_block_size: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
     ):
         super().__init__(
-            kv_cache_spec,
-            block_pool,
-            enable_caching,
-            kv_cache_group_id,
-            dcp_world_size,
-            pcp_world_size,
+            kv_cache_spec=kv_cache_spec,
+            block_pool=block_pool,
+            enable_caching=enable_caching,
+            kv_cache_group_id=kv_cache_group_id,
+            scheduler_block_size=scheduler_block_size,
+            dcp_world_size=dcp_world_size,
+            pcp_world_size=pcp_world_size,
         )
         sink_len = kv_cache_spec.sink_len
         assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -105,11 +105,18 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
-        # managers (full attention, mamba "align"); harmlessly empty elsewhere.
+        # Partial-hit copy-on-write bookkeeping.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
-        self._cow_sources_to_release: list[KVCacheBlock] = []
+        # Blocks participating in a pending copy (both source and target).
+        # Each holds one retention released at `new_step_starts`, after the
+        # worker copy has run, so that a request freed within the same step
+        # cannot leak either end of the copy to another request.
+        self._cow_blocks_to_release: list[KVCacheBlock] = []
+        # Blocks whose partial tail entry was newly registered this step;
+        # their content is only written during this step's execution, so
+        # same-step consumers must be deferred.
+        self._partial_blocks_cached_this_step: set[int] = set()
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -364,15 +371,18 @@ class SingleTypeKVCacheManager(ABC):
         ``source_block`` to a private ``cow_block``.
 
         The request already holds a ref on ``source_block`` (from the
-        prefix-cache touch, or from allocation for the mamba producer). We keep
-        that ref and release it next step (``new_step_starts``), after the
-        worker copy has run, rather than freeing it now -- this keeps the block
-        alive and out of the free queue across the step without a retain/free
-        round-trip.
+        prefix-cache touch). We keep that ref and release it next step
+        (``new_step_starts``), after the worker copy has run, rather than
+        freeing it now -- this keeps the block alive and out of the free queue
+        across the step without a retain/free round-trip. ``cow_block`` gets
+        an extra retention for the same window: if the request is freed within
+        this step, the pending copy must not target a block that another
+        request could be given in the meantime.
         """
         req_blocks = self.req_to_blocks[request_id]
         assert block_idx < len(req_blocks)
         assert req_blocks[block_idx] is source_block
+        assert not source_block.is_null and source_block.ref_cnt > 0
         req_blocks[block_idx] = cow_block
         self._kv_cache_block_copies.append(
             KVCacheBlockCopy(
@@ -380,7 +390,8 @@ class SingleTypeKVCacheManager(ABC):
                 dst_block_id=cow_block.block_id,
             )
         )
-        self._cow_sources_to_release.append(source_block)
+        cow_block.ref_cnt += 1
+        self._cow_blocks_to_release.extend((source_block, cow_block))
 
     def cache_blocks(
         self,
@@ -599,11 +610,12 @@ class SingleTypeKVCacheManager(ABC):
         return 0
 
     def new_step_starts(self) -> None:
-        # Release the previous step's COW source blocks; their copies have now
+        # Release the previous step's COW blocks; their copies have now
         # run on the worker. Empty (no-op) for managers without partial hits.
-        if self._cow_sources_to_release:
-            self._free_retained_blocks(self._cow_sources_to_release)
-            self._cow_sources_to_release = []
+        if self._cow_blocks_to_release:
+            self._free_retained_blocks(self._cow_blocks_to_release)
+            self._cow_blocks_to_release = []
+        self._partial_blocks_cached_this_step.clear()
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
@@ -768,6 +780,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         if request_id not in self.num_cached_block and self._has_partial_local_hit(
             new_computed_blocks, num_local_computed_tokens
         ):
+            if (
+                new_computed_blocks[-1].block_id
+                in self._partial_blocks_cached_this_step
+            ):
+                # The partial tail's KV is only written during this step's
+                # execution, while the consumer's CoW copy runs at step start.
+                # Defer to the next step (mirrors the mamba guard in
+                # MambaManager.get_num_blocks_to_allocate).
+                return self.block_pool.num_gpu_blocks + 1
             num_blocks += 1
         return num_blocks
 
@@ -839,13 +860,17 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        self.block_pool.cache_partial_block(
+        partial_hash = self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
+        if partial_hash is not None:
+            # Newly registered: its KV is written during this step's
+            # execution, so same-step consumers must be deferred.
+            self._partial_blocks_cached_this_step.add(blocks[block_idx].block_id)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1525,9 +1550,38 @@ class MambaManager(SingleTypeKVCacheManager):
                 if partial_hit is not None:
                     block_idx, source_block = partial_hit
                     cow_block = new_blocks[0]
-                    self._apply_cow(request_id, block_idx, source_block, cow_block)
-                    returned_blocks = [cow_block] + returned_blocks
                     new_blocks = new_blocks[1:]
+                    if blocks_allocated:
+                        # Producer (the request that registered its own prompt
+                        # tail): the worker block-table update protocol for
+                        # running requests is append-only, so we cannot
+                        # redirect req_blocks[block_idx] here. Keep the
+                        # request on its own block and hand the prefix-cache
+                        # entry a private copy of the state instead.
+                        assert req_blocks[block_idx] is source_block
+                        assert not source_block.is_null
+                        self.block_pool.move_block_hashes(source_block, cow_block)
+                        self._kv_cache_block_copies.append(
+                            KVCacheBlockCopy(
+                                src_block_id=source_block.block_id,
+                                dst_block_id=cow_block.block_id,
+                            )
+                        )
+                        # Retain both ends of the copy until it has run on the
+                        # worker; `cow_block` keeps the ref from allocation as
+                        # it is not handed to the request.
+                        source_block.ref_cnt += 1
+                        self._cow_blocks_to_release.extend((source_block, cow_block))
+                        if cow_block.block_hash is not None:
+                            # The copied state only exists once this step
+                            # starts executing; defer same-step consumers.
+                            self.cached_blocks_this_step.add(cow_block.block_hash)
+                    else:
+                        # Consumer (new request hitting someone else's partial
+                        # entry): redirect its table to a private copy before
+                        # the first table is sent to the worker.
+                        self._apply_cow(request_id, block_idx, source_block, cow_block)
+                        returned_blocks = [cow_block] + returned_blocks
                 req_blocks.extend(new_blocks)
                 self._allocated_block_reqs.add(request_id)
                 self._partial_hit_reqs.pop(request_id, None)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,6 +4,7 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import ClassVar
 
 from vllm.utils.math_utils import cdiv
@@ -34,6 +35,13 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
+
+
+@dataclass
+class _RetainedKVCacheBlockCopy:
+    source_block: KVCacheBlock
+    dst_block: KVCacheBlock
+    copy: KVCacheBlockCopy
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -594,7 +602,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         full_block_hashes = BlockHashListWithBlockSize(
             block_hashes, hash_block_size, block_size
         )
-        max_num_partial_units = min(
+        max_num_hash_blocks = min(
             max_length // hash_block_size,
             len(block_hashes),
         )
@@ -602,38 +610,40 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
             KVCacheBlockListWithHitLength() for _ in range(len(kv_cache_group_ids))
         )
-        for fine_idx in range(max_num_partial_units - 1, -1, -1):
-            num_tokens = (fine_idx + 1) * hash_block_size
-            block_hash = block_hashes[fine_idx]
-            last_block_idx = fine_idx // scale_factor
+        max_num_full_blocks = max_length // block_size
+        num_full_blocks = 0
+        for block_hash in itertools.islice(full_block_hashes, max_num_full_blocks):
+            cached_full_block = block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            )
+            if not cached_full_block:
+                break
+            for computed, cached in zip(computed_blocks, cached_full_block):
+                computed.append(cached)
+            num_full_blocks += 1
 
-            cached_tail = block_pool.get_cached_block(block_hash, kv_cache_group_ids)
+        hit_length = num_full_blocks * block_size
+        first_partial_idx = num_full_blocks * scale_factor
+        max_partial_idx = min(
+            first_partial_idx + scale_factor - 1,
+            max_num_hash_blocks,
+        )
+        for fine_idx in range(max_partial_idx - 1, first_partial_idx - 1, -1):
+            num_tokens = (fine_idx + 1) * hash_block_size
+            cached_tail = block_pool.get_cached_block(
+                block_hashes[fine_idx], kv_cache_group_ids
+            )
             if not cached_tail:
                 continue
 
-            prefix_blocks: list[list[KVCacheBlock]] = [[] for _ in kv_cache_group_ids]
-            prefix_ok = True
-            for block_idx in range(last_block_idx):
-                cached_prefix = block_pool.get_cached_block(
-                    full_block_hashes[block_idx], kv_cache_group_ids
-                )
-                if not cached_prefix:
-                    prefix_ok = False
-                    break
-                for blocks, cached in zip(prefix_blocks, cached_prefix):
-                    blocks.append(cached)
-            if not prefix_ok:
-                continue
-
-            for computed, prefix, cached in zip(
-                computed_blocks, prefix_blocks, cached_tail
-            ):
-                computed.extend(prefix)
+            for computed, cached in zip(computed_blocks, cached_tail):
                 computed.append(cached)
-                assert isinstance(computed, KVCacheBlockListWithHitLength)
-                computed.hit_length = num_tokens
+            hit_length = num_tokens
             break
 
+        for computed in computed_blocks:
+            assert isinstance(computed, KVCacheBlockListWithHitLength)
+            computed.hit_length = hit_length
         return computed_blocks
 
     @classmethod
@@ -1274,11 +1284,8 @@ class MambaManager(SingleTypeKVCacheManager):
             self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
             self._pending_cow_source_blocks: list[KVCacheBlock] = []
             self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
-            self._active_snapshot_blocks: list[KVCacheBlock] = []
-            self._delayed_snapshot_blocks: list[KVCacheBlock] = []
-            self._active_snapshot_source_blocks: list[KVCacheBlock] = []
-            self._delayed_snapshot_source_blocks: list[KVCacheBlock] = []
-            self._delayed_kv_cache_block_copies: list[KVCacheBlockCopy] = []
+            self._active_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
+            self._delayed_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
 
     @classmethod
     def find_longest_cache_hit(
@@ -1609,18 +1616,12 @@ class MambaManager(SingleTypeKVCacheManager):
             if self._pending_cow_source_blocks:
                 self._free_retained_blocks(self._pending_cow_source_blocks)
                 self._pending_cow_source_blocks = []
-            if self._active_snapshot_source_blocks:
-                self._free_retained_blocks(self._active_snapshot_source_blocks)
-                self._active_snapshot_source_blocks = []
-            if self._active_snapshot_blocks:
-                self.block_pool.free_blocks(self._active_snapshot_blocks)
-                self._active_snapshot_blocks = []
-            self._active_snapshot_blocks = self._delayed_snapshot_blocks
-            self._delayed_snapshot_blocks = []
-            self._active_snapshot_source_blocks = self._delayed_snapshot_source_blocks
-            self._delayed_snapshot_source_blocks = []
-            self._kv_cache_block_copies = self._delayed_kv_cache_block_copies
-            self._delayed_kv_cache_block_copies = []
+            self._free_snapshot_copies(self._active_snapshot_copies)
+            self._active_snapshot_copies = self._delayed_snapshot_copies
+            self._delayed_snapshot_copies = []
+            self._kv_cache_block_copies = [
+                snapshot.copy for snapshot in self._active_snapshot_copies
+            ]
         self.cached_blocks_this_step.clear()
 
     def _cache_partial_snapshot(
@@ -1661,18 +1662,29 @@ class MambaManager(SingleTypeKVCacheManager):
             self.block_pool.free_blocks([snapshot_block])
             return None
 
-        self._delayed_snapshot_blocks.append(snapshot_block)
         self._retain_block(source_block)
-        self._delayed_snapshot_source_blocks.append(source_block)
-        self._delayed_kv_cache_block_copies.append(
-            KVCacheBlockCopy(
-                kv_cache_group_id=self.kv_cache_group_id,
-                src_block_id=source_block.block_id,
-                dst_block_id=snapshot_block.block_id,
-                num_tokens=self.block_size,
+        self._delayed_snapshot_copies.append(
+            _RetainedKVCacheBlockCopy(
+                source_block=source_block,
+                dst_block=snapshot_block,
+                copy=KVCacheBlockCopy(
+                    kv_cache_group_id=self.kv_cache_group_id,
+                    src_block_id=source_block.block_id,
+                    dst_block_id=snapshot_block.block_id,
+                    num_tokens=self.block_size,
+                ),
             )
         )
         return partial_hash
+
+    def _free_snapshot_copies(
+        self,
+        snapshots: list[_RetainedKVCacheBlockCopy],
+    ) -> None:
+        if not snapshots:
+            return
+        self._free_retained_blocks([snapshot.source_block for snapshot in snapshots])
+        self.block_pool.free_blocks([snapshot.dst_block for snapshot in snapshots])
 
     def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
         copies = self._kv_cache_block_copies

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -106,11 +106,43 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Partial-hit copy-on-write bookkeeping. Instance-level switch for the
-        # generic machinery below; defaults to the class capability flag.
-        # MambaManager narrows it to the "align" cache mode.
+        # ------------------------------------------------------------------
+        # Partial-hit copy-on-write bookkeeping.
+        #
+        # Overview of the partial-hit lifecycle (all generic machinery lives
+        # in this base class; subclasses only contribute their finder and,
+        # for mamba, a producer variant):
+        #
+        #   PRODUCER side (request whose prompt ends inside a cache block):
+        #     cache_blocks -> _cache_partial_tail_block registers the last
+        #     prompt *hash* boundary as an extra prefix-cache key pointing at
+        #     the (still partially filled) tail block. No copy happens here
+        #     for append-only KV (FA/SWA); mamba overrides this because its
+        #     state blocks are rewritten in place.
+        #
+        #   CONSUMER side (a later request hitting that entry mid-block):
+        #     1. find_longest_cache_hit returns a hit length that is NOT a
+        #        multiple of this manager's block_size (fine-grained hit).
+        #     2. get_num_blocks_to_allocate reserves +1 block for the CoW.
+        #     3. add_local_computed_blocks records (block_idx, source_block)
+        #        in _partial_hit_reqs.
+        #     4. allocate_new_blocks pops that record, allocates a private
+        #        cow_block, and _apply_cow swaps it into req_to_blocks and
+        #        queues a KVCacheBlockCopy(src, dst).
+        #     5. The scheduler drains take_kv_cache_block_copies() into
+        #        SchedulerOutput; the worker executes the copies after
+        #        zeroing new blocks and before the forward pass.
+        #     6. new_step_starts (next step) releases the retentions taken
+        #        in _apply_cow — by then the copy has run on the worker.
+        # ------------------------------------------------------------------
+        # Instance-level switch for the generic machinery below; defaults to
+        # the class capability flag. MambaManager narrows it to the "align"
+        # cache mode.
         self.partial_hits_enabled: bool = self.supports_fine_grained_hash_lookup
+        # {req_id: (index into req_to_blocks, the shared partially-hit block)}
+        # set at step 3 above and consumed at step 4.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+        # Pending copies queued at step 4, drained by the scheduler at step 5.
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
         # Blocks participating in a pending copy (both source and target).
         # Each holds one retention released at `new_step_starts`, after the
@@ -131,6 +163,16 @@ class SingleTypeKVCacheManager(ABC):
         new_computed_blocks: Sequence[KVCacheBlock],
         num_local_computed_tokens: int,
     ) -> bool:
+        # A partial hit means the LOCAL prefix-cache hit ends inside one of
+        # this manager's cache blocks, so the tail block is shared read-only
+        # while the request must keep appending into it -> needs CoW.
+        # Two conditions:
+        #  - There must be hit blocks at all: an external-only (connector)
+        #    prefix has a private tail and never needs CoW.
+        #  - The hit length must be off this manager's block boundary. Note
+        #    it is checked against *this manager's* block_size: the same
+        #    common hit (e.g. 6 tokens) can be partial for a block-4 group
+        #    and exact for a block-2 group.
         return (
             len(new_computed_blocks) > 0
             and num_local_computed_tokens % self.block_size != 0
@@ -222,15 +264,25 @@ class SingleTypeKVCacheManager(ABC):
         if self.partial_hits_enabled and self._has_partial_local_hit(
             new_computed_blocks, num_local_computed_tokens
         ):
+            # This runs only on the slow path (first allocation with fresh
+            # hits): the fast path above returns early for running requests,
+            # which never see new prefix-cache hits.
             if (
                 new_computed_blocks[-1].block_id
                 in self._partial_blocks_cached_this_step
             ):
-                # The partial tail's KV is only written during this step's
-                # execution, while the consumer's CoW copy runs at step start.
-                # Defer to the next step by reporting an impossible demand.
+                # Ordering hazard: the producer registered this partial tail
+                # THIS step, so the tail's KV will only be written during
+                # this step's forward pass — but a consumer's CoW copy runs
+                # at the START of the step (before forward). Copying now
+                # would duplicate garbage. Defer the consumer to the next
+                # step by reporting an impossible demand, which makes the
+                # scheduler treat it as "not enough blocks" and retry later.
                 return self.block_pool.num_gpu_blocks + 1
-            # Reserve the copy-on-write block for the partial tail.
+            # Reserve the extra block that `allocate_new_blocks` will pull
+            # for the copy-on-write of the partial tail. Without this, the
+            # free-capacity check could pass here and then fail mid-step
+            # inside allocate_new_blocks.
             num_new_blocks += 1
 
         return num_new_blocks + num_evictable_blocks
@@ -290,12 +342,20 @@ class SingleTypeKVCacheManager(ABC):
         if self.partial_hits_enabled and self._has_partial_local_hit(
             new_computed_blocks, num_local_computed_tokens
         ):
-            # The hit ends inside the tail block; remember it so
-            # `allocate_new_blocks` redirects the request to a private
-            # copy-on-write block, and exclude it from the cached count
-            # (its full-block content is not this request's).
+            # The hit ends inside the tail block. At this point the tail
+            # (new_computed_blocks[-1]) has been touched by super() above,
+            # so it already carries this request's ref — that ref is what
+            # keeps it alive until the CoW copy runs (see _apply_cow).
+            # block_idx is the tail's position in req_to_blocks: e.g. a
+            # 6-token hit with block_size 4 gives block_idx 1 — the second
+            # block, which the finder placed last in the hit list.
             block_idx = num_local_computed_tokens // self.block_size
             self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
+            # Also cap the "already cached" count at the full blocks only:
+            # the tail block's registered content belongs to the producer's
+            # sequence, not this request's — after CoW the request writes
+            # its own continuation there, and cache_blocks must be allowed
+            # to re-cache that block under this request's own hashes.
             self.num_cached_block[request_id] = block_idx
 
     def allocate_external_computed_blocks(
@@ -358,12 +418,21 @@ class SingleTypeKVCacheManager(ABC):
         if request_id in self._partial_hit_reqs:
             # Consumer of a partial prefix-cache hit: redirect the tail to a
             # private copy-on-write block before the first block table is
-            # sent to the worker.
+            # sent to the worker. This must happen exactly once, on the
+            # request's first allocation — pop() guarantees that. The CoW
+            # block REPLACES the tail in req_to_blocks (in place, via
+            # _apply_cow), so len(req_blocks) is unchanged and the regular
+            # length-based allocation below stays correct; the extra block
+            # consumed here is the one get_num_blocks_to_allocate reserved.
             block_idx, source_block = self._partial_hit_reqs.pop(request_id)
             cow_block = self.block_pool.get_new_blocks(1)[0]
             self._apply_cow(request_id, block_idx, source_block, cow_block)
             if self.tracks_new_block_ids:
+                # Report for worker-side zeroing like any new block. The copy
+                # runs after zeroing, so the zero is overwritten — harmless.
                 self.new_block_ids.append(cow_block.block_id)
+            # Include the CoW block in the returned "new blocks" so the
+            # scheduler's block-table diff sent to the worker contains it.
             cow_blocks.append(cow_block)
 
         req_blocks = self.req_to_blocks[request_id]
@@ -415,9 +484,24 @@ class SingleTypeKVCacheManager(ABC):
         request table is updated. Temporarily retain ``cow_block`` too;
         ``new_step_starts`` releases both after the queued worker copy has run,
         preventing same-step frees from recycling either copy endpoint.
+
+        Ref-count timeline for ``source_block`` (single consumer):
+          before hit:            R      (its own refs; >= 0, in cache)
+          touch (add_local):     R + 1  <- the hit-ref this method inherits
+          swap out of the table: R + 1  (the table no longer points at it,
+                                         but the hit-ref is NOT dropped here)
+          next new_step_starts:  R      (hit-ref released; copy has run)
+        ``cow_block`` symmetrically: allocation ref (1) is handed to the
+        request via the table; the +1 below is the copy retention, released
+        at the same new_step_starts. If the request is freed within this
+        step, the table ref goes away but the retention keeps the block from
+        being handed to another request before the queued copy executes.
         """
         req_blocks = self.req_to_blocks[request_id]
         assert block_idx < len(req_blocks)
+        # The caller recorded exactly this (index, block) pair; if the table
+        # were mutated in between (e.g. by remove_skipped_blocks) we must
+        # fail loudly rather than copy into the wrong slot.
         assert req_blocks[block_idx] is source_block
         assert not source_block.is_null and source_block.ref_cnt > 0
         req_blocks[block_idx] = cow_block
@@ -495,17 +579,31 @@ class SingleTypeKVCacheManager(ABC):
         """
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
+            # Hash granularity == block granularity: every reachable boundary
+            # is already a full-block entry; nothing "partial" can exist.
             return
+        # The only partial boundary worth registering is the end of the
+        # prompt rounded down to a hash boundary: that is where an exact
+        # replay (or a longer prompt sharing this prefix) will look.
         boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
         if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            # > num_tokens: the prompt hasn't been computed that far yet
+            # (chunked prefill); a later cache_blocks call will get here.
             return
         if boundary_tokens % self.block_size == 0:
+            # Boundary sits exactly on a block edge: the normal full-block
+            # entry (cache_full_blocks) already covers it.
             return
 
         blocks = self.req_to_blocks[request.request_id]
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
+        # Register an EXTRA lookup key on the existing tail block: the chained
+        # hash at `boundary_tokens` maps to this block with
+        # block_hash_num_tokens = boundary_tokens. No allocation, no copy —
+        # safe for append-only KV because the block's first `boundary_tokens
+        # % block_size` positions never change once written.
         partial_hash = self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],
@@ -694,8 +792,15 @@ class SingleTypeKVCacheManager(ABC):
         return 0
 
     def new_step_starts(self) -> None:
-        # Release the previous step's COW blocks; their copies have now
-        # run on the worker. Empty (no-op) for managers without partial hits.
+        # Called at the start of every scheduler step. Two duties:
+        # 1. Release the previous step's CoW retentions: the worker executed
+        #    the queued copies during that step, so neither endpoint needs
+        #    protection anymore. Sources whose refs drop to 0 rejoin the
+        #    free queue but keep their cache entries (eviction candidates).
+        #    _free_retained_blocks handles the same block appearing multiple
+        #    times (several consumers CoW-ing one source in one step).
+        # 2. Reset the same-step producer guard: entries registered last
+        #    step are now backed by computed KV and safe to consume.
         if self._cow_blocks_to_release:
             self._free_retained_blocks(self._cow_blocks_to_release)
             self._cow_blocks_to_release = []
@@ -716,6 +821,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_size: int,
         hash_block_size: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        # Two-phase scan. Example with block_size 4, hash_block_size 2 and a
+        # cached 6-token prefix: raw hashes [h0(2) h1(4) h2(6)], full-block
+        # keys are the view [h1] (a block's key is the chained hash at its
+        # LAST hash boundary, so h1 covers tokens 0..3).
+        #   Phase 1 matches full blocks left-to-right via the block-size view
+        #     -> 1 full block, hit 4.
+        #   Phase 2 probes the hash boundaries INSIDE the next block, right
+        #     to left (h2 first) -> partial entry at 6 -> hit 6, and the tail
+        #     block is appended after the full blocks.
         assert block_size % hash_block_size == 0
         scale_factor = block_size // hash_block_size
         full_block_hashes = BlockHashListWithBlockSize(
@@ -729,6 +843,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
             [] for _ in range(len(kv_cache_group_ids))
         )
+        # Phase 1: longest run of cached FULL blocks from the start. The
+        # chained-hash property makes this sound: a missing block implies
+        # every later block is missing too.
         max_num_full_blocks = max_length // block_size
         num_full_blocks = 0
         for block_hash in itertools.islice(full_block_hashes, max_num_full_blocks):
@@ -741,9 +858,17 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 computed.append(cached)
             num_full_blocks += 1
 
+        # Phase 2: try to extend the hit into the first non-full block by
+        # probing its interior hash boundaries from the highest one down
+        # (longest extension first). Only the final prompt tail is ever
+        # registered (see _cache_partial_tail_block), so typically at most
+        # one of these probes can succeed; `continue` (not `break`) because
+        # partial entries are point registrations, not a chain.
         hit_length = num_full_blocks * block_size
         first_partial_idx = num_full_blocks * scale_factor
         max_partial_idx = min(
+            # scale_factor - 1: the block's LAST boundary is the full-block
+            # key itself, already known to miss from phase 1.
             first_partial_idx + scale_factor - 1,
             max_num_hash_blocks,
         )
@@ -794,6 +919,11 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
+        # Fine-grained mode: the coordinator passes alignment_tokens ==
+        # hash_block_size (< block_size) when partial hits are enabled;
+        # resolve_block_hashes then kept the raw hash-granularity list.
+        # Otherwise alignment_tokens >= block_size and we take the coarse
+        # path below on a block-size view.
         if alignment_tokens < block_size and block_size % alignment_tokens == 0:
             assert isinstance(block_hashes, list)
             computed_blocks, hit_length = cls._find_fine_grained_cache_hit(
@@ -809,6 +939,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 # point recomputed, so drop one hash unit rather than a whole
                 # cache block. The tail block's KV is append-only, so it still
                 # covers the reduced length; trim blocks past the new tail.
+                # Three shapes (block 4, hash 2):
+                #   hit 6 (partial tail) -> claim 4: cdiv(4,4)=1, tail entry
+                #     dropped, ends on a clean block boundary;
+                #   hit 8 (2 full)       -> claim 6: cdiv(6,4)=2, both blocks
+                #     kept, block 1 becomes the CoW source for the mid-block
+                #     claim;
+                #   hit 10 (tail at 10)  -> claim 8: cdiv(8,4)=2, tail
+                #     dropped, full blocks serve exactly.
                 hit_length -= alignment_tokens
                 num_blocks = cdiv(hit_length, block_size)
                 for computed in computed_blocks:
@@ -915,21 +1053,36 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                 )
             return full_block_cache[block_idx]
 
+        # Walk candidate lookup boundaries u = k * hash right-to-left so the
+        # first success is the LONGEST hit. A single get_cached_block at the
+        # raw hash h[k-1] finds either kind of entry, because a full block's
+        # key IS the raw hash at its last boundary and a partial tail's key
+        # is the raw hash at its registration boundary.
         max_num_units = min(max_length // hash_block_size, len(block_hashes))
         for k in range(max_num_units, 0, -1):
             lookup_tokens = k * hash_block_size
+            # With eagle, the claim is one hash unit below the lookup: the
+            # entry at u proves KV coverage up to u, and the dropped unit
+            # [claim, u) gets recomputed for the drafting head.
             claim = lookup_tokens - drop_tokens
             if claim <= 0:
                 break
             entry = block_pool.get_cached_block(block_hashes[k - 1], kv_cache_group_ids)
             if not entry:
                 continue
-            # Window coverage for the claim: every block holding tokens
-            # [claim - window + 1, claim - 1] must be cached, except the
-            # entry's own block.
+            # Unlike full attention, an SWA hit at `claim` is only valid if
+            # the whole attention window ending there is present: the next
+            # token (position `claim`) attends to [claim - window + 1,
+            # claim - 1], and those tokens' KV must all be in cached blocks.
+            # The entry's own block covers itself (its KV is valid up to
+            # u >= claim); every other block in that range needs its own
+            # full-block entry.
             entry_block_idx = (lookup_tokens - 1) // block_size
             last_block_idx = (claim - 1) // block_size
             first_block_idx = max(claim - sliding_window + 1, 0) // block_size
+            # Note: with eagle, entry_block_idx can exceed last_block_idx
+            # (claim rounded down to the previous block); the entry then only
+            # serves as evidence and is not part of the returned blocks.
             window_blocks: dict[int, list[KVCacheBlock]] = {}
             covered = True
             for j in range(last_block_idx, first_block_idx - 1, -1):
@@ -939,7 +1092,11 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                     break
                 window_blocks[j] = cached
             if not covered:
+                # This candidate fails, but a shorter boundary may still have
+                # a fully covered (smaller) window — keep scanning.
                 continue
+            # Blocks before the window are unreachable for SWA: pad with
+            # nulls so list positions still line up with block indices.
             computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
                 [block_pool.null_block] * first_block_idx
                 + [
@@ -1537,6 +1694,11 @@ class MambaManager(SingleTypeKVCacheManager):
                 - len(new_computed_blocks)
                 - len(self.req_to_blocks[request_id])
             )
+            # Two sources of a pending CoW here: a consumer's fresh partial
+            # hit (the predicate, same as the base class) OR the producer's
+            # own self-CoW queued by _cache_partial_tail_block last step
+            # (only reachable via _partial_hit_reqs — the producer is a
+            # running request, so it has no new_computed_blocks).
             has_partial_hit = (
                 self._has_partial_local_hit(
                     new_computed_blocks, num_local_computed_tokens
@@ -1643,6 +1805,18 @@ class MambaManager(SingleTypeKVCacheManager):
                 new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
                 returned_blocks = req_blocks[prev_block_len:]
                 if partial_hit is not None:
+                    # Unlike FA/SWA (which handle only the consumer, in the
+                    # base class), mamba resolves TWO partial-hit shapes here,
+                    # distinguished by whether this request already has
+                    # allocated blocks (`blocks_allocated`):
+                    #   - producer: it registered ITS OWN tail via
+                    #     _cache_partial_tail_block last cache_blocks call and
+                    #     keeps running — its state block will be rewritten in
+                    #     place, so the CACHE ENTRY (not the request) must be
+                    #     moved to a private copy;
+                    #   - consumer: a new request hitting someone else's
+                    #     entry — same as the base machinery, the REQUEST is
+                    #     redirected to a private copy.
                     block_idx, source_block = partial_hit
                     cow_block = new_blocks[0]
                     new_blocks = new_blocks[1:]
@@ -1735,6 +1909,11 @@ class MambaManager(SingleTypeKVCacheManager):
             return
         if num_tokens % hash_block_size != 0:
             return
+        # Stricter than the base (FA/SWA) version: the entry must be
+        # registered at EXACTLY the moment the state represents the boundary.
+        # FA can register late (its tail KV never changes once written);
+        # mamba's block holds only the LATEST state, so once decoding moves
+        # past the boundary, that state is gone.
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
@@ -1757,8 +1936,13 @@ class MambaManager(SingleTypeKVCacheManager):
             block_size=self.block_size,
         )
         if partial_hash is not None:
+            # Self-CoW: the producer itself is queued in _partial_hit_reqs so
+            # its NEXT allocate_new_blocks moves the cache entry to a private
+            # snapshot (move_block_hashes) before it rewrites this block.
             self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
             self.num_cached_block[request.request_id] = block_idx
+            # Same-step guard, hash-keyed for mamba (the base uses block ids):
+            # the boundary state only materializes during this step's forward.
             self.cached_blocks_this_step.add(partial_hash)
 
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -40,10 +40,9 @@ class SingleTypeKVCacheManager(ABC):
     logic of one specific type of attention layer.
     """
 
+    # Cache hits can use hash_block_size when it is smaller than group_block_size.
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
-
-    # Whether newly allocated block IDs are reported via `take_new_block_ids`
-    # (feeds `new_block_ids_to_zero` for worker-side zeroing).
+    # KVCacheZeroer needs to track new blocks for worker-side zeroing.
     tracks_new_block_ids: ClassVar[bool] = False
 
     def __init__(
@@ -65,6 +64,8 @@ class SingleTypeKVCacheManager(ABC):
             kv_cache_group_id: The id of the kv cache group of this manager.
             scheduler_block_size: The scheduling granularity (LCM of all group
                 block sizes); a multiple of this manager's ``block_size``.
+            dcp_world_size: The world size of decoder parallelism.
+            pcp_world_size: The world size of prefill parallelism.
             max_admission_blocks_per_request: Recycling-aware per-request
                 block cap used by `get_num_blocks_to_allocate`. Only set for
                 spec types that recycle blocks across chunks (SWA,
@@ -192,7 +193,7 @@ class SingleTypeKVCacheManager(ABC):
 
         num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
         num_local_computed_blocks = len(new_computed_blocks) + num_req_blocks
-        # Number of whole blocks that are skipped by the attention window.
+        # Number of blocks that are skipped by the attention window.
         # If nothing is skipped, this is 0.
         num_skipped_blocks = num_skipped_tokens // self.block_size
         # We need blocks for the non-skipped suffix. If there are still
@@ -367,17 +368,12 @@ class SingleTypeKVCacheManager(ABC):
         source_block: KVCacheBlock,
         cow_block: KVCacheBlock,
     ) -> None:
-        """Redirect ``req_blocks[block_idx]`` from a shared, partially-hit
-        ``source_block`` to a private ``cow_block``.
+        """Redirect a partial prefix-cache hit to a private COW block.
 
-        The request already holds a ref on ``source_block`` (from the
-        prefix-cache touch). We keep that ref and release it next step
-        (``new_step_starts``), after the worker copy has run, rather than
-        freeing it now -- this keeps the block alive and out of the free queue
-        across the step without a retain/free round-trip. ``cow_block`` gets
-        an extra retention for the same window: if the request is freed within
-        this step, the pending copy must not target a block that another
-        request could be given in the meantime.
+        The existing prefix-cache touch keeps ``source_block`` alive after the
+        request table is updated. Temporarily retain ``cow_block`` too;
+        ``new_step_starts`` releases both after the queued worker copy has run,
+        preventing same-step frees from recycling either copy endpoint.
         """
         req_blocks = self.req_to_blocks[request_id]
         assert block_idx < len(req_blocks)
@@ -409,7 +405,7 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval: Sparse local-checkpoint granularity. ``None``
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
-                a tail once per that-sized segment. Only SWA acts on it.
+                a tail once per that-sized segment.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -543,12 +539,13 @@ class SingleTypeKVCacheManager(ABC):
             pcp_world_size: The world size of prefill context parallelism.
 
         Returns:
-            A tuple containing cached blocks and the exact cache-hit length in
-            tokens. The cached block tuple has skipped blocks replaced by null
-            blocks for each kv cache group in `kv_cache_group_ids`.
-            For example, sliding window manager should return a list like
-            ([NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]) for block size 4
-            and sliding window 8 and len(kv_cache_group_ids) = 1.
+            cached_blocks: Cached blocks for each KV cache group in
+                ``kv_cache_group_ids``, with skipped blocks replaced by null
+                blocks. The i-th element is the cached blocks for the i-th KV
+                cache group. For example, a sliding window manager with block
+                size 4, sliding window 8, and one KV cache group returns
+                ``[NULL, NULL, KVCacheBlock(7), KVCacheBlock(8)]``.
+            hit_length: Exact cache-hit length in tokens.
         """
 
         raise NotImplementedError

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1113,13 +1113,41 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
 
         # (2) Replay-boundary tail. ``get_computed_blocks`` caps hits at
         # ``num_prompt - 1`` (to recompute the last token's logits), so an exact
-        # prompt replay can only land on the latest *fine*-aligned boundary.
+        # prompt replay can only land on the latest reachable boundary.
         # Sparse retention would otherwise skip it, so keep its tail explicitly.
-        if retention_interval is not None and num_prompt_tokens is not None:
-            latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
-            prompt_end_block = latest // block_size + shift
+        # With partial hits and a prompt that ends inside a hash block, every
+        # group registers a partial tail at the last hash boundary, so the
+        # joint replay hit lands there: keep that (possibly mid-block) tail
+        # block plus enough full blocks to cover the whole window. With a
+        # hash-aligned prompt, the tail entry would sit at ``num_prompt``
+        # itself — past the hit cap and unusable for an exact replay — so the
+        # joint replay falls back to the coarse aligned boundary, which every
+        # group serves through its block-aligned entries.
+        if (
+            retention_interval is not None or partial_anchor_tokens is not None
+        ) and num_prompt_tokens is not None:
+            if (
+                partial_anchor_tokens is not None
+                and num_prompt_tokens % partial_anchor_tokens != 0
+            ):
+                latest = (
+                    num_prompt_tokens // partial_anchor_tokens * partial_anchor_tokens
+                )
+                # The fine anchor is the last usable boundary, so the EAGLE
+                # peek cannot go past it: the lookup lands on the anchor
+                # itself and the claim moves one hash unit down instead.
+                anchor_shift = 0
+            else:
+                latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+                anchor_shift = shift
+            if latest % block_size == 0:
+                prompt_end_block = latest // block_size + anchor_shift
+                keep = need
+            else:
+                prompt_end_block = latest // block_size + 1 + anchor_shift
+                keep = need + 1
             for i in range(
-                max(start_block, prompt_end_block - need),
+                max(start_block, prompt_end_block - keep),
                 min(end_block, prompt_end_block),
             ):
                 mask[i - start_block] = True

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from abc import ABC, abstractmethod
-from collections import Counter, defaultdict
+from collections import defaultdict
 from collections.abc import Sequence
 from typing import ClassVar
 
@@ -131,8 +131,9 @@ class SingleTypeKVCacheManager(ABC):
         #     5. The scheduler drains take_kv_cache_block_copies() into
         #        SchedulerOutput; the worker executes the copies after
         #        zeroing new blocks and before the forward pass.
-        #     6. new_step_starts (next step) releases the retentions taken
-        #        in _apply_cow — by then the copy has run on the worker.
+        #     6. new_step_starts (next step) hands the retentions taken in
+        #        _apply_cow back to the caller; the scheduler frees them once
+        #        the step that ran the copy is no longer in flight.
         # ------------------------------------------------------------------
         # Instance-level switch for the generic machinery below; defaults to
         # the class capability flag. MambaManager narrows it to the "align"
@@ -144,9 +145,10 @@ class SingleTypeKVCacheManager(ABC):
         # Pending copies queued at step 4, drained by the scheduler at step 5.
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
         # Blocks participating in a pending copy (both source and target).
-        # Each holds one retention released at `new_step_starts`, after the
-        # worker copy has run, so that a request freed within the same step
-        # cannot leak either end of the copy to another request.
+        # Each holds one retention handed back at `new_step_starts` and
+        # released once the worker copy has run, so that a request freed
+        # within the same step cannot leak either end of the copy to
+        # another request.
         self._cow_blocks_to_release: list[KVCacheBlock] = []
         # Blocks whose partial tail entry was newly registered this step;
         # their content is only written during this step's execution, so
@@ -458,18 +460,6 @@ class SingleTypeKVCacheManager(ABC):
         self._kv_cache_block_copies = []
         return copies
 
-    def _free_retained_blocks(self, blocks: Sequence[KVCacheBlock]) -> None:
-        freed_blocks: list[KVCacheBlock] = []
-        ref_counts_by_id = Counter(block.block_id for block in blocks)
-        blocks_by_id = {block.block_id: block for block in blocks}
-        for block_id, count in ref_counts_by_id.items():
-            block = blocks_by_id[block_id]
-            assert block.ref_cnt >= count
-            block.ref_cnt -= count
-            if block.ref_cnt == 0 and not block.is_null:
-                freed_blocks.append(block)
-        self.block_pool.free_block_queue.append_n(freed_blocks)
-
     def _apply_cow(
         self,
         request_id: str,
@@ -481,15 +471,17 @@ class SingleTypeKVCacheManager(ABC):
 
         The existing prefix-cache touch keeps ``source_block`` alive after the
         request table is updated. Temporarily retain ``cow_block`` too;
-        ``new_step_starts`` releases both after the queued worker copy has run,
-        preventing same-step frees from recycling either copy endpoint.
+        ``new_step_starts`` hands both back for release after the queued
+        worker copy has run, preventing same-step frees from recycling
+        either copy endpoint.
 
         Ref-count timeline for ``source_block`` (single consumer):
           before hit:            R      (its own refs; >= 0, in cache)
           touch (add_local):     R + 1  <- the hit-ref this method inherits
           swap out of the table: R + 1  (the table no longer points at it,
                                          but the hit-ref is NOT dropped here)
-          next new_step_starts:  R      (hit-ref released; copy has run)
+          next new_step_starts:  R      (hit-ref released once the copy's
+                                         step is no longer in flight)
         ``cow_block`` symmetrically: allocation ref (1) is handed to the
         request via the table; the +1 below is the copy retention, released
         at the same new_step_starts. If the request is freed within this
@@ -790,20 +782,23 @@ class SingleTypeKVCacheManager(ABC):
         # The default behavior is to not skip any tokens.
         return 0
 
-    def new_step_starts(self) -> None:
+    def new_step_starts(self) -> list[KVCacheBlock]:
         # Called at the start of every scheduler step. Two duties:
-        # 1. Release the previous step's CoW retentions: the worker executed
-        #    the queued copies during that step, so neither endpoint needs
-        #    protection anymore. Sources whose refs drop to 0 rejoin the
-        #    free queue but keep their cache entries (eviction candidates).
-        #    _free_retained_blocks handles the same block appearing multiple
-        #    times (several consumers CoW-ing one source in one step).
+        # 1. Hand back the previous step's CoW retentions for release: the
+        #    worker runs the queued copies during that step, so neither
+        #    endpoint needs protection once that step completes. The caller
+        #    frees them, fencing against the step still being in flight on
+        #    the GPU (see Scheduler._free_cow_retained_blocks). Sources whose
+        #    refs drop to 0 rejoin the free queue but keep their cache
+        #    entries (eviction candidates). The same block may appear
+        #    multiple times (several consumers CoW-ing one source in one
+        #    step); each occurrence carries one retention ref.
         # 2. Reset the same-step producer guard: entries registered last
         #    step are now backed by computed KV and safe to consume.
-        if self._cow_blocks_to_release:
-            self._free_retained_blocks(self._cow_blocks_to_release)
-            self._cow_blocks_to_release = []
+        blocks_to_release = self._cow_blocks_to_release
+        self._cow_blocks_to_release = []
         self._partial_blocks_cached_this_step.clear()
+        return blocks_to_release
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
@@ -1744,9 +1739,10 @@ class MambaManager(SingleTypeKVCacheManager):
                 assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)
 
-    def new_step_starts(self) -> None:
-        super().new_step_starts()
+    def new_step_starts(self) -> list[KVCacheBlock]:
+        blocks_to_release = super().new_step_starts()
         self.cached_blocks_this_step.clear()
+        return blocks_to_release
 
     def _cache_partial_tail_block(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1607,13 +1607,8 @@ class MambaManager(SingleTypeKVCacheManager):
     def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
-        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
-        # draft tokens from the previous step that may or may not be rejected later.
-        # This can make us think we are further ahead in the sequence than we actually
-        # are, so let's assume that all tokens are rejected so we don't free blocks
-        # that we might actually need.
-        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
-
+        # Spec-rollback safety: callers pass the processed-token basis, which
+        # excludes possibly-rejected in-flight tokens.
         super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
@@ -2043,6 +2038,7 @@ def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
     max_num_batched_tokens: int,
     max_model_len: int,
+    max_concurrent_batches: int = 1,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
     """
@@ -2056,6 +2052,8 @@ def get_manager_for_kv_cache_spec(
         kv_cache_spec: The KVCacheSpec instance
         max_num_batched_tokens: The maximum number of tokens in a batch
         max_model_len: The maximum context length the model could serve
+        max_concurrent_batches: The maximum number of scheduler steps that can
+            overlap on the GPU (async scheduling / pipeline parallelism)
     Returns:
         An instance of the appropriate SingleTypeKVCacheManager subclass
     """
@@ -2071,6 +2069,7 @@ def get_manager_for_kv_cache_spec(
             kv_cache_spec.max_admission_blocks_per_request(
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_model_len=max_model_len,
+                max_concurrent_batches=max_concurrent_batches,
             )
         )
     manager = manager_class(kv_cache_spec, **kwargs)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,7 +4,6 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import ClassVar
 
 from vllm.utils.math_utils import cdiv
@@ -33,12 +32,6 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
-
-
-@dataclass
-class _RetainedKVCacheBlockCopy:
-    source_block: KVCacheBlock
-    copy: KVCacheBlockCopy
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -107,6 +100,12 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+        # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
+        # managers (full attention, mamba "align"); harmlessly empty elsewhere.
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+        self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
+        self._cow_sources_to_release: list[KVCacheBlock] = []
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -334,7 +333,9 @@ class SingleTypeKVCacheManager(ABC):
 
     def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
         """Drain and return pending KV cache block copies."""
-        return []
+        copies = self._kv_cache_block_copies
+        self._kv_cache_block_copies = []
+        return copies
 
     def _retain_block(self, block: KVCacheBlock) -> None:
         if block.is_null:
@@ -355,13 +356,32 @@ class SingleTypeKVCacheManager(ABC):
                 freed_blocks.append(block)
         self.block_pool.free_block_queue.append_n(freed_blocks)
 
-    def _free_retained_copies(
+    def _apply_cow(
         self,
-        copies: list[_RetainedKVCacheBlockCopy],
+        request_id: str,
+        block_idx: int,
+        source_block: KVCacheBlock,
+        cow_block: KVCacheBlock,
     ) -> None:
-        if not copies:
-            return
-        self._free_retained_blocks([copy.source_block for copy in copies])
+        """Redirect ``req_blocks[block_idx]`` from a shared, partially-hit
+        ``source_block`` to a private ``cow_block``.
+
+        Records the block copy for the worker and defers releasing the source's
+        hit-ref to the next step (``new_step_starts``), after the copy has run.
+        """
+        req_blocks = self.req_to_blocks[request_id]
+        assert block_idx < len(req_blocks)
+        assert req_blocks[block_idx] is source_block
+        self._retain_block(source_block)
+        req_blocks[block_idx] = cow_block
+        self.block_pool.free_blocks([source_block])
+        self._kv_cache_block_copies.append(
+            KVCacheBlockCopy(
+                src_block_id=source_block.block_id,
+                dst_block_id=cow_block.block_id,
+            )
+        )
+        self._cow_sources_to_release.append(source_block)
 
     def cache_blocks(
         self,
@@ -444,6 +464,7 @@ class SingleTypeKVCacheManager(ABC):
         # Default to [] in case a request is freed (aborted) before alloc.
         req_blocks = self.req_to_blocks.pop(request_id, [])
         self.num_cached_block.pop(request_id, None)
+        self._partial_hit_reqs.pop(request_id, None)
         return req_blocks
 
     def free(self, request_id: str) -> None:
@@ -579,37 +600,15 @@ class SingleTypeKVCacheManager(ABC):
         return 0
 
     def new_step_starts(self) -> None:
-        # do nothing by default
-        return None
+        # Release the previous step's COW source blocks; their copies have now
+        # run on the worker. Empty (no-op) for managers without partial hits.
+        if self._cow_sources_to_release:
+            self._free_retained_blocks(self._cow_sources_to_release)
+            self._cow_sources_to_release = []
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
-
-    def __init__(
-        self,
-        kv_cache_spec: KVCacheSpec,
-        block_pool: BlockPool,
-        enable_caching: bool,
-        kv_cache_group_id: int,
-        scheduler_block_size: int,
-        dcp_world_size: int = 1,
-        pcp_world_size: int = 1,
-        max_admission_blocks_per_request: int | None = None,
-    ) -> None:
-        super().__init__(
-            kv_cache_spec=kv_cache_spec,
-            block_pool=block_pool,
-            enable_caching=enable_caching,
-            kv_cache_group_id=kv_cache_group_id,
-            scheduler_block_size=scheduler_block_size,
-            dcp_world_size=dcp_world_size,
-            pcp_world_size=pcp_world_size,
-            max_admission_blocks_per_request=max_admission_blocks_per_request,
-        )
-        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
-        self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
-        self._copy_refs_to_release: list[_RetainedKVCacheBlockCopy] = []
 
     @classmethod
     def _find_fine_grained_cache_hit(
@@ -807,25 +806,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         new_blocks: list[KVCacheBlock] = []
         if request_id in self._partial_hit_reqs:
             block_idx, source_block = self._partial_hit_reqs.pop(request_id)
-            self._retain_block(source_block)
             cow_block = self.block_pool.get_new_blocks(1)[0]
-            req_blocks = self.req_to_blocks[request_id]
-            assert block_idx < len(req_blocks)
-            assert req_blocks[block_idx] is source_block
-            req_blocks[block_idx] = cow_block
-            self.block_pool.free_blocks([source_block])
+            self._apply_cow(request_id, block_idx, source_block, cow_block)
             self.new_block_ids.append(cow_block.block_id)
-            block_copy = KVCacheBlockCopy(
-                src_block_id=source_block.block_id,
-                dst_block_id=cow_block.block_id,
-            )
-            self._kv_cache_block_copies.append(block_copy)
-            self._copy_refs_to_release.append(
-                _RetainedKVCacheBlockCopy(
-                    source_block=source_block,
-                    copy=block_copy,
-                )
-            )
             new_blocks.append(cow_block)
 
         new_blocks.extend(
@@ -874,19 +857,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
-
-    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
-        copies = self._kv_cache_block_copies
-        self._kv_cache_block_copies = []
-        return copies
-
-    def free(self, request_id: str) -> None:
-        self._partial_hit_reqs.pop(request_id, None)
-        super().free(request_id)
-
-    def new_step_starts(self) -> None:
-        self._free_retained_copies(self._copy_refs_to_release)
-        self._copy_refs_to_release = []
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1288,9 +1258,6 @@ class MambaManager(SingleTypeKVCacheManager):
             self.last_state_block_idx: dict[str, int] = {}
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
-            self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
-            self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
-            self._copy_refs_to_release: list[_RetainedKVCacheBlockCopy] = []
 
     @classmethod
     def find_longest_cache_hit(
@@ -1570,22 +1537,7 @@ class MambaManager(SingleTypeKVCacheManager):
                 if partial_hit is not None:
                     block_idx, source_block = partial_hit
                     cow_block = new_blocks[0]
-                    assert block_idx < len(req_blocks)
-                    assert req_blocks[block_idx] is source_block
-                    self._retain_block(source_block)
-                    req_blocks[block_idx] = cow_block
-                    self.block_pool.free_blocks([source_block])
-                    block_copy = KVCacheBlockCopy(
-                        src_block_id=source_block.block_id,
-                        dst_block_id=cow_block.block_id,
-                    )
-                    self._kv_cache_block_copies.append(block_copy)
-                    self._copy_refs_to_release.append(
-                        _RetainedKVCacheBlockCopy(
-                            source_block=source_block,
-                            copy=block_copy,
-                        )
-                    )
+                    self._apply_cow(request_id, block_idx, source_block, cow_block)
                     returned_blocks = [cow_block] + returned_blocks
                     new_blocks = new_blocks[1:]
                 req_blocks.extend(new_blocks)
@@ -1598,7 +1550,6 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
-            self._partial_hit_reqs.pop(request_id, None)
         return super().pop_blocks_for_free(request_id)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
@@ -1632,9 +1583,7 @@ class MambaManager(SingleTypeKVCacheManager):
                 self.cached_blocks_this_step.add(block.block_hash)
 
     def new_step_starts(self) -> None:
-        if self.mamba_cache_mode == "align":
-            self._free_retained_copies(self._copy_refs_to_release)
-            self._copy_refs_to_release = []
+        super().new_step_starts()
         self.cached_blocks_this_step.clear()
 
     def _cache_partial_tail_block(
@@ -1674,11 +1623,6 @@ class MambaManager(SingleTypeKVCacheManager):
             self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
             self.num_cached_block[request.request_id] = block_idx
         return partial_hash
-
-    def take_kv_cache_block_copies(self) -> list[KVCacheBlockCopy]:
-        copies = self._kv_cache_block_copies
-        self._kv_cache_block_copies = []
-        return copies
 
     def add_local_computed_blocks(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -605,8 +605,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             max_admission_blocks_per_request=max_admission_blocks_per_request,
         )
         self.num_cached_hash_block: dict[str, int] = {}
-        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock, bool]] = {}
-        self._pending_cow_source_blocks: list[KVCacheBlock] = []
+        self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
+        self._retained_cow_source_blocks: list[KVCacheBlock] = []
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
 
     @classmethod
@@ -798,14 +798,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         if hit_length > 0 and hit_length % self.block_size != 0:
             block_idx = hit_length // self.block_size
             source_block = new_computed_blocks[-1]
-            req_blocks = self.req_to_blocks[request_id]
-            release_req_ref = (
-                block_idx < len(req_blocks) and req_blocks[block_idx] is source_block
-            )
             self._partial_hit_reqs[request_id] = (
                 block_idx,
                 source_block,
-                release_req_ref,
             )
             self.num_cached_block[request_id] = block_idx
 
@@ -814,16 +809,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
     ) -> list[KVCacheBlock]:
         new_blocks: list[KVCacheBlock] = []
         if request_id in self._partial_hit_reqs:
-            block_idx, source_block, release_source_ref = self._partial_hit_reqs.pop(
-                request_id
-            )
+            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
+            self._retain_block(source_block)
             cow_block = self.block_pool.get_new_blocks(1)[0]
             req_blocks = self.req_to_blocks[request_id]
-            if block_idx < len(req_blocks):
-                req_blocks[block_idx] = cow_block
-            else:
-                assert block_idx == len(req_blocks)
-                req_blocks.append(cow_block)
+            assert block_idx < len(req_blocks)
+            assert req_blocks[block_idx] is source_block
+            req_blocks[block_idx] = cow_block
+            self.block_pool.free_blocks([source_block])
             self.new_block_ids.append(cow_block.block_id)
             self._kv_cache_block_copies.append(
                 KVCacheBlockCopy(
@@ -831,9 +824,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                     dst_block_id=cow_block.block_id,
                 )
             )
-            if not release_source_ref:
-                self._retain_block(source_block)
-            self._pending_cow_source_blocks.append(source_block)
+            self._retained_cow_source_blocks.append(source_block)
             new_blocks.append(cow_block)
 
         new_blocks.extend(
@@ -895,9 +886,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         super().free(request_id)
 
     def new_step_starts(self) -> None:
-        if self._pending_cow_source_blocks:
-            self._free_retained_blocks(self._pending_cow_source_blocks)
-            self._pending_cow_source_blocks = []
+        if self._retained_cow_source_blocks:
+            self._free_retained_blocks(self._retained_cow_source_blocks)
+            self._retained_cow_source_blocks = []
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1304,7 +1295,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
             self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
-            self._pending_cow_source_blocks: list[KVCacheBlock] = []
+            self._retained_cow_source_blocks: list[KVCacheBlock] = []
             self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
             self._active_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
             self._delayed_snapshot_copies: list[_RetainedKVCacheBlockCopy] = []
@@ -1585,14 +1576,16 @@ class MambaManager(SingleTypeKVCacheManager):
                     cow_block = new_blocks[0]
                     assert block_idx < len(req_blocks)
                     assert req_blocks[block_idx] is source_block
+                    self._retain_block(source_block)
                     req_blocks[block_idx] = cow_block
+                    self.block_pool.free_blocks([source_block])
                     self._kv_cache_block_copies.append(
                         KVCacheBlockCopy(
                             src_block_id=source_block.block_id,
                             dst_block_id=cow_block.block_id,
                         )
                     )
-                    self._pending_cow_source_blocks.append(source_block)
+                    self._retained_cow_source_blocks.append(source_block)
                     returned_blocks = [cow_block] + returned_blocks
                     new_blocks = new_blocks[1:]
                 req_blocks.extend(new_blocks)
@@ -1640,9 +1633,9 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         if self.mamba_cache_mode == "align":
-            if self._pending_cow_source_blocks:
-                self._free_retained_blocks(self._pending_cow_source_blocks)
-                self._pending_cow_source_blocks = []
+            if self._retained_cow_source_blocks:
+                self._free_retained_blocks(self._retained_cow_source_blocks)
+                self._retained_cow_source_blocks = []
             self._free_snapshot_copies(self._active_snapshot_copies)
             self._active_snapshot_copies = self._delayed_snapshot_copies
             self._delayed_snapshot_copies = []

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -460,6 +460,11 @@ class SingleTypeKVCacheManager(ABC):
                 use_eagle=self.use_eagle,
                 retention_interval=retention_interval,
                 num_prompt_tokens=request.num_prompt_tokens,
+                partial_anchor_tokens=(
+                    self.block_pool.hash_block_size
+                    if self.partial_hits_enabled
+                    else None
+                ),
             )
             self.block_pool.cache_full_blocks(
                 request=request,
@@ -523,13 +528,16 @@ class SingleTypeKVCacheManager(ABC):
         use_eagle: bool,
         retention_interval: int | None = None,
         num_prompt_tokens: int | None = None,
+        partial_anchor_tokens: int | None = None,
     ) -> list[bool] | None:
         """Per-block mask for ``cache_full_blocks``. ``None`` means cache
         every (non-null) block — the default for full attention.
 
         Subclasses with sparse hit semantics (SWA) override this to skip
         blocks that can never serve a hit at any alignment-aligned prefix
-        length.
+        length. ``partial_anchor_tokens`` is the hash granularity of partial
+        prefix-cache entries when partial hits are enabled: the replay
+        boundary then sits on a hash boundary instead of an aligned one.
         """
         return None
 
@@ -796,14 +804,19 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 block_size=block_size,
                 hash_block_size=alignment_tokens,
             )
-            if drop_eagle_block and computed_blocks[0]:
+            if drop_eagle_block and hit_length > 0:
+                # Eagle only needs the tokens right before the generation
+                # point recomputed, so drop one hash unit rather than a whole
+                # cache block. The tail block's KV is append-only, so it still
+                # covers the reduced length; trim blocks past the new tail.
+                hit_length -= alignment_tokens
+                num_blocks = cdiv(hit_length, block_size)
                 for computed in computed_blocks:
-                    computed.pop()
-                hit_length = len(computed_blocks[0]) * block_size
-            # Fine-grained hits land on a hash-block boundary (== alignment_tokens)
-            # by construction, and the eagle pop drops to a full-block boundary, so
-            # the result is always alignment-aligned; no extra trim needed here
-            # (unlike the coarse branch below, which handles alignment > block_size).
+                    del computed[num_blocks:]
+            # Fine-grained hits land on a hash-block boundary
+            # (== alignment_tokens) by construction; no extra trim needed here
+            # (unlike the coarse branch below, which handles
+            # alignment > block_size).
             return computed_blocks, hit_length
 
         max_num_blocks = max_length // block_size
@@ -846,6 +859,8 @@ class FullAttentionManager(SingleTypeKVCacheManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -862,6 +877,79 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # the last matched block.
             blocks += 1
         return blocks
+
+    @classmethod
+    def _find_fine_grained_cache_hit(
+        cls,
+        block_hashes: list[BlockHash],
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        sliding_window: int,
+        drop_eagle_block: bool,
+        block_size: int,
+        hash_block_size: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """Longest hit at hash-block granularity.
+
+        Candidate lookup boundaries walk right-to-left over hash boundaries
+        ``u``; a single lookup at ``u`` finds both full blocks (whose cache key
+        is the hash at their last hash boundary) and partial prompt tails. The
+        claimed hit is ``u`` minus the eagle drop, and the window ending at
+        the claim must be covered by cached full blocks (the entry's own block
+        covers itself: its KV is valid up to ``u`` >= claim).
+        """
+        assert block_size % hash_block_size == 0
+        drop_tokens = hash_block_size if drop_eagle_block else 0
+        full_view = BlockHashListWithBlockSize(
+            block_hashes, hash_block_size, block_size
+        )
+        # Memoize full-block lookups: each block is checked at most once
+        # across all candidates.
+        full_block_cache: dict[int, list[KVCacheBlock] | None] = {}
+
+        def _lookup_full_block(block_idx: int) -> list[KVCacheBlock] | None:
+            if block_idx not in full_block_cache:
+                full_block_cache[block_idx] = block_pool.get_cached_block(
+                    full_view[block_idx], kv_cache_group_ids
+                )
+            return full_block_cache[block_idx]
+
+        max_num_units = min(max_length // hash_block_size, len(block_hashes))
+        for k in range(max_num_units, 0, -1):
+            lookup_tokens = k * hash_block_size
+            claim = lookup_tokens - drop_tokens
+            if claim <= 0:
+                break
+            entry = block_pool.get_cached_block(block_hashes[k - 1], kv_cache_group_ids)
+            if not entry:
+                continue
+            # Window coverage for the claim: every block holding tokens
+            # [claim - window + 1, claim - 1] must be cached, except the
+            # entry's own block.
+            entry_block_idx = (lookup_tokens - 1) // block_size
+            last_block_idx = (claim - 1) // block_size
+            first_block_idx = max(claim - sliding_window + 1, 0) // block_size
+            window_blocks: dict[int, list[KVCacheBlock]] = {}
+            covered = True
+            for j in range(last_block_idx, first_block_idx - 1, -1):
+                cached = entry if j == entry_block_idx else _lookup_full_block(j)
+                if not cached:
+                    covered = False
+                    break
+                window_blocks[j] = cached
+            if not covered:
+                continue
+            computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+                [block_pool.null_block] * first_block_idx
+                + [
+                    window_blocks[j][group]
+                    for j in range(first_block_idx, last_block_idx + 1)
+                ]
+                for group in range(len(kv_cache_group_ids))
+            )
+            return computed_blocks, claim
+        return tuple([] for _ in range(len(kv_cache_group_ids))), 0
 
     @classmethod
     def find_longest_cache_hit(
@@ -888,6 +976,21 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
+        if (
+            alignment_tokens < kv_cache_spec.block_size
+            and kv_cache_spec.block_size % alignment_tokens == 0
+        ):
+            assert isinstance(block_hashes, list)
+            return cls._find_fine_grained_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_length,
+                kv_cache_group_ids=kv_cache_group_ids,
+                block_pool=block_pool,
+                sliding_window=kv_cache_spec.sliding_window,
+                drop_eagle_block=drop_eagle_block,
+                block_size=kv_cache_spec.block_size,
+                hash_block_size=alignment_tokens,
+            )
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
@@ -968,6 +1071,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         use_eagle: bool,
         retention_interval: int | None = None,
         num_prompt_tokens: int | None = None,
+        partial_anchor_tokens: int | None = None,
     ) -> list[bool] | None:
         assert isinstance(kv_cache_spec, SlidingWindowSpec)
         if alignment_tokens is None:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -106,7 +106,10 @@ class SingleTypeKVCacheManager(ABC):
         # determining the attention groups.
         self.use_eagle = False
 
-        # Partial-hit copy-on-write bookkeeping.
+        # Partial-hit copy-on-write bookkeeping. Instance-level switch for the
+        # generic machinery below; defaults to the class capability flag.
+        # MambaManager narrows it to the "align" cache mode.
+        self.partial_hits_enabled: bool = self.supports_fine_grained_hash_lookup
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._kv_cache_block_copies: list[KVCacheBlockCopy] = []
         # Blocks participating in a pending copy (both source and target).
@@ -215,6 +218,21 @@ class SingleTypeKVCacheManager(ABC):
         num_evictable_blocks = self._get_num_evictable_blocks(
             new_computed_blocks[num_skipped_new_computed_blocks:]
         )
+
+        if self.partial_hits_enabled and self._has_partial_local_hit(
+            new_computed_blocks, num_local_computed_tokens
+        ):
+            if (
+                new_computed_blocks[-1].block_id
+                in self._partial_blocks_cached_this_step
+            ):
+                # The partial tail's KV is only written during this step's
+                # execution, while the consumer's CoW copy runs at step start.
+                # Defer to the next step by reporting an impossible demand.
+                return self.block_pool.num_gpu_blocks + 1
+            # Reserve the copy-on-write block for the partial tail.
+            num_new_blocks += 1
+
         return num_new_blocks + num_evictable_blocks
 
     def add_local_computed_blocks(
@@ -268,6 +286,17 @@ class SingleTypeKVCacheManager(ABC):
         # them so cache_blocks() will not try to re-cache blocks that already
         # have a block_hash set.
         self.num_cached_block[request_id] = len(req_blocks)
+
+        if self.partial_hits_enabled and self._has_partial_local_hit(
+            new_computed_blocks, num_local_computed_tokens
+        ):
+            # The hit ends inside the tail block; remember it so
+            # `allocate_new_blocks` redirects the request to a private
+            # copy-on-write block, and exclude it from the cached count
+            # (its full-block content is not this request's).
+            block_idx = num_local_computed_tokens // self.block_size
+            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
+            self.num_cached_block[request_id] = block_idx
 
     def allocate_external_computed_blocks(
         self,
@@ -325,17 +354,29 @@ class SingleTypeKVCacheManager(ABC):
         Returns:
             The new allocated blocks.
         """
+        cow_blocks: list[KVCacheBlock] = []
+        if request_id in self._partial_hit_reqs:
+            # Consumer of a partial prefix-cache hit: redirect the tail to a
+            # private copy-on-write block before the first block table is
+            # sent to the worker.
+            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
+            cow_block = self.block_pool.get_new_blocks(1)[0]
+            self._apply_cow(request_id, block_idx, source_block, cow_block)
+            if self.tracks_new_block_ids:
+                self.new_block_ids.append(cow_block.block_id)
+            cow_blocks.append(cow_block)
+
         req_blocks = self.req_to_blocks[request_id]
         num_required_blocks = cdiv(num_tokens, self.block_size)
         num_new_blocks = num_required_blocks - len(req_blocks)
         if num_new_blocks <= 0:
-            return []
+            return cow_blocks
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
             if self.tracks_new_block_ids:
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
-            return new_blocks
+            return cow_blocks + new_blocks
 
     def take_new_block_ids(self) -> list[int]:
         """Drain and return block IDs allocated since the last call."""
@@ -410,29 +451,67 @@ class SingleTypeKVCacheManager(ABC):
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
 
-        if num_cached_blocks >= num_full_blocks:
+        if num_cached_blocks < num_full_blocks:
+            block_mask = self.reachable_block_mask(
+                start_block=num_cached_blocks,
+                end_block=num_full_blocks,
+                alignment_tokens=self.scheduler_block_size,
+                kv_cache_spec=self.kv_cache_spec,
+                use_eagle=self.use_eagle,
+                retention_interval=retention_interval,
+                num_prompt_tokens=request.num_prompt_tokens,
+            )
+            self.block_pool.cache_full_blocks(
+                request=request,
+                blocks=self.req_to_blocks[request.request_id],
+                num_cached_blocks=num_cached_blocks,
+                num_full_blocks=num_full_blocks,
+                block_size=self.block_size,
+                kv_cache_group_id=self.kv_cache_group_id,
+                block_mask=block_mask,
+            )
+
+            self.num_cached_block[request.request_id] = num_full_blocks
+
+        if self.partial_hits_enabled:
+            self._cache_partial_tail_block(request, num_tokens)
+
+    def _cache_partial_tail_block(
+        self,
+        request: Request,
+        num_tokens: int,
+    ) -> None:
+        """Cache the prompt tail when it ends inside a cache block.
+
+        Only the final prompt hash boundary is registered as a partial
+        prefix-cache entry; intermediate hash boundaries inside the same cache
+        block are intentionally skipped. Overridden by MambaManager, whose
+        cache entries snapshot a state rather than append-only KV.
+        """
+        hash_block_size = self.block_pool.hash_block_size
+        if self.block_size == hash_block_size:
+            return
+        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        if boundary_tokens == 0 or boundary_tokens > num_tokens:
+            return
+        if boundary_tokens % self.block_size == 0:
             return
 
-        block_mask = self.reachable_block_mask(
-            start_block=num_cached_blocks,
-            end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
-            kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
-            retention_interval=retention_interval,
-            num_prompt_tokens=request.num_prompt_tokens,
-        )
-        self.block_pool.cache_full_blocks(
+        blocks = self.req_to_blocks[request.request_id]
+        block_idx = boundary_tokens // self.block_size
+        if block_idx >= len(blocks):
+            return
+        partial_hash = self.block_pool.cache_partial_block(
             request=request,
-            blocks=self.req_to_blocks[request.request_id],
-            num_cached_blocks=num_cached_blocks,
-            num_full_blocks=num_full_blocks,
-            block_size=self.block_size,
+            block=blocks[block_idx],
+            num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
-            block_mask=block_mask,
+            block_size=self.block_size,
         )
-
-        self.num_cached_block[request.request_id] = num_full_blocks
+        if partial_hash is not None:
+            # Newly registered: its KV is written during this step's
+            # execution, so same-step consumers must be deferred.
+            self._partial_blocks_cached_this_step.add(blocks[block_idx].block_id)
 
     @classmethod
     def reachable_block_mask(
@@ -754,120 +833,6 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                 computed.pop()
             hit_length -= block_size
         return computed_blocks, hit_length
-
-    def get_num_blocks_to_allocate(
-        self,
-        request_id: str,
-        num_tokens: int,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        total_computed_tokens: int,
-        num_local_computed_tokens: int,
-        num_tokens_main_model: int,
-        apply_admission_cap: bool = False,
-    ) -> int:
-        num_blocks = super().get_num_blocks_to_allocate(
-            request_id,
-            num_tokens,
-            new_computed_blocks,
-            total_computed_tokens,
-            num_local_computed_tokens,
-            num_tokens_main_model,
-            apply_admission_cap=apply_admission_cap,
-        )
-        if request_id not in self.num_cached_block and self._has_partial_local_hit(
-            new_computed_blocks, num_local_computed_tokens
-        ):
-            if (
-                new_computed_blocks[-1].block_id
-                in self._partial_blocks_cached_this_step
-            ):
-                # The partial tail's KV is only written during this step's
-                # execution, while the consumer's CoW copy runs at step start.
-                # Defer to the next step (mirrors the mamba guard in
-                # MambaManager.get_num_blocks_to_allocate).
-                return self.block_pool.num_gpu_blocks + 1
-            num_blocks += 1
-        return num_blocks
-
-    def add_local_computed_blocks(
-        self,
-        request_id: str,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        num_local_computed_tokens: int,
-        num_external_computed_tokens: int,
-    ) -> None:
-        super().add_local_computed_blocks(
-            request_id,
-            new_computed_blocks,
-            num_local_computed_tokens,
-            num_external_computed_tokens,
-        )
-        if self._has_partial_local_hit(new_computed_blocks, num_local_computed_tokens):
-            block_idx = num_local_computed_tokens // self.block_size
-            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
-            self.num_cached_block[request_id] = block_idx
-
-    def allocate_new_blocks(
-        self, request_id: str, num_tokens: int, num_tokens_main_model: int
-    ) -> list[KVCacheBlock]:
-        new_blocks: list[KVCacheBlock] = []
-        if request_id in self._partial_hit_reqs:
-            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
-            cow_block = self.block_pool.get_new_blocks(1)[0]
-            self._apply_cow(request_id, block_idx, source_block, cow_block)
-            self.new_block_ids.append(cow_block.block_id)
-            new_blocks.append(cow_block)
-
-        new_blocks.extend(
-            super().allocate_new_blocks(request_id, num_tokens, num_tokens_main_model)
-        )
-        return new_blocks
-
-    def cache_blocks(
-        self,
-        request: Request,
-        num_tokens: int,
-        retention_interval: int | None = None,
-    ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
-        hash_block_size = self.block_pool.hash_block_size
-        if self.block_size == hash_block_size:
-            return
-        self._cache_partial_tail_block(request, num_tokens)
-
-    def _cache_partial_tail_block(
-        self,
-        request: Request,
-        num_tokens: int,
-    ) -> None:
-        """Cache the prompt tail when it ends inside a cache block.
-
-        Only the final prompt hash boundary is registered as a partial
-        prefix-cache entry; intermediate hash boundaries inside the same cache
-        block are intentionally skipped.
-        """
-        hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
-        if boundary_tokens == 0 or boundary_tokens > num_tokens:
-            return
-        if boundary_tokens % self.block_size == 0:
-            return
-
-        blocks = self.req_to_blocks[request.request_id]
-        block_idx = boundary_tokens // self.block_size
-        if block_idx >= len(blocks):
-            return
-        partial_hash = self.block_pool.cache_partial_block(
-            request=request,
-            block=blocks[block_idx],
-            num_tokens=boundary_tokens,
-            kv_cache_group_id=self.kv_cache_group_id,
-            block_size=self.block_size,
-        )
-        if partial_hash is not None:
-            # Newly registered: its KV is written during this step's
-            # execution, so same-step consumers must be deferred.
-            self._partial_blocks_cached_this_step.add(blocks[block_idx].block_id)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1262,6 +1227,7 @@ class MambaManager(SingleTypeKVCacheManager):
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
+        self.partial_hits_enabled = self.mamba_cache_mode == "align"
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
         if self.mamba_cache_mode == "align":
             # Mapping from request ID to the index of the block
@@ -1608,10 +1574,6 @@ class MambaManager(SingleTypeKVCacheManager):
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
         super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
-        if self.mamba_cache_mode == "align":
-            partial_hash = self._cache_partial_tail_block(request, num_tokens)
-            if partial_hash is not None:
-                self.cached_blocks_this_step.add(partial_hash)
         if num_cached_blocks_after > num_cached_blocks_before:
             for block in self.req_to_blocks[request.request_id][
                 num_cached_blocks_before:num_cached_blocks_after
@@ -1629,27 +1591,31 @@ class MambaManager(SingleTypeKVCacheManager):
         self,
         request: Request,
         num_tokens: int,
-    ) -> BlockHashWithGroupId | None:
+    ) -> None:
+        """Mamba cache entries snapshot a state rather than append-only KV, so
+        the producer must be copy-on-written before it keeps decoding into the
+        registered tail: record it in ``_partial_hit_reqs``, and only register
+        when ``num_tokens`` sits exactly on the final prompt hash boundary."""
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
-            return None
+            return
         if num_tokens % self.block_size == 0:
-            return None
+            return
         if num_tokens % hash_block_size != 0:
-            return None
+            return
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
         if num_tokens != latest_prompt_hash_boundary:
-            return None
+            return
 
         block_idx = num_tokens // self.block_size
         blocks = self.req_to_blocks[request.request_id]
         if block_idx >= len(blocks):
-            return None
+            return
         source_block = blocks[block_idx]
         if source_block.is_null:
-            return None
+            return
 
         partial_hash = self.block_pool.cache_partial_block(
             request=request,
@@ -1661,27 +1627,7 @@ class MambaManager(SingleTypeKVCacheManager):
         if partial_hash is not None:
             self._partial_hit_reqs[request.request_id] = (block_idx, source_block)
             self.num_cached_block[request.request_id] = block_idx
-        return partial_hash
-
-    def add_local_computed_blocks(
-        self,
-        request_id: str,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        num_local_computed_tokens: int,
-        num_external_computed_tokens: int,
-    ) -> None:
-        super().add_local_computed_blocks(
-            request_id,
-            new_computed_blocks,
-            num_local_computed_tokens,
-            num_external_computed_tokens,
-        )
-        if self.mamba_cache_mode == "align" and self._has_partial_local_hit(
-            new_computed_blocks, num_local_computed_tokens
-        ):
-            block_idx = num_local_computed_tokens // self.block_size
-            self._partial_hit_reqs[request_id] = (block_idx, new_computed_blocks[-1])
-            self.num_cached_block[request_id] = block_idx
+            self.cached_blocks_this_step.add(partial_hash)
 
 
 class CrossAttentionManager(SingleTypeKVCacheManager):

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -442,7 +442,10 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self,
+        max_num_batched_tokens: int,
+        max_model_len: int,
+        max_concurrent_batches: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -450,9 +453,13 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         (`max_memory_usage_bytes`) and the runtime admission gate, so requests
         admitted by startup can also be admitted at runtime.
         """
-        # During chunked prefill, we hold KV for at most one chunk window.
+        # During chunked prefill, we hold KV for at most one chunk window, the
+        # newly scheduled tokens, and — since frees happen on the
+        # processed-token basis — up to `max_concurrent_batches - 1` in-flight
+        # chunks.
         num_tokens = min(
-            self.attention_chunk_size + max_num_batched_tokens, max_model_len
+            self.attention_chunk_size + max_concurrent_batches * max_num_batched_tokens,
+            max_model_len,
         )
         return cdiv(num_tokens, self.block_size)
 
@@ -460,7 +467,9 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         return max_blocks * self.page_size_bytes
 
@@ -504,7 +513,10 @@ class SlidingWindowSpec(AttentionSpec):
         )
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self,
+        max_num_batched_tokens: int,
+        max_model_len: int,
+        max_concurrent_batches: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -515,10 +527,12 @@ class SlidingWindowSpec(AttentionSpec):
         before each chunk's `get_num_blocks_to_allocate`.
         """
         # During chunked prefill, we hold KV for the last `sliding_window-1`
-        # computed tokens plus the newly scheduled tokens, and never more
-        # than `max_model_len`.
+        # computed tokens, the newly scheduled tokens, and — since frees happen
+        # on the processed-token basis — up to `max_concurrent_batches - 1`
+        # in-flight chunks; never more than `max_model_len`.
         num_tokens = min(
-            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
+            self.sliding_window - 1 + max_concurrent_batches * max_num_batched_tokens,
+            max_model_len,
         )
         # +1 because the sliding window may not start from the beginning of
         # the block. E.g. block size 4 and num_token 4 needs two blocks
@@ -532,7 +546,9 @@ class SlidingWindowSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_model_len=max_model_len,
+            max_concurrent_batches=vllm_config.max_concurrent_batches,
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -141,6 +141,11 @@ class Request:
         self.num_output_placeholders = 0
         self.async_tokens_to_discard = 0
 
+        # Tokens of steps whose output is not yet processed (async scheduling
+        # and PP run ahead of the GPU); `num_computed_tokens` counts them
+        # optimistically.
+        self.num_in_flight_tokens = 0
+
         # V2+PP+async: Enforces `pp_size` cadence between same-request decode steps
         # so the worker's broadcast slot ring stays consistent.
         self.next_decode_eligible_step = 0

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -111,7 +111,7 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer
+from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
 
 logger = init_logger(__name__)
 
@@ -840,6 +840,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if scheduler_output.new_block_ids_to_zero:
             assert self.kv_block_zeroer is not None
             self.kv_block_zeroer.zero_block_ids(scheduler_output.new_block_ids_to_zero)
+
+        # Apply copy-on-write block copies for partial prefix-cache hits, after
+        # zeroing new blocks and before the forward pass reads them.
+        if scheduler_output.kv_cache_block_copies:
+            copy_kv_cache_blocks_inplace(
+                self.kv_caches,
+                self.kv_cache_config.num_blocks,
+                scheduler_output.kv_cache_block_copies,
+            )
 
     def prepare_inputs(
         self, scheduler_output: SchedulerOutput, batch_desc: BatchExecutionDescriptor

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -222,6 +222,7 @@ from .utils import (
     KVBlockZeroer,
     add_kv_sharing_layers_to_kv_cache_groups,
     bind_kv_cache,
+    copy_kv_cache_blocks_inplace,
     prepare_kernel_block_sizes,
     sanity_check_mm_encoder_outputs,
 )
@@ -1154,6 +1155,21 @@ class GPUModelRunner(
         # stale NaN/data from corrupting attention or SSM computation.
         if scheduler_output.new_block_ids_to_zero:
             self._zero_block_ids(scheduler_output.new_block_ids_to_zero)
+        if scheduler_output.kv_cache_block_copies:
+            kv_caches = {
+                layer_name: layer.kv_cache
+                for layer_name, layer in (
+                    self.compilation_config.static_forward_context.items()
+                )
+                if hasattr(layer, "kv_cache")
+            }
+            copy_kv_cache_blocks_inplace(
+                kv_caches,
+                self.attn_groups,
+                self._kernel_block_sizes,
+                self.cache_config.cache_dtype,
+                scheduler_output.kv_cache_block_copies,
+            )
 
         # Free the cached encoder outputs.
         for mm_hash in scheduler_output.free_encoder_mm_hashes:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1156,18 +1156,9 @@ class GPUModelRunner(
         if scheduler_output.new_block_ids_to_zero:
             self._zero_block_ids(scheduler_output.new_block_ids_to_zero)
         if scheduler_output.kv_cache_block_copies:
-            kv_caches = {
-                layer_name: layer.kv_cache
-                for layer_name, layer in (
-                    self.compilation_config.static_forward_context.items()
-                )
-                if hasattr(layer, "kv_cache")
-            }
             copy_kv_cache_blocks_inplace(
-                kv_caches,
-                self.attn_groups,
-                self._kernel_block_sizes,
-                self.cache_config.cache_dtype,
+                self.kv_caches,
+                self.kv_cache_config.num_blocks,
                 scheduler_output.kv_cache_block_copies,
             )
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -38,11 +38,6 @@ from vllm.v1.kv_cache_interface import (
 
 logger = init_logger(__name__)
 
-# Distinct fake sizes used only to identify the num-blocks and block-size
-# dimensions returned by backend.get_kv_cache_shape().
-_KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL = 1_234_567
-_KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL = 1_234_560
-
 
 @triton.jit
 def _zero_kv_blocks_kernel(
@@ -621,6 +616,10 @@ def _get_kv_cache_token_dim(
     head_size: int,
     cache_dtype: str,
 ) -> int:
+    # Distinct fake sizes used only to identify the num-blocks and block-size
+    # dimensions returned by backend.get_kv_cache_shape().
+    _KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL = 1_234_567
+    _KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL = 1_234_560
     shape = backend.get_kv_cache_shape(
         _KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL,
         _KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -38,6 +38,11 @@ from vllm.v1.kv_cache_interface import (
 
 logger = init_logger(__name__)
 
+# Distinct fake sizes used only to identify the num-blocks and block-size
+# dimensions returned by backend.get_kv_cache_shape().
+_KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL = 1_234_567
+_KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL = 1_234_560
+
 
 @triton.jit
 def _zero_kv_blocks_kernel(
@@ -616,15 +621,14 @@ def _get_kv_cache_token_dim(
     head_size: int,
     cache_dtype: str,
 ) -> int:
-    token_sentinel = 1234560
     shape = backend.get_kv_cache_shape(
-        1234567,
-        token_sentinel,
+        _KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL,
+        _KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL,
         num_kv_heads,
         head_size,
         cache_dtype_str=cache_dtype,
     )
-    token_dim = shape.index(token_sentinel)
+    token_dim = shape.index(_KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL)
     if token_dim > block_dim:
         token_dim -= 1
     return token_dim

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -549,64 +549,91 @@ def copy_kv_cache_blocks_inplace(
             continue
         kv_cache_spec = group.kv_cache_spec
         if isinstance(kv_cache_spec, FullAttentionSpec):
-            kernel_block_size = kernel_block_sizes[group_id]
-            copy_full_blocks = isinstance(kv_cache_spec, MLAAttentionSpec) and (
-                kv_cache_spec.compress_ratio != 1
-                or kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
+            _copy_full_attention_kv_cache_blocks(
+                kv_caches=kv_caches,
+                group=group,
+                group_copies=group_copies,
+                kernel_block_size=kernel_block_sizes[group_id],
+                cache_dtype=cache_dtype,
             )
-            block_dim = group.backend.get_kv_cache_block_dim(
-                kernel_block_size,
-                kv_cache_spec.num_kv_heads,
-                kv_cache_spec.head_size,
-                cache_dtype_str=cache_dtype,
-            )
-            token_dim = _get_kv_cache_token_dim(
-                group.backend,
-                block_dim,
-                kv_cache_spec.num_kv_heads,
-                kv_cache_spec.head_size,
-                cache_dtype,
-            )
-            blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
-            for layer_name in group.layer_names:
-                kv_cache = kv_caches.get(layer_name)
-                if kv_cache is None:
-                    continue
-                for src_block_id, dst_block_id, num_tokens in group_copies:
-                    if copy_full_blocks:
-                        num_tokens = kv_cache_spec.block_size
-                    num_tokens = min(num_tokens, kv_cache_spec.block_size)
-                    num_full_kernel_blocks, partial_tokens = divmod(
-                        num_tokens, kernel_block_size
-                    )
-                    src_start = src_block_id * blocks_per_kv_block
-                    dst_start = dst_block_id * blocks_per_kv_block
-                    if num_full_kernel_blocks > 0:
-                        src_blocks = kv_cache.narrow(
-                            block_dim, src_start, num_full_kernel_blocks
-                        )
-                        dst_blocks = kv_cache.narrow(
-                            block_dim, dst_start, num_full_kernel_blocks
-                        )
-                        dst_blocks.copy_(src_blocks, non_blocking=True)
-                    if partial_tokens > 0:
-                        offset = num_full_kernel_blocks
-                        src_block = kv_cache.select(block_dim, src_start + offset)
-                        dst_block = kv_cache.select(block_dim, dst_start + offset)
-                        dst_block.narrow(token_dim, 0, partial_tokens).copy_(
-                            src_block.narrow(token_dim, 0, partial_tokens),
-                            non_blocking=True,
-                        )
         elif isinstance(kv_cache_spec, MambaSpec):
-            for layer_name in group.layer_names:
-                kv_cache = kv_caches.get(layer_name)
-                if kv_cache is None:
-                    continue
-                for state in kv_cache:
-                    for src_block_id, dst_block_id, _ in group_copies:
-                        state[dst_block_id].copy_(
-                            state[src_block_id], non_blocking=True
-                        )
+            _copy_mamba_state_blocks(
+                kv_caches=kv_caches,
+                group=group,
+                group_copies=group_copies,
+            )
+
+
+def _copy_full_attention_kv_cache_blocks(
+    kv_caches: dict[str, Any],
+    group: AttentionGroup,
+    group_copies: list[tuple[int, int, int]],
+    kernel_block_size: int,
+    cache_dtype: str,
+) -> None:
+    kv_cache_spec = group.kv_cache_spec
+    assert isinstance(kv_cache_spec, FullAttentionSpec)
+    copy_full_blocks = isinstance(kv_cache_spec, MLAAttentionSpec) and (
+        kv_cache_spec.compress_ratio != 1
+        or kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
+    )
+    block_dim = group.backend.get_kv_cache_block_dim(
+        kernel_block_size,
+        kv_cache_spec.num_kv_heads,
+        kv_cache_spec.head_size,
+        cache_dtype_str=cache_dtype,
+    )
+    token_dim = _get_kv_cache_token_dim(
+        group.backend,
+        block_dim,
+        kv_cache_spec.num_kv_heads,
+        kv_cache_spec.head_size,
+        cache_dtype,
+    )
+    blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
+    for layer_name in group.layer_names:
+        kv_cache = kv_caches.get(layer_name)
+        if kv_cache is None:
+            continue
+        for src_block_id, dst_block_id, num_tokens in group_copies:
+            if copy_full_blocks:
+                num_tokens = kv_cache_spec.block_size
+            num_tokens = min(num_tokens, kv_cache_spec.block_size)
+            num_full_kernel_blocks, partial_tokens = divmod(
+                num_tokens, kernel_block_size
+            )
+            src_start = src_block_id * blocks_per_kv_block
+            dst_start = dst_block_id * blocks_per_kv_block
+            if num_full_kernel_blocks > 0:
+                src_blocks = kv_cache.narrow(
+                    block_dim, src_start, num_full_kernel_blocks
+                )
+                dst_blocks = kv_cache.narrow(
+                    block_dim, dst_start, num_full_kernel_blocks
+                )
+                dst_blocks.copy_(src_blocks, non_blocking=True)
+            if partial_tokens > 0:
+                offset = num_full_kernel_blocks
+                src_block = kv_cache.select(block_dim, src_start + offset)
+                dst_block = kv_cache.select(block_dim, dst_start + offset)
+                dst_block.narrow(token_dim, 0, partial_tokens).copy_(
+                    src_block.narrow(token_dim, 0, partial_tokens),
+                    non_blocking=True,
+                )
+
+
+def _copy_mamba_state_blocks(
+    kv_caches: dict[str, Any],
+    group: AttentionGroup,
+    group_copies: list[tuple[int, int, int]],
+) -> None:
+    for layer_name in group.layer_names:
+        kv_cache = kv_caches.get(layer_name)
+        if kv_cache is None:
+            continue
+        for state in kv_cache:
+            for src_block_id, dst_block_id, _ in group_copies:
+                state[dst_block_id].copy_(state[src_block_id], non_blocking=True)
 
 
 def _get_kv_cache_token_dim(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -23,6 +23,7 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     MultipleOf,
 )
+from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
@@ -31,6 +32,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
+    MLAAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 
@@ -516,6 +518,116 @@ def bind_kv_cache(
     # Bind kv_caches to forward context
     for layer_name, kv_cache in kv_caches.items():
         forward_context[layer_name].kv_cache = kv_cache
+
+
+def copy_kv_cache_blocks_inplace(
+    kv_caches: dict[str, Any],
+    attn_groups: Iterable[AttentionGroup] | Iterable[Iterable[AttentionGroup]],
+    kernel_block_sizes: list[int],
+    cache_dtype: str,
+    kv_cache_block_copies: Iterable[KVCacheBlockCopy],
+) -> None:
+    copies_by_group: defaultdict[int, list[tuple[int, int, int]]] = defaultdict(list)
+    for copy in kv_cache_block_copies:
+        copies_by_group[copy.kv_cache_group_id].append(
+            (copy.src_block_id, copy.dst_block_id, copy.num_tokens)
+        )
+    if not copies_by_group:
+        return
+
+    flattened_groups: list[AttentionGroup] = []
+    for item in attn_groups:
+        if isinstance(item, AttentionGroup):
+            flattened_groups.append(item)
+        else:
+            flattened_groups.extend(item)
+
+    for group in flattened_groups:
+        group_id = group.kv_cache_group_id
+        group_copies = copies_by_group.get(group_id)
+        if not group_copies:
+            continue
+        kv_cache_spec = group.kv_cache_spec
+        if isinstance(kv_cache_spec, FullAttentionSpec):
+            kernel_block_size = kernel_block_sizes[group_id]
+            copy_full_blocks = isinstance(kv_cache_spec, MLAAttentionSpec) and (
+                kv_cache_spec.compress_ratio != 1
+                or kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
+            )
+            block_dim = group.backend.get_kv_cache_block_dim(
+                kernel_block_size,
+                kv_cache_spec.num_kv_heads,
+                kv_cache_spec.head_size,
+                cache_dtype_str=cache_dtype,
+            )
+            token_dim = _get_kv_cache_token_dim(
+                group.backend,
+                block_dim,
+                kv_cache_spec.num_kv_heads,
+                kv_cache_spec.head_size,
+                cache_dtype,
+            )
+            blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
+            for layer_name in group.layer_names:
+                kv_cache = kv_caches.get(layer_name)
+                if kv_cache is None:
+                    continue
+                for src_block_id, dst_block_id, num_tokens in group_copies:
+                    if copy_full_blocks:
+                        num_tokens = kv_cache_spec.block_size
+                    num_tokens = min(num_tokens, kv_cache_spec.block_size)
+                    num_full_kernel_blocks, partial_tokens = divmod(
+                        num_tokens, kernel_block_size
+                    )
+                    src_start = src_block_id * blocks_per_kv_block
+                    dst_start = dst_block_id * blocks_per_kv_block
+                    if num_full_kernel_blocks > 0:
+                        src_blocks = kv_cache.narrow(
+                            block_dim, src_start, num_full_kernel_blocks
+                        )
+                        dst_blocks = kv_cache.narrow(
+                            block_dim, dst_start, num_full_kernel_blocks
+                        )
+                        dst_blocks.copy_(src_blocks, non_blocking=True)
+                    if partial_tokens > 0:
+                        offset = num_full_kernel_blocks
+                        src_block = kv_cache.select(block_dim, src_start + offset)
+                        dst_block = kv_cache.select(block_dim, dst_start + offset)
+                        dst_block.narrow(token_dim, 0, partial_tokens).copy_(
+                            src_block.narrow(token_dim, 0, partial_tokens),
+                            non_blocking=True,
+                        )
+        elif isinstance(kv_cache_spec, MambaSpec):
+            for layer_name in group.layer_names:
+                kv_cache = kv_caches.get(layer_name)
+                if kv_cache is None:
+                    continue
+                for state in kv_cache:
+                    for src_block_id, dst_block_id, _ in group_copies:
+                        state[dst_block_id].copy_(
+                            state[src_block_id], non_blocking=True
+                        )
+
+
+def _get_kv_cache_token_dim(
+    backend: type[AttentionBackend],
+    block_dim: int,
+    num_kv_heads: int,
+    head_size: int,
+    cache_dtype: str,
+) -> int:
+    token_sentinel = 1234560
+    shape = backend.get_kv_cache_shape(
+        1234567,
+        token_sentinel,
+        num_kv_heads,
+        head_size,
+        cache_dtype_str=cache_dtype,
+    )
+    token_dim = shape.index(token_sentinel)
+    if token_dim > block_dim:
+        token_dim -= 1
+    return token_dim
 
 
 def is_residual_scattered_for_sp(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import math
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import product as iprod
 from typing import Any
@@ -32,7 +32,6 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
-    MLAAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 
@@ -521,143 +520,39 @@ def bind_kv_cache(
 
 
 def copy_kv_cache_blocks_inplace(
-    kv_caches: dict[str, Any],
-    attn_groups: Iterable[AttentionGroup] | Iterable[Iterable[AttentionGroup]],
-    kernel_block_sizes: list[int],
-    cache_dtype: str,
-    kv_cache_block_copies: Iterable[KVCacheBlockCopy],
+    kv_caches: Iterable[torch.Tensor | list[torch.Tensor]],
+    num_blocks: int,
+    kv_cache_block_copies: Sequence[KVCacheBlockCopy],
 ) -> None:
-    copies_by_group: defaultdict[int, list[tuple[int, int, int]]] = defaultdict(list)
-    for copy in kv_cache_block_copies:
-        copies_by_group[copy.kv_cache_group_id].append(
-            (copy.src_block_id, copy.dst_block_id, copy.num_tokens)
-        )
-    if not copies_by_group:
+    if not kv_cache_block_copies:
         return
 
-    flattened_groups: list[AttentionGroup] = []
-    for item in attn_groups:
-        if isinstance(item, AttentionGroup):
-            flattened_groups.append(item)
-        else:
-            flattened_groups.extend(item)
+    storage_tensors: list[torch.Tensor] = []
+    seen_storage: set[int] = set()
+    for entry in kv_caches:
+        # Mamba layers hold a list of state tensors; attention layers a single
+        # tensor. Both alias the shared block-major backing storage.
+        tensors = entry if isinstance(entry, (list, tuple)) else (entry,)
+        for tensor in tensors:
+            ptr = tensor.untyped_storage().data_ptr()
+            if ptr in seen_storage:
+                continue
+            seen_storage.add(ptr)
+            storage_tensors.append(tensor)
 
-    for group in flattened_groups:
-        group_id = group.kv_cache_group_id
-        group_copies = copies_by_group.get(group_id)
-        if not group_copies:
-            continue
-        kv_cache_spec = group.kv_cache_spec
-        if isinstance(kv_cache_spec, FullAttentionSpec):
-            _copy_full_attention_kv_cache_blocks(
-                kv_caches=kv_caches,
-                group=group,
-                group_copies=group_copies,
-                kernel_block_size=kernel_block_sizes[group_id],
-                cache_dtype=cache_dtype,
-            )
-        elif isinstance(kv_cache_spec, MambaSpec):
-            _copy_mamba_state_blocks(
-                kv_caches=kv_caches,
-                group=group,
-                group_copies=group_copies,
-            )
+    if not storage_tensors:
+        return
+    src_block_ids, dst_block_ids = zip(*kv_cache_block_copies)
+    device = storage_tensors[0].device
+    src_indices = torch.tensor(src_block_ids, dtype=torch.long, device=device)
+    dst_indices = torch.tensor(dst_block_ids, dtype=torch.long, device=device)
 
-
-def _copy_full_attention_kv_cache_blocks(
-    kv_caches: dict[str, Any],
-    group: AttentionGroup,
-    group_copies: list[tuple[int, int, int]],
-    kernel_block_size: int,
-    cache_dtype: str,
-) -> None:
-    kv_cache_spec = group.kv_cache_spec
-    assert isinstance(kv_cache_spec, FullAttentionSpec)
-    copy_full_blocks = isinstance(kv_cache_spec, MLAAttentionSpec) and (
-        kv_cache_spec.compress_ratio != 1
-        or kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
-    )
-    block_dim = group.backend.get_kv_cache_block_dim(
-        kernel_block_size,
-        kv_cache_spec.num_kv_heads,
-        kv_cache_spec.head_size,
-        cache_dtype_str=cache_dtype,
-    )
-    token_dim = _get_kv_cache_token_dim(
-        group.backend,
-        block_dim,
-        kv_cache_spec.num_kv_heads,
-        kv_cache_spec.head_size,
-        cache_dtype,
-    )
-    blocks_per_kv_block = kv_cache_spec.block_size // kernel_block_size
-    for layer_name in group.layer_names:
-        kv_cache = kv_caches.get(layer_name)
-        if kv_cache is None:
-            continue
-        for src_block_id, dst_block_id, num_tokens in group_copies:
-            if copy_full_blocks:
-                num_tokens = kv_cache_spec.block_size
-            num_tokens = min(num_tokens, kv_cache_spec.block_size)
-            num_full_kernel_blocks, partial_tokens = divmod(
-                num_tokens, kernel_block_size
-            )
-            src_start = src_block_id * blocks_per_kv_block
-            dst_start = dst_block_id * blocks_per_kv_block
-            if num_full_kernel_blocks > 0:
-                src_blocks = kv_cache.narrow(
-                    block_dim, src_start, num_full_kernel_blocks
-                )
-                dst_blocks = kv_cache.narrow(
-                    block_dim, dst_start, num_full_kernel_blocks
-                )
-                dst_blocks.copy_(src_blocks, non_blocking=True)
-            if partial_tokens > 0:
-                offset = num_full_kernel_blocks
-                src_block = kv_cache.select(block_dim, src_start + offset)
-                dst_block = kv_cache.select(block_dim, dst_start + offset)
-                dst_block.narrow(token_dim, 0, partial_tokens).copy_(
-                    src_block.narrow(token_dim, 0, partial_tokens),
-                    non_blocking=True,
-                )
-
-
-def _copy_mamba_state_blocks(
-    kv_caches: dict[str, Any],
-    group: AttentionGroup,
-    group_copies: list[tuple[int, int, int]],
-) -> None:
-    for layer_name in group.layer_names:
-        kv_cache = kv_caches.get(layer_name)
-        if kv_cache is None:
-            continue
-        for state in kv_cache:
-            for src_block_id, dst_block_id, _ in group_copies:
-                state[dst_block_id].copy_(state[src_block_id], non_blocking=True)
-
-
-def _get_kv_cache_token_dim(
-    backend: type[AttentionBackend],
-    block_dim: int,
-    num_kv_heads: int,
-    head_size: int,
-    cache_dtype: str,
-) -> int:
-    # Distinct fake sizes used only to identify the num-blocks and block-size
-    # dimensions returned by backend.get_kv_cache_shape().
-    _KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL = 1_234_567
-    _KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL = 1_234_560
-    shape = backend.get_kv_cache_shape(
-        _KV_CACHE_SHAPE_NUM_BLOCKS_SENTINEL,
-        _KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL,
-        num_kv_heads,
-        head_size,
-        cache_dtype_str=cache_dtype,
-    )
-    token_dim = shape.index(_KV_CACHE_SHAPE_BLOCK_SIZE_SENTINEL)
-    if token_dim > block_dim:
-        token_dim -= 1
-    return token_dim
+    for tensor in storage_tensors:
+        assert tensor.device == device
+        blocks = torch.empty(0, dtype=torch.uint8, device=device)
+        blocks.set_(tensor.untyped_storage())
+        blocks = blocks.view(num_blocks, -1)
+        blocks[dst_indices] = blocks[src_indices]
 
 
 def is_residual_scattered_for_sp(


### PR DESCRIPTION
# Fine-grained (sub-block) partial prefix-cache hits for hybrid models, via copy-on-write

> **Draft for design review.** This PR builds on the partial prefix-cache *primitives* from #45939 (`[1/N]`, the merge base of this branch) and makes the KV cache managers actually **produce and consume mid-block cache hits** — for full attention, sliding window attention (SWA), and align-mode Mamba — plus two unconditional lifetime-safety fixes that the feature surfaced. Written for reviewers familiar with the v1 scheduler and `KVCacheManager`, but not with this feature.

---

## 1. Problem

On `main`, a prefix-cache hit must end on a **cache-block boundary**, and for hybrid models (multiple KV cache groups with different block sizes) on a **scheduler-block boundary** — the LCM of all group block sizes. Everything past the last aligned boundary of a shared prefix is recomputed, even though its KV is sitting in the cache:

```text
block_size = 16, shared prefix = 1000 tokens

           block 61       block 62 (tail)
        ┌───────────┐   ┌───────────┬───╌╌╌
tokens  │ 976 … 991 │   │ 992 … 999 │  (unwritten)
        └───────────┘   └───────────┴───╌╌╌
             hit ✓          8 tokens wasted — no boundary, no hit
```

#45939 laid the groundwork: `Request.block_hashes` are computed at `hash_block_size` granularity (the GCD of group block sizes for hybrid models), hashes are **prefix-chained** (the hash at any boundary fingerprints the entire prefix up to it), and `BlockPool.cache_partial_block()` can register a lookup key that ends *inside* a physical block. But nothing ever registered or consumed such entries.

This PR closes that loop. With `--block-size 64 --hash-block-size 16` (or a hybrid model whose natural GCD is finer than a group's block size), a hit can now end at any hash boundary inside a block.

**The hard part** is that a mid-block hit makes the tail block **shared**: the producer's sequence continues past the boundary with its own tokens, while a consumer must append *different* tokens after the same boundary. Physical pages are append-only from the worker's point of view, so the consumer cannot simply write into the producer's block. The answer is **copy-on-write (CoW)**: the consumer gets a private copy of the tail block, populated by a GPU-side block copy that the scheduler ships to the worker.

## 2. Key concepts

| Concept | Where | Meaning |
|---|---|---|
| `hash_block_size` vs `block_size` | `CacheConfig`, `--hash-block-size` | Hash-key granularity vs physical page size. Fine-grained hits are possible whenever `hash_block_size < block_size` for some group. |
| `enable_partial_hash_hits` | `HybridKVCacheCoordinator` | Master switch: `hash_block_size < scheduler_block_size` **and** every group either supports fine-grained lookup or already has `block_size == hash_block_size`. Hybrid-coordinator-only by construction. |
| `alignment_tokens` | threaded into every `find_longest_cache_hit` | `hash_block_size` when the feature is on, else `scheduler_block_size`. This is how each manager knows which mode it is in. |
| `supports_fine_grained_hash_lookup` | `ClassVar` on managers | `FullAttentionManager`, `SlidingWindowManager`, `MambaManager`: yes. `ChunkedLocalAttentionManager`, `CrossAttentionManager`: no (a chunked-local group disables the feature globally). |
| Partial tail entry | `BlockPool.cache_partial_block` | An *extra lookup key* (the chained hash at the prompt's last hash boundary) registered on an existing tail block. No copy, no allocation at registration time. |
| `KVCacheBlockCopy(src, dst)` | `SchedulerOutput.kv_cache_block_copies` | The CoW work item; executed by the model runner before the forward pass. |
| `Request.num_in_flight_tokens` | `request.py` | Tokens of scheduled-but-unprocessed steps; used to compute a *settled* token count for out-of-window frees (§6). |

Also note a signature change reviewers will see everywhere: `find_longest_cache_hit` now returns `(blocks_per_group, hit_length_in_tokens)`. Hit length can no longer be derived as `len(blocks) * block_size` — a partial hit ends mid-block, and a Mamba hit is a single state block padded with nulls.

## 3. Component map

```mermaid
flowchart TB
    subgraph SCHED["Scheduler (sched/scheduler.py)"]
        S1["schedule():<br/>drains take_kv_cache_block_copies()<br/>sets cow_copy_fence_seq"]
        S2["_try_schedule():<br/>block-aligned chunk *ends*,<br/>mamba_partial_tail_stop"]
        S3["_free_cow_retained_blocks():<br/>deferred-free fence (#45357 machinery)"]
    end

    subgraph KVM["KVCacheManager"]
        K1["allocate_slots():<br/>threads num_local_computed_tokens"]
        K2["cow_retained_block_free_handler<br/>(installed by scheduler)"]
    end

    subgraph COORD["HybridKVCacheCoordinator"]
        C1["enable_partial_hash_hits<br/>alignment_tokens selection"]
        C2["find_longest_cache_hit:<br/>cross-group min over hit_length_by_group"]
    end

    subgraph MGRS["SingleTypeKVCacheManager (base: shared CoW machinery)"]
        M0["_cache_partial_tail_block · _partial_hit_reqs<br/>_apply_cow · retention refs · same-step guards"]
        MFA["FullAttentionManager<br/>two-phase finder"]
        MSWA["SlidingWindowManager<br/>claim-walk finder +<br/>reachable_block_mask anchor"]
        MMB["MambaManager<br/>align-mode only,<br/>producer self-CoW"]
    end

    BP["BlockPool<br/>cache_partial_block · move_block_hashes"]
    SO["SchedulerOutput<br/>kv_cache_block_copies"]
    MR["Model runner<br/>copy_kv_cache_blocks_inplace()<br/>(after zeroing, before forward)"]

    S1 --> K1 --> C1 --> M0
    M0 --> MFA & MSWA & MMB
    MFA & MSWA & MMB --> BP
    S1 --> SO --> MR
    S3 --> K2
```

The design principle: **all generic consumer-side CoW machinery lives in the base `SingleTypeKVCacheManager`**; each concrete manager only contributes its finder and (for Mamba) a producer-side specialization. The coordinator owns the on/off decision and the cross-group reduction; the scheduler owns transport (`SchedulerOutput`) and lifetime fencing.

## 4. Lifecycle walkthrough

The whole feature is one producer/consumer protocol around a shared tail block:

```mermaid
sequenceDiagram
    participant P as Producer request
    participant M as Manager (base)
    participant BP as BlockPool
    participant C as Consumer request
    participant S as Scheduler
    participant W as Worker (model runner)

    Note over P,BP: step N — producer registers
    P->>M: cache_blocks() → _cache_partial_tail_block()
    M->>BP: cache_partial_block(tail, hash@boundary)
    Note right of BP: extra lookup key on the existing tail block<br/>no copy — FA/SWA KV is append-only

    Note over C,W: step N+1 (same-step consumption is deferred, §5)
    C->>M: find_longest_cache_hit → mid-block hit, tail shared
    C->>M: get_num_blocks_to_allocate → +1 block reserved for CoW
    C->>M: add_local_computed_blocks → record in _partial_hit_reqs
    C->>M: allocate_new_blocks → _apply_cow():<br/>req_blocks[i] := fresh cow_block,<br/>queue KVCacheBlockCopy(src→dst),<br/>retention ref on BOTH endpoints
    M->>S: take_kv_cache_block_copies()
    S->>W: SchedulerOutput.kv_cache_block_copies
    W->>W: copy_kv_cache_blocks_inplace() — before forward
    Note over C,W: consumer appends its own tokens to its private copy

    Note over M,S: step N+2 (or later, under async sched)
    S->>M: new_step_starts() → returns retained blocks
    S->>S: _free_cow_retained_blocks():<br/>release only once cow_copy_fence_seq ≤ processed_step_seq
```

### 4a. Producer: registering a partial tail (`cache_blocks`)

Full blocks are cached exactly as before. Then `_cache_partial_tail_block()` computes `boundary = num_prompt_tokens // hash_block_size * hash_block_size`; if that boundary is mid-block and computed, it registers the chained hash at `boundary` as an extra key on the existing tail block. This is free for FA/SWA because KV pages are **append-only**: positions before the boundary never change once written, so the entry stays valid while the producer keeps appending to the same block. Only the prompt's *final* hash boundary is registered — one extra dict entry per request, not one per interior boundary.

**Mamba is the exception** and gets the inverted protocol. A Mamba block holds only the *latest* state, rewritten in place — the append-only argument collapses. So (i) an entry may only be registered by a step that ends *exactly* at the boundary, which the scheduler guarantees by inserting a chunk stop at the prompt's last hash boundary (`mamba_partial_tail_stop` in `_try_schedule`); and (ii) the **producer self-CoWs**: the cache entry moves to a private snapshot block (`BlockPool.move_block_hashes(src, dst)` + a queued `KVCacheBlockCopy`), while the request keeps writing its original block. The copy direction is forced by the worker protocol: a running request's block table is updated **append-only**, so redirecting `req_blocks[i]` under a running producer would silently desync the worker — the request must keep its block and the *cache* takes the copy.

### 4b. Consumer: lookup

Each finder receives `alignment_tokens = hash_block_size` and probes hash boundaries:

- **FullAttentionManager** — two phases: walk the block-size view left-to-right for the longest chained run of full blocks, then probe the first incomplete block's interior hash boundaries highest-first. A hit appends the producer's shared tail block and sets `hit_length = (fine_idx + 1) * hash_block_size`.
- **SlidingWindowManager** — the reason this branch exists. An SWA hit at length `L` is only valid if the whole window `[L−W+1, L)` is cached, and the old finder only probed block-aligned candidates. The new finder walks **claim boundaries** (multiples of `alignment_tokens`) right-to-left; one hash lookup per claim finds *either* entry kind (a full block's key is its last-boundary hash; a partial tail's key is its registration hash), then window coverage is verified against full-block entries (memoized across claims; a window miss jumps the claim past the missing block, keeping the walk linear). Pre-window positions are null-padded as before.
- **MambaManager** — right-to-left scan; first hit wins and yields a single state block padded with nulls, plus its exact `hit_length`.

Two cross-cutting adjustments:

- **Eagle drop is now one hash unit**, not one full block: fine-grained finders claim `hit − hash_block_size` (append-only KV still covers the reduced length), and the coordinator's retry margin matches so a retry can never claim past the current candidate.
- **SWA `reachable_block_mask`** (which deliberately *skips caching* blocks that can never serve a hit) learns a `partial_anchor_tokens` parameter: with fine-grained hits, the joint replay boundary can land on the prompt's last hash boundary, so the mask retains the (possibly mid-block) tail block plus enough full blocks to cover a whole window from it.

### 4c. Consumer: allocation → CoW

All in the base class, keyed on `_has_partial_local_hit` — note this is **per-manager**: the same 6-token hit is partial for a block-4 group and exact for a block-2 group.

1. `get_num_blocks_to_allocate` reserves **+1 block** for the copy target (`num_local_computed_tokens` is threaded down from `allocate_slots` for this).
2. `add_local_computed_blocks` records `(block_idx, source_block)` in `_partial_hit_reqs` and caps `num_cached_block` at the full blocks — the consumer's continuation differs from the producer's, so it must be able to re-cache the tail under its *own* hashes later.
3. `allocate_new_blocks` pops the record exactly once, and `_apply_cow` **replaces** `req_to_blocks[block_idx]` with a fresh block *in place* (table length unchanged ⇒ the ordinary length-based allocation math below is untouched), queues `KVCacheBlockCopy(src, dst)`, and takes one retention ref on **each** endpoint. The CoW block rides the normal new-block-IDs path to the worker; zeroing happens before the copy, so the overwrite is harmless.
4. `Scheduler.schedule()` drains the queued copies into `SchedulerOutput.kv_cache_block_copies`; both model runners execute `copy_kv_cache_blocks_inplace()` **before the forward pass** (dedups backing storages by data pointer and does a uint8 block-row copy — uniform across attention KV and Mamba state tensors).

## 5. Why the guards exist (the subtle 20%)

Three hazards, each with a regression test that fails without its fix:

1. **Same-step consumption.** An entry registered in step N is backed by real KV only *after* step N's forward — but a consumer's copy runs at the *start* of its step. Consuming in step N would copy garbage. Fix: entries registered this step (`_partial_blocks_cached_this_step`) make `get_num_blocks_to_allocate` return an impossible demand, deferring the consumer exactly one step.
2. **Same-step free.** A consumer freed/preempted in the very step that queued its copy would return the copy target to the pool; another request could receive that block before the copy executes on the GPU. Fix: the retention refs on both endpoints from §4c, released only at `new_step_starts()`.
3. **In-flight fence for the releases themselves.** With overlapping batches, `new_step_starts()` for step N+1 can run while step N — the step executing the copy — is still on the GPU. Releasing then re-opens hazard 2 via a KV-connector load into the reallocated block, unordered against the copy. Fix: `new_step_starts()` returns the retained blocks to the scheduler, which routes them through the pre-existing deferred-free fence from #45357 (`cow_copy_fence_seq` vs `processed_step_seq`) — the same path used for end-of-life frees.

Additionally, `_apply_cow` asserts `req_blocks[block_idx] is source_block` so any interleaving that mutated the table between recording and application fails loudly rather than corrupting.

## 6. Free-path safety: processed-token basis (fixes #47282)

Fine-grained SWA testing surfaced a pre-existing lifetime bug that this PR fixes unconditionally. Under async scheduling / PP, the scheduler runs ahead of the GPU: `request.num_computed_tokens` is advanced at *schedule* time. SWA/chunked-local/Mamba `remove_skipped_blocks` used that optimistic count as the out-of-window free boundary — freeing blocks that an **in-flight step's attention window still reads**:

```text
GPU:        step N executing ── attention reads window [T−W, T)
Scheduler:  scheduling N+1 ──── num_computed_tokens = T+k   (k in flight)
                                frees blocks below T+k−W  ← step N still reads them
```

A KV-consumer connector can reallocate such a block as a load destination and overwrite it on an unordered stream ⇒ corrupted output. Independently, rejected spec tokens roll `num_computed_tokens` back, so a block freed against the optimistic boundary can be *needed again*.

Fix: track `Request.num_in_flight_tokens` and free on the **settled** count `num_computed_tokens − num_in_flight_tokens`. The counter is structurally exact — incremented in `_update_after_schedule` and decremented in `update_from_output` over the *same* per-step `num_scheduled_tokens` dict, and the engine core processes every scheduler output exactly once — so it cannot drift across preemption, spec rejection, or failed-KV-load recovery. This **subsumes and removes** `MambaManager`'s local speculative-token subtraction (same rollback hazard, now handled exactly for prefill chunks and PP depth too). Sync scheduling has zero in-flight tokens at allocation time and is byte-identical.

Cost: blocks slide out of the window one step later, so the SWA per-request admission bound grows to `W − 1 + max_concurrent_batches × max_num_batched_tokens`, accounted in `max_admission_blocks_per_request` — the single source of truth for both startup pool sizing and the runtime admission gate.

## 7. Scheduler chunking changes

With mid-block resume points, `_try_schedule` aligns chunk **ends** to block multiples instead of flooring chunk *lengths* (a floored length after a mid-block resume leaves every subsequent chunk end unaligned — align-mode Mamba would then register block-end hashes whose state was never materialized). A mid-block resume gets a first chunk stopping exactly at the next block boundary so the resumed CoW block freezes its boundary state before being run past, and `mamba_partial_tail_stop` adds one stop at the prompt's last hash boundary so every prompt registers a Mamba partial tail entry.

## 8. User-facing surface & gating

- **`--hash-block-size N`** is the opt-in (e.g. `--block-size 64 --hash-block-size 16`). Only meaningful for hybrid (multi-KV-group) models; every group's block size must be divisible by it. Single-group models reject any value ≠ `block_size × dcp × pcp`. Excluded from compile-graph hashing.
- **Default off in practice**: unset, `hash_block_size` falls back to the GCD of group block sizes (pre-existing behavior); most hybrid models have equal group block sizes, so GCD = LCM and nothing changes without the flag.
- **Auto-disabled** when any group is chunked local attention, when Mamba is not in `align` cache mode (that manager just opts out), when prefix caching is off, or under DCP/PCP.
- **MooncakeStoreConnector** fails fast at init when fine-grained hits would be active (mid-block hit lengths aren't consumable by the connector yet — follow-up PR); its coordinator changes here only track the new `(blocks, hit_length)` finder signature.
- The processed-token-basis free (§6) and the CoW retention fence (§5.3) are **unconditional correctness fixes**, not gated by the flag.

## 9. Suggested review order

1. `vllm/v1/core/kv_cache_utils.py` — `resolve_kv_cache_block_sizes` validation, `resolve_block_hashes`, `KVCacheBlockCopy`.
2. `vllm/v1/core/single_type_kv_cache_manager.py` — base-class CoW machinery first (there is a six-step lifecycle overview comment on the bookkeeping fields), then `FullAttentionManager` → `SlidingWindowManager` → `MambaManager`. *Heads-up: the inline commentary is intentionally verbose for this review and will be trimmed before an upstream PR.*
3. `vllm/v1/core/kv_cache_coordinator.py` — gating + cross-group hit-length reduction.
4. `vllm/v1/core/sched/scheduler.py`, `sched/output.py`, `request.py` — copy transport, chunk-end alignment, in-flight counter, fenced frees.
5. `vllm/v1/core/block_pool.py`, `vllm/v1/worker/utils.py`, model runners — `move_block_hashes`, GPU copy.
6. Tests (map below).

## 10. Testing

All under `tests/v1/core/` unless noted; suites pass locally (175 tests across the prefix-cache suites at last run):

| Area | Tests |
|---|---|
| Primitives & hash resolution | `test_partial_prefix_cache_primitives.py`, `test_kv_cache_utils.py` |
| FA/SWA fine-grained hits, Eagle hash-unit drop, `reachable_block_mask` anchors | `test_prefix_caching.py`, `test_single_type_kv_cache_manager.py` (direct finder tests: hit / eagle drop / cap below tail / window-coverage break) |
| CoW hazards (each fails without its fix) | `test_hybrid_mamba_partial_tail_producer_append_only_worker_table`, `test_partial_hit_cow_copy_target_pinned_until_copy_runs`, `test_full_attention_partial_tail_same_step_guard` |
| Shared-source CoW (two consumers, one source, ref-count teardown) | `test_prefix_caching.py` |
| Fenced frees | `test_deferred_block_free.py` |
| Processed-token-basis window frees | `test_swa_inflight_window_free.py` |
| Mooncake signature tracking | `tests/.../unit/test_mooncake_store_coordinator.py` |

```bash
.venv/bin/python -m pytest tests/v1/core/ -v
```

---

*AI assistance was used throughout this branch (see commit trailers); every change has been reviewed and is defended by the human submitter. This is a fork-internal design-review draft, not (yet) an upstream submission — upstream will follow the AGENTS.md contribution policy including duplicate-work checks and comment trimming.*
